### PR TITLE
Increased coverage of owasp/api.

### DIFF
--- a/backend/tests/owasp/api/chapter_tests.py
+++ b/backend/tests/owasp/api/chapter_tests.py
@@ -1,0 +1,42 @@
+import pytest
+from apps.owasp.api.chapter import ChapterSerializer
+
+@pytest.mark.parametrize(
+    "data,expected",
+    [
+        (
+            {
+                "name": "OWASP Nagoya",
+                "description": "A test chapter",
+                "level": "other",
+                "created_at": "2024-11-01T00:00:00Z",
+                "updated_at": "2024-07-02T00:00:00Z",
+            },
+            True,
+        ),
+        (
+            {
+                "name": "OWASP something",
+                "description": "it is description",
+                "level": "github",
+                "created_at": "2023-12-01T00:00:00Z",
+                "updated_at": "2023-09-02T00:00:00Z",
+            }, 
+            True,
+        ),
+    ],
+)
+def test_chapter_serializer_validation(data, expected):
+    """
+    Test the validation logic of ProjectSerializer using parameterized test cases.
+    """
+    serializer = ChapterSerializer(data=data)
+    is_valid = serializer.is_valid()
+    
+    if not is_valid:
+        # Debug: Print the errors for invalid cases
+        print(f"Validation failed for data: {data}")
+        print(f"Errors: {serializer.errors}")
+    
+    # Assert that the result matches the expected outcome
+    assert is_valid == expected

--- a/backend/tests/owasp/api/committee_tests.py
+++ b/backend/tests/owasp/api/committee_tests.py
@@ -1,0 +1,40 @@
+import pytest
+from apps.owasp.api.committee import CommitteeSerializer
+
+@pytest.mark.parametrize(
+    "data,expected",
+    [
+        (
+            {
+                "name": "Test Project",
+                "description": "A test project",
+                "created_at": "2024-11-01T00:00:00Z",
+                "updated_at": "2024-07-02T00:00:00Z",
+            },
+            True,
+        ),
+        (
+            {
+                "name": "this is a project",
+                "description": "A project without a name",
+                "created_at": "2023-12-01T00:00:00Z",
+                "updated_at": "2023-09-02T00:00:00Z",
+            }, 
+            True,
+        ),
+    ],
+)
+def test_committee_serializer_validation(data, expected):
+    """
+    Test the validation logic of ProjectSerializer using parameterized test cases.
+    """
+    serializer = CommitteeSerializer(data=data)
+    is_valid = serializer.is_valid()
+    
+    if not is_valid:
+        # Debug: Print the errors for invalid cases
+        print(f"Validation failed for data: {data}")
+        print(f"Errors: {serializer.errors}")
+    
+    # Assert that the result matches the expected outcome
+    assert is_valid == expected

--- a/backend/tests/owasp/api/event_tests.py
+++ b/backend/tests/owasp/api/event_tests.py
@@ -1,0 +1,40 @@
+import pytest
+from apps.owasp.api.event import EventSerializer
+
+@pytest.mark.parametrize(
+    "data,expected",
+    [
+        (
+            {
+                "name": "Test Event",
+                "description": "A test event",
+                "url": "https://github.com/owasp/Nest",
+                "created_at": "2024-11-01T00:00:00Z",
+                "updated_at": "2024-07-02T00:00:00Z",
+            },
+            True,
+        ),
+        (
+            {
+                "name": "biggest event",
+                "description": "this is a biggest event",
+                "url": "https://github.com/owasp",
+                "created_at": "2023-12-01T00:00:00Z",
+                "updated_at": "2023-09-02T00:00:00Z",
+            }, 
+            True,
+        ),
+    ],
+)
+def test_event_serializer_validation(data, expected):
+    """
+    Test the validation logic of ProjectSerializer using parameterized test cases.
+    """
+    serializer = EventSerializer(data=data)
+    is_valid = serializer.is_valid()
+    
+    if not is_valid:
+        print(f"Validation failed for data: {data}")
+        print(f"Errors: {serializer.errors}")
+    
+    assert is_valid == expected

--- a/backend/tests/owasp/api/project_tests.py
+++ b/backend/tests/owasp/api/project_tests.py
@@ -1,0 +1,42 @@
+import pytest
+from apps.owasp.api.project import ProjectSerializer
+
+@pytest.mark.parametrize(
+    "data,expected",
+    [
+        (
+            {
+                "name": "another project",
+                "description": "A test project by owasp",
+                "level": "other",
+                "created_at": "2023-01-01T00:00:00Z",
+                "updated_at": "2023-01-02T00:00:00Z",
+            },
+            True,
+        ),
+        (
+            {
+                "name": "this is a project",
+                "description": "this is not a project, this is just a file",
+                "level": "Hello",
+                "created_at": "2023-01-01T00:00:00Z",
+                "updated_at": "2023-01-02T00:00:00Z",
+            }, 
+            False,
+        ),
+    ],
+)
+def test_project_serializer_validation(data, expected):
+    """
+    Test the validation logic of ProjectSerializer using parameterized test cases.
+    """
+    serializer = ProjectSerializer(data=data)
+    is_valid = serializer.is_valid()
+    
+    if not is_valid:
+        # Debug: Print the errors for invalid cases
+        print(f"Validation failed for data: {data}")
+        print(f"Errors: {serializer.errors}")
+    
+    # Assert that the result matches the expected outcome
+    assert is_valid == expected

--- a/backend/tests/owasp/api/search/chapter_search_tests.py
+++ b/backend/tests/owasp/api/search/chapter_search_tests.py
@@ -1,0 +1,87 @@
+import pytest
+import json
+from unittest.mock import patch
+from django.http import JsonResponse, HttpRequest
+
+from apps.owasp.api.search.chapter import get_chapters, chapters
+from apps.owasp.models.chapter import Chapter
+
+# Test data for parametrized tests
+MOCKED_COORDINATES = (37.7749, -122.4194)
+MOCKED_USER_IP = "127.0.0.1"
+MOCKED_HITS = {
+    "hits": [
+        {"idx_name": "OWASP San Francisco", "idx_url": "https://owasp.sf"},
+        {"idx_name": "OWASP New York", "idx_url": "https://owasp.ny"},
+    ],
+    "nbPages": 5,
+}
+
+@pytest.mark.parametrize(
+    "query, page, expected_hits",
+    [
+        ("security", 1, MOCKED_HITS),
+        ("web", 2, MOCKED_HITS),
+        ("", 1, MOCKED_HITS),  # Edge case: empty query
+    ],
+)
+def test_get_chapters(query, page, expected_hits):
+    """Test get_chapters function."""
+    # Use context managers for mocking
+    with (
+        patch("apps.owasp.api.search.chapter.raw_search", return_value=expected_hits) as mock_raw_search
+    ):
+        # Call function
+        result = get_chapters(query=query, page=page, meta={"REMOTE_ADDR": MOCKED_USER_IP})
+
+        # Assertions
+        mock_raw_search.assert_called_once()
+        assert result == expected_hits
+
+@pytest.mark.parametrize(
+    "query, page, expected_response",
+    [
+        (
+            "security",
+            1,
+            {
+                "active_chapters_count": 10,
+                "chapters": MOCKED_HITS["hits"],
+                "total_pages": MOCKED_HITS["nbPages"],
+            },
+        ),
+    ],
+)
+def test_chapters(query, page, expected_response):
+    """Test chapters API endpoint."""
+    # Create a mock request
+    request = HttpRequest()
+    request.GET = {
+        "q": query,
+        "page": str(page)
+    }
+    request.META = {"REMOTE_ADDR": MOCKED_USER_IP}
+
+    # Use context managers for mocking
+    with (
+        patch.object(Chapter, "active_chapters_count", return_value=10) as mock_active_count,
+        patch("apps.owasp.api.search.chapter.get_chapters", return_value=MOCKED_HITS) as mock_get_chapters
+    ):
+        # Call function
+        response = chapters(request)
+
+        # Assertions
+        assert isinstance(response, JsonResponse)
+        assert response.status_code == 200
+        
+        # Parse the JSON content instead of using .json()
+        response_data = json.loads(response.content)
+        assert response_data == expected_response
+        
+        # Verify mock calls
+        mock_get_chapters.assert_called_once_with(
+            query=query, 
+            page=page, 
+            meta=request.META
+        )
+        mock_active_count.assert_called_once()

--- a/backend/tests/owasp/api/search/committee_search_tests.py
+++ b/backend/tests/owasp/api/search/committee_search_tests.py
@@ -1,0 +1,86 @@
+import pytest
+import json
+from unittest.mock import patch
+from django.http import JsonResponse, HttpRequest
+
+from apps.owasp.api.search.committee import get_committees, committees
+from apps.owasp.models.committee import Committee
+
+# Test data for parametrized tests
+MOCKED_COORDINATES = (37.7749, -122.4194)
+MOCKED_USER_IP = "127.0.0.1"
+MOCKED_HITS = {
+    "hits": [
+        {"idx_name": "OWASP San Francisco", "idx_url": "https://owasp.sf"},
+        {"idx_name": "OWASP New York", "idx_url": "https://owasp.ny"},
+    ],
+    "nbPages": 5,
+}
+
+@pytest.mark.parametrize(
+    "query, page, expected_hits",
+    [
+        ("security", 1, MOCKED_HITS),
+        ("web", 2, MOCKED_HITS),
+        ("", 1, MOCKED_HITS),  # Edge case: empty query
+    ],
+)
+def test_get_committees(query, page, expected_hits):
+    """Test get_committees function."""
+    # Use context managers for mocking
+    with (
+        patch("apps.owasp.api.search.committee.raw_search", return_value=expected_hits) as mock_raw_search
+    ):
+        # Call function
+        result = get_committees(query=query, page=page)
+
+        # Assertions
+        mock_raw_search.assert_called_once()
+        assert result == expected_hits
+
+@pytest.mark.parametrize(
+    "query, page, expected_response",
+    [
+        (
+            "security",
+            1,
+            {
+                "active_committees_count": 10,
+                "committees": MOCKED_HITS["hits"],
+                "total_pages": MOCKED_HITS["nbPages"],
+            },
+        ),
+    ],
+)
+def test_committees(query, page, expected_response):
+    """Test committees API endpoint."""
+    # Create a mock request
+    request = HttpRequest()
+    request.GET = {
+        "q": query,
+        "page": str(page)
+    }
+
+    # Use context managers for mocking
+    with (
+        patch.object(Committee, "active_committees_count", return_value=10) as mock_active_count,
+        patch("apps.owasp.api.search.committee.get_committees", return_value=MOCKED_HITS) as mock_get_committees
+    ):
+        # Call function
+        response = committees(request)
+
+        # Assertions
+        assert isinstance(response, JsonResponse)
+        assert response.status_code == 200
+        
+        # Parse the JSON content instead of using .json()
+        response_data = json.loads(response.content)
+        assert response_data == expected_response
+        
+        # Verify mock calls
+        mock_get_committees.assert_called_once_with(
+            query=query, 
+            page=page, 
+            
+        )
+        mock_active_count.assert_called_once()

--- a/backend/tests/owasp/api/search/issue_search_tests.py
+++ b/backend/tests/owasp/api/search/issue_search_tests.py
@@ -1,0 +1,86 @@
+import pytest
+import json
+from unittest.mock import patch
+from django.http import JsonResponse, HttpRequest
+
+from apps.owasp.api.search.issue import get_issues, project_issues
+from apps.github.models.issue import Issue
+
+# Test data for parametrized tests
+MOCKED_COORDINATES = (37.7749, -122.4194)
+MOCKED_USER_IP = "127.0.0.1"
+MOCKED_HITS = {
+    "hits": [
+        {"idx_name": "OWASP San Francisco", "idx_url": "https://owasp.sf"},
+        {"idx_name": "OWASP New York", "idx_url": "https://owasp.ny"},
+    ],
+    "nbPages": 5,
+}
+
+@pytest.mark.parametrize(
+    "query, page, expected_hits",
+    [
+        ("security", 1, MOCKED_HITS),
+        ("web", 2, MOCKED_HITS),
+        ("", 1, MOCKED_HITS),  # Edge case: empty query
+    ],
+)
+def test_get_issues(query, page, expected_hits):
+    """Test get_issues function."""
+    # Use context managers for mocking
+    with (
+        patch("apps.owasp.api.search.issue.raw_search", return_value=expected_hits) as mock_raw_search
+    ):
+        # Call function
+        result = get_issues(query, page=page, distinct=False)
+
+        # Assertions
+        mock_raw_search.assert_called_once()
+        assert result == expected_hits
+
+@pytest.mark.parametrize(
+    "query, page, expected_response",
+    [
+        (
+            "security",
+            1,
+            {
+                "open_issues_count": 10,
+                "issues": MOCKED_HITS["hits"],
+                "total_pages": MOCKED_HITS["nbPages"],
+            },
+        ),
+    ],
+)
+def test_issues(query, page, expected_response):
+    """Test issues API endpoint."""
+    # Create a mock request
+    request = HttpRequest()
+    request.GET = {
+        "q": query,
+        "page": str(page)
+    }
+
+    # Use context managers for mocking
+    with (
+        patch.object(Issue, "open_issues_count", return_value=10) as mock_active_count,
+        patch("apps.owasp.api.search.issue.get_issues", return_value=MOCKED_HITS) as mock_get_issues
+    ):
+        # Call function
+        response = project_issues(request)
+
+        # Assertions
+        assert isinstance(response, JsonResponse)
+        assert response.status_code == 200
+        
+        # Parse the JSON content instead of using .json()
+        response_data = json.loads(response.content)
+        assert response_data == expected_response
+        
+        # Verify mock calls
+        mock_get_issues.assert_called_once_with(
+            query, 
+            page=page, 
+            distinct=False
+        )
+        mock_active_count.assert_called_once()

--- a/backend/tests/owasp/api/search/project_search_tests.py
+++ b/backend/tests/owasp/api/search/project_search_tests.py
@@ -1,0 +1,86 @@
+import pytest
+import json
+from unittest.mock import patch
+from django.http import JsonResponse, HttpRequest
+
+from apps.owasp.api.search.project import get_projects, projects
+from apps.owasp.models.project import Project
+
+# Test data for parametrized tests
+MOCKED_COORDINATES = (37.7749, -122.4194)
+MOCKED_USER_IP = "127.0.0.1"
+MOCKED_HITS = {
+    "hits": [
+        {"idx_name": "OWASP San Francisco", "idx_url": "https://owasp.sf"},
+        {"idx_name": "OWASP New York", "idx_url": "https://owasp.ny"},
+    ],
+    "nbPages": 5,
+}
+
+@pytest.mark.parametrize(
+    "query, page, expected_hits",
+    [
+        ("security", 1, MOCKED_HITS),
+        ("web", 2, MOCKED_HITS),
+        ("", 1, MOCKED_HITS),  # Edge case: empty query
+    ],
+)
+def test_get_projects(query, page, expected_hits):
+    """Test get_projects function."""
+    # Use context managers for mocking
+    with (
+        patch("apps.owasp.api.search.project.raw_search", return_value=expected_hits) as mock_raw_search
+    ):
+        # Call function
+        result = get_projects(query=query, page=page)
+
+        # Assertions
+        mock_raw_search.assert_called_once()
+        assert result == expected_hits
+
+@pytest.mark.parametrize(
+    "query, page, expected_response",
+    [
+        (
+            "security",
+            1,
+            {
+                "active_projects_count": 10,
+                "projects": MOCKED_HITS["hits"],
+                "total_pages": MOCKED_HITS["nbPages"],
+            },
+        ),
+    ],
+)
+def test_projects(query, page, expected_response):
+    """Test projects API endpoint."""
+    # Create a mock request
+    request = HttpRequest()
+    request.GET = {
+        "q": query,
+        "page": str(page)
+    }
+
+    # Use context managers for mocking
+    with (
+        patch.object(Project, "active_projects_count", return_value=10) as mock_active_count,
+        patch("apps.owasp.api.search.project.get_projects", return_value=MOCKED_HITS) as mock_get_projects
+    ):
+        # Call function
+        response = projects(request)
+
+        # Assertions
+        assert isinstance(response, JsonResponse)
+        assert response.status_code == 200
+        
+        # Parse the JSON content instead of using .json()
+        response_data = json.loads(response.content)
+        assert response_data == expected_response
+        
+        # Verify mock calls
+        mock_get_projects.assert_called_once_with(
+            query=query, 
+            page=page, 
+            
+        )
+        mock_active_count.assert_called_once()

--- a/backend/tests/owasp/api/urls_tests.py
+++ b/backend/tests/owasp/api/urls_tests.py
@@ -1,0 +1,36 @@
+import pytest
+from apps.owasp.api.urls import router  
+from apps.owasp.api.chapter import ChapterViewSet
+from apps.owasp.api.committee import CommitteeViewSet
+from apps.owasp.api.event import EventViewSet
+from apps.owasp.api.project import ProjectViewSet
+
+
+@pytest.mark.parametrize(
+    "url_name, expected_prefix, viewset_class",
+    [
+        ("chapter-list", "owasp/chapters", ChapterViewSet),
+        ("committee-list", "owasp/committees", CommitteeViewSet),
+        ("event-list", "owasp/events", EventViewSet),
+        ("project-list", "owasp/projects", ProjectViewSet),
+    ],
+)
+def test_router_registration(url_name, expected_prefix, viewset_class):
+    """
+    Test that the router correctly registers viewsets and generates URLs.
+    """
+    # Find routes with the specified `url_name`
+    matching_routes = [route for route in router.urls if route.name == url_name]
+    assert matching_routes, f"Route '{url_name}' not found in router."
+
+    for route in matching_routes:
+        # Verify that the route's pattern includes the expected prefix
+        assert expected_prefix in route.pattern.describe(), (
+            f"Prefix '{expected_prefix}' not found in route '{route.name}'."
+        )
+
+        # Extract the viewset from the route and verify its type
+        viewset = route.callback.cls
+        assert issubclass(viewset, viewset_class), (
+            f"Viewset for '{route.name}' does not match {viewset_class}."
+        )


### PR DESCRIPTION
<!-- Thanks for contributing to OWASP Nest!-->

<!-- Don't forget to link your PR to an existing issue if any.-->
Resolves #181 
This PR resolve "Increase backend owasp/api coverage"
<!-- Describe the big picture of your changes.-->
In this PR, coverage of the backend owasp/api is increased (which was before 0%). Lead to increase in the total coverage by 7-8%. Below are the snapshots to see the actual coverage of all the file.

![Screenshot 2024-12-17 215153](https://github.com/user-attachments/assets/a7ccb464-8b2d-4578-8f87-0271d7dc4749)
![Screenshot 2024-12-17 215213](https://github.com/user-attachments/assets/be156704-36bb-4556-9b04-001177d83639)

All the test file are created inside the backend/tests folder and structured the same way as in backend/app folder.
backend/tests/owasp/
├── __init__.py
├── api
│   ├── chapter_tests.py
│   ├── committee_tests.py
│   ├── event_tests.py
│   ├── project_tests.py
│   ├── search
│   │   ├── chapter_search_tests.py
│   │   ├── committee_search_tests.py
│   │   ├── issue_search_tests.py
│   │   └── project_search_tests.py
│   └── urls_tests.py
└── models
    ├── __init__.py
    └── project_tests.py

<!-- Thanks again for your contribution!-->
