### PR TITLE
Removed owasp search api endpoints

### DIFF
--- a/backend/apps/owasp/api/search/chapter.py
+++ b/backend/apps/owasp/api/search/chapter.py
@@ -1,7 +1,6 @@
 """OWASP app chapter search API."""
 
 from algoliasearch_django import raw_search
-from django.http import JsonResponse
 
 from apps.common.geocoding import get_ip_coordinates
 from apps.common.utils import get_user_ip
@@ -33,18 +32,3 @@ def get_chapters(query, attributes=None, limit=25, meta=None, page=1):
         params["aroundLatLng"] = f"{coordinates[0]},{coordinates[1]}"
 
     return raw_search(Chapter, query, params)
-
-
-def chapters(request):
-    """Search chapters API endpoint."""
-    page = int(request.GET.get("page", 1))
-    query = request.GET.get("q", "")
-    chapters = get_chapters(query=query, page=page, meta=request.META)
-    return JsonResponse(
-        {
-            "active_chapters_count": Chapter.active_chapters_count(),
-            "chapters": chapters["hits"],
-            "total_pages": chapters["nbPages"],
-        },
-        safe=False,
-    )

--- a/backend/apps/owasp/api/search/committee.py
+++ b/backend/apps/owasp/api/search/committee.py
@@ -1,7 +1,6 @@
 """OWASP app committee search API."""
 
 from algoliasearch_django import raw_search
-from django.http import JsonResponse
 
 from apps.owasp.models.committee import Committee
 
@@ -28,18 +27,3 @@ def get_committees(query, attributes=None, limit=25, page=1):
     }
 
     return raw_search(Committee, query, params)
-
-
-def committees(request):
-    """Search committees API endpoint."""
-    page = int(request.GET.get("page", 1))
-    query = request.GET.get("q", "")
-    committees = get_committees(query=query, page=page)
-    return JsonResponse(
-        {
-            "active_committees_count": Committee.active_committees_count(),
-            "committees": committees["hits"],
-            "total_pages": committees["nbPages"],
-        },
-        safe=False,
-    )

--- a/backend/apps/owasp/api/search/project.py
+++ b/backend/apps/owasp/api/search/project.py
@@ -1,10 +1,7 @@
 """OWASP app project search API."""
 
 from algoliasearch_django import raw_search
-from django.core.cache import cache
-from django.http import JsonResponse
 
-from apps.common.constants import DAY_IN_SECONDS
 from apps.owasp.models.project import Project
 
 PROJECT_CACHE_PREFIX = "project:"
@@ -36,25 +33,3 @@ def get_projects(query, attributes=None, limit=25, page=1):
     }
 
     return raw_search(Project, query, params)
-
-
-def projects(request):
-    """Search projects API endpoint."""
-    page = int(request.GET.get("page", 1))
-    query = request.GET.get("q", "")
-
-    cache_key = f"{PROJECT_CACHE_PREFIX}{query}_page_{page}"
-    projects = cache.get(cache_key)
-
-    if projects is None:
-        projects = get_projects(query=query, page=page)
-        cache.set(cache_key, projects, DAY_IN_SECONDS)
-
-    return JsonResponse(
-        {
-            "active_projects_count": Project.active_projects_count(),
-            "projects": projects["hits"],
-            "total_pages": projects["nbPages"],
-        },
-        safe=False,
-    )

--- a/backend/settings/urls.py
+++ b/backend/settings/urls.py
@@ -11,10 +11,6 @@ from django.urls import include, path
 from rest_framework import routers
 
 from apps.github.api.urls import router as github_router
-from apps.owasp.api.search.chapter import chapters as search_chapters
-from apps.owasp.api.search.committee import committees as search_committees
-from apps.owasp.api.search.issue import project_issues as search_project_issues
-from apps.owasp.api.search.project import projects as search_projects
 from apps.owasp.api.urls import router as owasp_router
 from apps.slack.apps import SlackConfig
 
@@ -24,10 +20,6 @@ router.registry.extend(owasp_router.registry)
 
 urlpatterns = [
     path("api/v1/", include(router.urls)),
-    path("api/v1/owasp/search/issue", search_project_issues, name="api-search-project-issues"),
-    path("api/v1/owasp/search/project", search_projects, name="api-search-projects"),
-    path("api/v1/owasp/search/chapter", search_chapters, name="api-search-chapters"),
-    path("api/v1/owasp/search/committee", search_committees, name="api-search-committees"),
     path("a/", admin.site.urls),
 ]
 

--- a/backend/tests/owasp/api/search/chapter_tests.py
+++ b/backend/tests/owasp/api/search/chapter_tests.py
@@ -1,12 +1,8 @@
-import json
 from unittest.mock import patch
 
 import pytest
-import requests
-from django.http import HttpRequest, JsonResponse
 
-from apps.owasp.api.search.chapter import chapters, get_chapters
-from apps.owasp.models.chapter import Chapter
+from apps.owasp.api.search.chapter import get_chapters
 
 MOCKED_COORDINATES = (37.7749, -122.4194)
 MOCKED_USER_IP = "127.0.0.1"
@@ -35,40 +31,3 @@ def test_get_chapters(query, page, expected_hits):
 
         mock_raw_search.assert_called_once()
         assert result == expected_hits
-
-
-@pytest.mark.parametrize(
-    ("query", "page", "expected_response"),
-    [
-        (
-            "security",
-            "1",
-            {
-                "active_chapters_count": 10,
-                "chapters": MOCKED_HITS["hits"],
-                "total_pages": MOCKED_HITS["nbPages"],
-            },
-        ),
-    ],
-)
-def test_chapters(query, page, expected_response):
-    request = HttpRequest()
-    request.GET = {"q": query, "page": page}
-    request.META = {"REMOTE_ADDR": MOCKED_USER_IP}
-
-    with (
-        patch.object(Chapter, "active_chapters_count", return_value=10) as mock_active_count,
-        patch(
-            "apps.owasp.api.search.chapter.get_chapters", return_value=MOCKED_HITS
-        ) as mock_get_chapters,
-    ):
-        response = chapters(request)
-
-        assert isinstance(response, JsonResponse)
-        assert response.status_code == requests.codes.ok
-
-        response_data = json.loads(response.content)
-        assert response_data == expected_response
-
-        mock_get_chapters.assert_called_once_with(query=query, meta=request.META, page=int(page))
-        mock_active_count.assert_called_once()

--- a/backend/tests/owasp/api/search/committee_tests.py
+++ b/backend/tests/owasp/api/search/committee_tests.py
@@ -1,12 +1,8 @@
-import json
 from unittest.mock import patch
 
 import pytest
-import requests
-from django.http import HttpRequest, JsonResponse
 
-from apps.owasp.api.search.committee import committees, get_committees
-from apps.owasp.models.committee import Committee
+from apps.owasp.api.search.committee import get_committees
 
 MOCKED_HITS = {
     ("hits"): [
@@ -39,42 +35,3 @@ def test_get_committees(query, page, expected_hits):
 
         mock_raw_search.assert_called_once()
         assert result == expected_hits
-
-
-@pytest.mark.parametrize(
-    ("query", "page", "expected_response"),
-    [
-        (
-            "security",
-            1,
-            {
-                "active_committees_count": 10,
-                "committees": MOCKED_HITS["hits"],
-                "total_pages": MOCKED_HITS["nbPages"],
-            },
-        ),
-    ],
-)
-def test_committees(query, page, expected_response):
-    request = HttpRequest()
-    request.GET = {"q": query, "page": str(page)}
-
-    with (
-        patch.object(Committee, "active_committees_count", return_value=10) as mock_active_count,
-        patch(
-            "apps.owasp.api.search.committee.get_committees", return_value=MOCKED_HITS
-        ) as mock_get_committees,
-    ):
-        response = committees(request)
-
-        assert isinstance(response, JsonResponse)
-        assert response.status_code == requests.codes.ok
-
-        response_data = json.loads(response.content)
-        assert response_data == expected_response
-
-        mock_get_committees.assert_called_once_with(
-            query=query,
-            page=page,
-        )
-        mock_active_count.assert_called_once()

--- a/backend/tests/owasp/api/search/project_tests.py
+++ b/backend/tests/owasp/api/search/project_tests.py
@@ -1,12 +1,8 @@
-import json
 from unittest.mock import patch
 
 import pytest
-import requests
-from django.http import HttpRequest, JsonResponse
 
-from apps.owasp.api.search.project import get_projects, projects
-from apps.owasp.models.project import Project
+from apps.owasp.api.search.project import get_projects
 
 MOCKED_HITS = {
     ("hits"): [
@@ -33,42 +29,3 @@ def test_get_projects(query, page, expected_hits):
 
         mock_raw_search.assert_called_once()
         assert result == expected_hits
-
-
-@pytest.mark.parametrize(
-    ("query", "page", "expected_response"),
-    [
-        (
-            "security",
-            1,
-            {
-                "active_projects_count": 10,
-                "projects": MOCKED_HITS["hits"],
-                "total_pages": MOCKED_HITS["nbPages"],
-            },
-        ),
-    ],
-)
-def test_projects(query, page, expected_response):
-    request = HttpRequest()
-    request.GET = {"q": query, "page": str(page)}
-
-    with (
-        patch.object(Project, "active_projects_count", return_value=10) as mock_active_count,
-        patch(
-            "apps.owasp.api.search.project.get_projects", return_value=MOCKED_HITS
-        ) as mock_get_projects,
-    ):
-        response = projects(request)
-
-        assert isinstance(response, JsonResponse)
-        assert response.status_code == requests.codes.ok
-
-        response_data = json.loads(response.content)
-        assert response_data == expected_response
-
-        mock_get_projects.assert_called_once_with(
-            query=query,
-            page=page,
-        )
-        mock_active_count.assert_called_once()


### PR DESCRIPTION
<!-- Thanks for contributing to OWASP Nest!-->

<!-- Don't forget to link your PR to an existing issue if any.-->
Resolves #254 

<!-- Describe the big picture of your changes.-->
Removed unnecessary search API endpoints.
Since the API is used by Slack app for the commands, hence the search files are kept as it is.

<!-- Thanks again for your contribution!-->
