### PR TITLE
Update Card component styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Follow these steps to set up the OWASP Nest application:
      git clone https://github.com/owasp/nest
      ```
 
-1. **Create Environment File**:
-   - Navigate to the `backend` directory and create a local environment file:
+1. **Create Environment Files**:
+   - Create a local environment file in the `backend` directory:
 
      ```bash
      touch backend/.env/local
@@ -22,6 +22,12 @@ Follow these steps to set up the OWASP Nest application:
 
      ```bash
      cp backend/.env/template backend/.env/local
+     ```
+
+   - Create a local environment file in the `frontend` directory:
+
+     ```bash
+     cp frontend/.env.example frontend/.env
      ```
 
 1. **Configure Environment Variables**:
@@ -98,44 +104,3 @@ If you plan to fetch GitHub OWASP data locally, follow these additional steps:
    ```bash
    make sync
    ```
-
-## Frontend Setup
-
-1. **Ensure Node.js Version**:
-    - The project now requires **Node.js 22**. Ensure you have Node.js 22 installed. You can check your version with:
-      ```bash
-      node -v
-      ```
-    - If you need to install Node.js 22, use a version manager like `nvm`:
-      ```bash
-      nvm install 22
-      nvm use 22
-      ```
-
-1. **Install Frontend Dependencies**:
-    - Navigate to the `frontend` directory and install the dependencies:
-
-      ```bash
-      cd frontend
-      npm install
-      ```
-
-1. **Run the Frontend Application**:
-    - Start the Vite development server:
-
-      ```bash
-      npm run dev
-      ```
-
-    - The application will be available at [http://localhost:3000](http://localhost:3000).
-
-## Linting and Formatting Setup
-
-To ensure code quality, we utilize ESLint and Prettier with Husky for pre-commit hooks.
-
-### Installing Dependencies
-
-Make sure you have the necessary dependencies installed:
-
-```bash
-npm install --save-dev eslint prettier husky lint-staged eslint-plugin-react eslint-plugin-react-hooks @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-config-prettier eslint-plugin-prettier

--- a/frontend/src/components/ActionButton.tsx
+++ b/frontend/src/components/ActionButton.tsx
@@ -11,7 +11,7 @@ interface ActionButtonProps {
 
 const ActionButton: React.FC<ActionButtonProps> = ({ url, onClick, tooltipLabel, children }) => {
   const baseStyles =
-    'flex justify-center items-center gap-2 p-1 px-2 rounded-md bg-transparent hover:bg-[#0D6EFD] text-[#0D6EFD] hover:text-white dark:text-white border border-[#0D6EFD] dark:border-0 '
+    'flex justify-center self-end items-center gap-2 p-1 px-2 rounded-md bg-transparent hover:bg-[#0D6EFD] text-[#0D6EFD] hover:text-white border border-[#0D6EFD] dark:border-sky-600 dark:text-sky-600 dark:hover:bg-sky-600'
 
   return url ? (
     <a

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -44,9 +44,9 @@ const Card = ({
   }
 
   return (
-    <div className=" w-full md:max-w-6xl  h-fit flex flex-col justify-normal items-start gap-4 md:gap-2 p-4 px-6 border border-border rounded-md ">
+    <div className=" w-full md:max-w-6xl h-fit flex flex-col justify-normal items-start gap-4 md:gap-2 pt-0 px-6 py-6 border border-border rounded-md ">
       <div className=" w-full flex justify-between items-center flex-wrap gap-2 ">
-        <div className=" flex justify-center items-center gap-2 ">
+        <div className=" flex justify-center items-center gap-2 mt-4">
           {level && (
             <span
               data-tooltip-id="level-tooltip"
@@ -60,24 +60,30 @@ const Card = ({
             </span>
           )}
           <a href={url} target="_blank">
-            <h1 className=" text-2xl font-semibold ">{title}</h1>
+            <h1 className=" text-2xl font-semibold dark:text-sky-600 pl-2">{title}</h1>
           </a>
         </div>
 
-        <div className="min-w-[30%] flex justify-end items-center md:gap-8 flex-wrap ">
+        <div className="min-w-[30%] flex justify-end items-center flex-wrap ">
           {icons &&
-            Object.keys(Icons).map((key) =>
-              icons[key] !== undefined ? <DisplayIcon key={key} item={key} icons={icons} /> : null
+            Object.keys(Icons).map((key, index) =>
+              icons[key] !== undefined ? (
+                <DisplayIcon key={key} item={key} icons={icons} idx={index} />
+              ) : null
             )}
         </div>
       </div>
+      <p className=" mr-8 mt-2 text-gray-600 dark:text-gray-300 ">{summary}</p>
       <h2>
         {leaders && (
-          <span className=" font-bold "> {leaders.length > 1 ? 'Leaders: ' : 'Leader: '} </span>
+          <span className=" font-bold text-gray-600 dark:text-gray-300 ">
+            {' '}
+            {leaders.length > 1 ? 'Leaders: ' : 'Leader: '}{' '}
+          </span>
         )}
         {leaders &&
           leaders.map((leader, index) => (
-            <span key={leader} className=" font-semibold ">
+            <span key={leader} className=" font-semibold text-gray-600 dark:text-gray-300">
               {' '}
               {index != leaders.length - 1 ? `${leader},` : `${leader}`}{' '}
             </span>
@@ -95,9 +101,8 @@ const Card = ({
           {projectName}
         </a>
       )}
-      <p className=" mr-8 text-gray-600 dark:text-gray-200 ">{summary}</p>
       <div className=" w-full flex md:flex-row flex-col justify-between items-center ">
-        <div className=" flex flex-col justify-normal items-start gap-2 ">
+        <div className=" flex justify-start items-start pt-3 max-w-4xl">
           <div className=" flex justify-normal items-center gap-2 flex-wrap ">
             {languages &&
               languages
@@ -107,10 +112,11 @@ const Card = ({
                     key={topic}
                     topic={topic}
                     tooltipLabel={`This repository uses ${topic}`}
+                    type="language"
                   />
                 ))}
             {languages && languages.length > 18 && (
-              <button onClick={loadMoreLanguages} className="">
+              <button onClick={loadMoreLanguages} className=" text-gray-600 dark:text-gray-300 ">
                 {toggleLanguages ? 'Show more' : 'Show less'}
               </button>
             )}
@@ -124,11 +130,12 @@ const Card = ({
                     key={topic}
                     topic={topic}
                     tooltipLabel={`This project is labeled as "${topic}"`}
+                    type="topic"
                   />
                 ))}
 
             {topics && topics.length > 18 && (
-              <button onClick={loadMoreTopics} className="">
+              <button onClick={loadMoreTopics} className=" text-gray-600 dark:text-gray-300 ">
                 {toggleTopics ? 'Show more' : 'Show less'}
               </button>
             )}

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -44,7 +44,7 @@ const Card = ({
   }
 
   return (
-    <div className=" w-full md:max-w-6xl h-fit flex flex-col justify-normal items-start gap-4 md:gap-2 pt-0 px-6 py-6 border border-border rounded-md ">
+    <div className=" w-full md:max-w-6xl h-fit flex flex-col justify-normal items-start gap-4 md:gap-2 pt-0 pl-6 py-6 border border-border rounded-md ">
       <div className=" w-full flex justify-between items-center flex-wrap gap-2 ">
         <div className=" flex justify-center items-center gap-2 mt-4">
           {level && (
@@ -76,20 +76,20 @@ const Card = ({
       <p className=" mr-8 mt-2 text-gray-600 dark:text-gray-300 ">{summary}</p>
       <h2>
         {leaders && (
-          <span className=" font-bold text-gray-600 dark:text-gray-300 ">
+          <span className=" font-semibold text-gray-600 dark:text-gray-300 ">
             {' '}
             {leaders.length > 1 ? 'Leaders: ' : 'Leader: '}{' '}
           </span>
         )}
         {leaders &&
           leaders.map((leader, index) => (
-            <span key={leader} className=" font-semibold text-gray-600 dark:text-gray-300">
+            <span key={leader} className=" text-gray-600 dark:text-gray-300">
               {' '}
               {index != leaders.length - 1 ? `${leader},` : `${leader}`}{' '}
             </span>
           ))}
       </h2>
-      <div className=" w-full flex justify-normal items-center gap-1 ">
+      <div className=" w-full flex justify-normal items-center gap-1 pr-6 ">
         {topContributors &&
           topContributors.map((contributor) => (
             <ContributorAvatar key={contributor.login} contributor={contributor} />
@@ -101,7 +101,7 @@ const Card = ({
           {projectName}
         </a>
       )}
-      <div className=" w-full flex md:flex-row flex-col justify-between items-center ">
+      <div className=" w-full flex md:flex-row flex-col justify-between items-center pr-6">
         <div className=" flex justify-start items-start pt-3 max-w-4xl">
           <div className=" flex justify-normal items-center gap-2 flex-wrap ">
             {languages &&

--- a/frontend/src/components/DisplayIcon.tsx
+++ b/frontend/src/components/DisplayIcon.tsx
@@ -16,7 +16,7 @@ export default function DisplayIcon({
     <div
       data-tooltip-id={`icon-tooltip-${item}`}
       data-tooltip-content={`${Icons[item as keyof typeof Icons]?.label}`}
-      className={` flex flex-col justify-center items-center gap-1 px-4 border-r border-l border-b border-border ${idx == 0 ? 'rounded-bl-lg' : ''} ${idx == Object.keys(icons).length - 1 ? 'rounded-br-lg' : ''}`}
+      className={` flex flex-col justify-center items-center gap-1 px-4 border-l border-b border-border ${idx == 0 ? 'rounded-bl-lg' : ''}`}
     >
       <span className=" text-gray-600 dark:text-gray-300 ">{icons[item]}</span>
       <span>

--- a/frontend/src/components/DisplayIcon.tsx
+++ b/frontend/src/components/DisplayIcon.tsx
@@ -3,16 +3,27 @@ import { IconType, tooltipStyle } from '../lib/constants'
 import { IconKeys, Icons } from './data'
 import FontAwesomeIconWrapper from '../lib/FontAwesomeIconWrapper'
 
-export default function DisplayIcon({ item, icons }: { item: string; icons: IconType }) {
+export default function DisplayIcon({
+  item,
+  icons,
+  idx,
+}: {
+  item: string
+  icons: IconType
+  idx: number
+}) {
   return icons[item] ? (
     <div
       data-tooltip-id={`icon-tooltip-${item}`}
       data-tooltip-content={`${Icons[item as keyof typeof Icons]?.label}`}
-      className=" flex flex-col justify-center items-center gap-1 px-4 "
+      className={` flex flex-col justify-center items-center gap-1 px-4 border-r border-l border-b border-border ${idx == 0 ? 'rounded-bl-lg' : ''} ${idx == Object.keys(icons).length - 1 ? 'rounded-br-lg' : ''}`}
     >
-      <span className="value">{icons[item]}</span>
+      <span className=" text-gray-600 dark:text-gray-300 ">{icons[item]}</span>
       <span>
-        <FontAwesomeIconWrapper icon={Icons[item as IconKeys]?.icon} />
+        <FontAwesomeIconWrapper
+          className="text-gray-600 dark:text-gray-300"
+          icon={Icons[item as IconKeys]?.icon}
+        />
       </span>
       <Tooltip id={`icon-tooltip-${item}`} style={tooltipStyle} />
     </div>

--- a/frontend/src/components/TopicBadge.tsx
+++ b/frontend/src/components/TopicBadge.tsx
@@ -1,12 +1,20 @@
 import { Tooltip } from 'react-tooltip'
 import { tooltipStyle } from '../lib/constants'
 
-const TopicBadge = ({ topic, tooltipLabel }: { topic: string; tooltipLabel?: string }) => {
+const TopicBadge = ({
+  topic,
+  tooltipLabel,
+  type,
+}: {
+  topic: string
+  tooltipLabel?: string
+  type: string
+}) => {
   return (
     <div
       data-tooltip-id={`lang-tooltip-${topic}`}
       data-tooltip-content={tooltipLabel}
-      className=" p-1 px-2 text-xs font-bold rounded-md bg-[#6C757D] text-white "
+      className={` p-1 px-2 text-xs font-bold rounded-md bg-[#6C757D] text-white ${type == 'language' ? 'bg-[#868E96]' : 'bg-[#6C757D]'}`}
     >
       {topic}
 


### PR DESCRIPTION
<!-- Thanks for contributing to OWASP Nest!-->

<!-- Describe the big picture of your changes.-->

Updated styles for Card component to work better with dark mode:
- Moved leaders of the project to be lower on the card, after the summary.
- Added borders to blocks with number of forks/stars/contributors.
- Updated labels to have different background color based on type - language or topic.

Updated README file.

<!-- Thanks again for your contribution!-->
