### PR TITLE
Add Total Count Of Projects To Search Bar Placeholder

### DIFF
--- a/backend/apps/owasp/api/search/project.py
+++ b/backend/apps/owasp/api/search/project.py
@@ -35,4 +35,7 @@ def get_projects(query, attributes=None, limit=25):
 
 def projects(request):
     """Search projects API endpoint."""
-    return JsonResponse(get_projects(request.GET.get("q", "")), safe=False)
+    return JsonResponse({
+        "active_projects_count": Project.active_projects_count(),
+        "projects": get_projects(request.GET.get("q", ""))
+    }, safe=False)

--- a/backend/apps/owasp/api/search/project.py
+++ b/backend/apps/owasp/api/search/project.py
@@ -35,7 +35,10 @@ def get_projects(query, attributes=None, limit=25):
 
 def projects(request):
     """Search projects API endpoint."""
-    return JsonResponse({
-        "active_projects_count": Project.active_projects_count(),
-        "projects": get_projects(request.GET.get("q", ""))
-    }, safe=False)
+    return JsonResponse(
+        {
+            "active_projects_count": Project.active_projects_count(),
+            "projects": get_projects(request.GET.get("q", "")),
+        },
+        safe=False,
+    )

--- a/backend/apps/owasp/templates/search/project.html
+++ b/backend/apps/owasp/templates/search/project.html
@@ -14,7 +14,7 @@
                                type="text"
                                @input="handleInput"
                                class="form-control"
-                               placeholder="Search for a project to contribute to...">
+                               :placeholder="searchPlaceholderText">
                         <button class="btn btn-outline-secondary"
                                 @click="searchQuery = ''"
                                 type="button"
@@ -159,12 +159,18 @@
         } = Vue;
         createApp({
             delimiters: ['${', '}'],
+            computed: {
+                searchPlaceholderText() {
+                    return `Search among ${this.activeProjectsCount} projects to contribute to...`;
+                }
+            },
             data() {
                 return {
                     projects: [],
                     selectedProject: {},
                     searchQuery: '',
                     isManualSearch: true,
+                    activeProjectsCount: 0,
                     levelStyleMap: {
                         "incubator": {
                             color: "#53AAE5",
@@ -201,13 +207,14 @@
                     const response = await fetch(`/api/v1/owasp/search/project?q=${this.searchQuery}`)
                         .then(res => res.json())
                         .then(json => {
-                            json.forEach(project => {
+                            json.projects.forEach(project => {
                                 project.level = project.idx_level.charAt(0).toUpperCase() + project.idx_level.slice(1).toLowerCase();
                                 project.summary = marked.parse(project.idx_summary || '');
                                 project.topics = project.idx_topics ? project.idx_topics.sort(() => Math.random() - 0.5).slice(0, 20) : [];
                                 project.updated_at = dayjs.unix(project.idx_updated_at || '').fromNow(true);
                             });
-                            this.projects = json;
+                            this.projects = json.projects;
+                            this.activeProjectsCount = json.active_projects_count;
                         })
                         .catch(err => console.error("There was an error! ", err));
 

--- a/backend/apps/owasp/templates/search/project.html
+++ b/backend/apps/owasp/templates/search/project.html
@@ -161,7 +161,9 @@
             delimiters: ['${', '}'],
             computed: {
                 searchPlaceholderText() {
-                    return `Search among ${this.activeProjectsCount} projects to contribute to...`;
+                    return this.activeProjectsCount ?
+                        `Search among ${this.activeProjectsCount} projects to contribute to...` :
+                        'Search...';
                 }
             },
             data() {


### PR DESCRIPTION
This PR addresses Issue #10 

Screenshot of the change:
<img width="929" alt="image" src="https://github.com/user-attachments/assets/6167fee7-582d-4e07-9a5e-ce748b803a29">

Please feel free to suggest different phrasing for the placeholder text, or any other feedback :) 

**Question:** This change has only been made to the `Projects` page. The placeholder in the `Contribute` page search box also says "Search for a project to contribute to...". Perhaps we need to reword that sentence to be more generic (since people might search for keywords in an issue as well?)