### PR TITLE
Configure Dockerfile for staging environment

### DIFF
--- a/docker-compose-staging.yaml
+++ b/docker-compose-staging.yaml
@@ -21,6 +21,18 @@ services:
     volumes:
       - ./data:/home/owasp/data
 
+  frontend:
+    container_name: nest-frontend
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile.staging
+    env_file: ./frontend/.env
+    restart: unless-stopped
+    networks:
+      - nest_app_network
+    expose:
+      - "80"
+
   certbot:
     container_name: nest-certbot
     image: certbot/certbot
@@ -61,10 +73,11 @@ services:
       - '443:443'
     volumes:
       - ./letsencrypt:/etc/letsencrypt
-      - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf
+      - ./nginx/staging.conf:/etc/nginx/conf.d/default.conf
       - certbot-webroot:/var/www/certbot
     depends_on:
       - backend
+      - frontend
     networks:
       - nest_app_network
 

--- a/docker-compose-staging.yaml
+++ b/docker-compose-staging.yaml
@@ -73,7 +73,7 @@ services:
       - '443:443'
     volumes:
       - ./letsencrypt:/etc/letsencrypt
-      - ./nginx/staging.conf:/etc/nginx/conf.d/default.conf
+      - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf
       - certbot-webroot:/var/www/certbot
     depends_on:
       - backend

--- a/frontend/Dockerfile.staging
+++ b/frontend/Dockerfile.staging
@@ -7,6 +7,7 @@ RUN npm install
 
 COPY . .
 RUN npm run build
+COPY .env .env
 
 FROM nginx:stable-alpine
 

--- a/nginx/staging.conf
+++ b/nginx/staging.conf
@@ -8,7 +8,17 @@ server {
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ciphers HIGH:!aNULL:!MD5;
 
+    # Serve frontend
     location / {
+        proxy_pass http://frontend:80;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Proxy backend API
+    location /api/ {
         proxy_pass http://backend:8000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
<!-- Thanks for contributing to OWASP Nest!-->

<!-- Don't forget to link your PR to an existing issue if any.-->
Resolves #191 

<!-- Describe the big picture of your changes.-->
This pull request includes several changes to the `docker-compose-staging.yaml`, `frontend/Dockerfile.staging`, and `nginx/staging.conf` files to integrate and serve the frontend application in the staging environment. The most important changes are listed below:

Docker Compose configuration updates:
- [x] Added a new `frontend` service configuration to the `docker-compose-staging.yaml` file. This includes setting up the container, build context, environment variables, and networking.
- [x] Updated the `nginx` service configuration to use `staging.conf` instead of `nginx.conf` and added dependency on the `frontend` service.
- [ ] Commit the requested changes and test in local env
<!-- Thanks again for your contribution!-->
