### PR TITLE
Move summary block higher on project details page

### DIFF
--- a/frontend/src/pages/ProjectDetails.tsx
+++ b/frontend/src/pages/ProjectDetails.tsx
@@ -71,12 +71,10 @@ const ProjectDetailsPage = () => {
       <div className="mx-auto max-w-6xl">
         <h1 className="mb-6 mt-4 text-4xl font-bold">{project.name}</h1>
         <p className="mb-6 text-xl">{project.description}</p>
-
         <div className="mb-8 rounded-lg bg-gray-100 p-6 shadow-md dark:bg-gray-800">
           <h2 className="mb-4 text-2xl font-semibold">Summary</h2>
           <p>{project.summary}</p>
         </div>
-        
         <div className="mb-8 grid grid-cols-1 gap-6 md:grid-cols-3">
           <div className="rounded-lg bg-gray-100 p-6 shadow-md dark:bg-gray-800 md:col-span-2">
             <h2 className="mb-4 text-2xl font-semibold">Project Details</h2>
@@ -129,8 +127,6 @@ const ProjectDetailsPage = () => {
             </div>
           </div>
         </div>
-
-
         <div className="mb-8 grid grid-cols-1 gap-6 md:grid-cols-2">
           <div className="rounded-lg bg-gray-100 p-6 shadow-md dark:bg-gray-800">
             <h2 className="mb-4 text-2xl font-semibold">Languages</h2>

--- a/frontend/src/pages/ProjectDetails.tsx
+++ b/frontend/src/pages/ProjectDetails.tsx
@@ -72,6 +72,11 @@ const ProjectDetailsPage = () => {
         <h1 className="mb-6 mt-4 text-4xl font-bold">{project.name}</h1>
         <p className="mb-6 text-xl">{project.description}</p>
 
+        <div className="mb-8 rounded-lg bg-gray-100 p-6 shadow-md dark:bg-gray-800">
+          <h2 className="mb-4 text-2xl font-semibold">Summary</h2>
+          <p>{project.summary}</p>
+        </div>
+        
         <div className="mb-8 grid grid-cols-1 gap-6 md:grid-cols-3">
           <div className="rounded-lg bg-gray-100 p-6 shadow-md dark:bg-gray-800 md:col-span-2">
             <h2 className="mb-4 text-2xl font-semibold">Project Details</h2>
@@ -125,10 +130,6 @@ const ProjectDetailsPage = () => {
           </div>
         </div>
 
-        <div className="mb-8 rounded-lg bg-gray-100 p-6 shadow-md dark:bg-gray-800">
-          <h2 className="mb-4 text-2xl font-semibold">Summary</h2>
-          <p>{project.summary}</p>
-        </div>
 
         <div className="mb-8 grid grid-cols-1 gap-6 md:grid-cols-2">
           <div className="rounded-lg bg-gray-100 p-6 shadow-md dark:bg-gray-800">


### PR DESCRIPTION
Resolves: #547 

Moved the summary block right after the page header
as per the requirement 
