### PR TITLE
fixed: button-bgcolor-on-hover

### DIFF
--- a/frontend/src/components/ActionButton.tsx
+++ b/frontend/src/components/ActionButton.tsx
@@ -12,7 +12,7 @@ interface ActionButtonProps {
 
 const ActionButton: React.FC<ActionButtonProps> = ({ url, onClick, tooltipLabel, children }) => {
   const baseStyles =
-    'flex flex-nowrap text-nowrap justify-center self-end items-center gap-2 p-1 px-2 rounded-md bg-transparent hover:bg-[#0D6EFD] text-[#0D6EFD] hover:text-white border border-[#0D6EFD] dark:border-sky-600 dark:text-sky-600 dark:hover:bg-sky-600'
+    'flex flex-nowrap text-nowrap justify-center self-end items-center gap-2 p-1 px-2 rounded-md bg-transparent hover:bg-[#0D6EFD] text-[#0D6EFD] hover:text-white border border-[#0D6EFD] dark:border-sky-600 dark:text-sky-600 dark:hover:bg-sky-100'
 
   return url ? (
     <a


### PR DESCRIPTION
fixes #408 

fixed button background color on hover in dark-mode at five end-points:
1. /contribute
2. /projects
3. /projects/'project-name'
4. /chapters
5. /chapters/'chapter-name'

https://github.com/user-attachments/assets/c2ca567c-da1c-4b2a-886b-20b67f8e9a8d


