### PR TITLE
Change Refactor index synonyms

### DIFF
--- a/backend/apps/github/index/issue.py
+++ b/backend/apps/github/index/issue.py
@@ -94,4 +94,4 @@ class IssueIndex(AlgoliaIndex, IndexBase):
     @staticmethod
     def update_synonyms():
         """Update synonyms."""
-        return IssueIndex.reindex_synonyms("github", "issues")
+        return IssueIndex.reindex_synonyms("github", "issue")

--- a/backend/apps/owasp/index/project.py
+++ b/backend/apps/owasp/index/project.py
@@ -91,4 +91,4 @@ class ProjectIndex(AlgoliaIndex, IndexBase):
     @staticmethod
     def update_synonyms():
         """Update synonyms."""
-        return ProjectIndex.reindex_synonyms("owasp", "projects")
+        return ProjectIndex.reindex_synonyms("owasp", "project")


### PR DESCRIPTION



Resolves #478 


I have renamed synonym files from plural to singular in 
[file](https://github.com/OWASP/Nest/blob/556a36652bddf2a446350cb23ea50f11b9094e3a/backend/apps/github/index/issue.py#L97) issues to issue
and 
[file](https://github.com/OWASP/Nest/blob/556a36652bddf2a446350cb23ea50f11b9094e3a/backend/apps/owasp/index/project.py#L94)
projects to project