### PR TITLE
Add default focus on search input when page loads

### DIFF
--- a/frontend/__tests__/src/pages/Chapters.test.tsx
+++ b/frontend/__tests__/src/pages/Chapters.test.tsx
@@ -93,6 +93,7 @@ describe('ChaptersPage Component', () => {
     })
     await waitFor(() => {
       expect(screen.getByPlaceholderText('Search for OWASP chapters...')).toBeInTheDocument()
+      expect(screen.getByPlaceholderText('Search for OWASP chapters...')).toHaveFocus()
       expect(screen.getByText('Chapter 1')).toBeInTheDocument()
       expect(screen.getByText('Next Page')).toBeInTheDocument()
     })

--- a/frontend/__tests__/src/pages/Committees.test.tsx
+++ b/frontend/__tests__/src/pages/Committees.test.tsx
@@ -60,6 +60,7 @@ describe('Committees Component', () => {
 
     await waitFor(() => {
       expect(screen.getByPlaceholderText('Search for OWASP committees...')).toBeInTheDocument()
+      expect(screen.getByPlaceholderText('Search for OWASP committees...')).toHaveFocus()
       expect(screen.getByText('Committee 1')).toBeInTheDocument()
       expect(screen.getByText('Next Page')).toBeInTheDocument()
     })

--- a/frontend/__tests__/src/pages/Projects.test.tsx
+++ b/frontend/__tests__/src/pages/Projects.test.tsx
@@ -56,6 +56,7 @@ describe('ProjectPage Component', () => {
     })
     await waitFor(() => {
       expect(screen.getByPlaceholderText('Search for OWASP projects...')).toBeInTheDocument()
+      expect(screen.getByPlaceholderText('Search for OWASP projects...')).toHaveFocus()
       expect(screen.getByText('Project 1')).toBeInTheDocument()
       expect(screen.getByText('Next Page')).toBeInTheDocument()
     })

--- a/frontend/src/components/Search.tsx
+++ b/frontend/src/components/Search.tsx
@@ -20,7 +20,7 @@ const SearchComponent: React.FC<SearchProps> = ({ onSearch, placeholder, initial
   useEffect(() => {
     inputRef.current?.focus()
   }, [])
-  
+
   const debouncedSearch = useMemo(
     () => debounce((query: string) => onSearch(query), 500),
     [onSearch]

--- a/frontend/src/components/Search.tsx
+++ b/frontend/src/components/Search.tsx
@@ -17,6 +17,10 @@ const SearchComponent: React.FC<SearchProps> = ({ onSearch, placeholder, initial
     setSearchQuery(initialValue)
   }, [initialValue])
 
+  useEffect(() => {
+    inputRef.current?.focus()
+  }, [])
+  
   const debouncedSearch = useMemo(
     () => debounce((query: string) => onSearch(query), 500),
     [onSearch]


### PR DESCRIPTION
<!-- Thanks for contributing to OWASP Nest!-->

<!-- Don't forget to link your PR to an existing issue if any.-->
Resolves #261 

<!-- Describe the big picture of your changes.-->
This PR adds a default focus to the search input field when the page loads.
Users can start typing immediately without clicking on the search bar. 

Thank You!

<!-- Thanks again for your contribution!-->
