### PR TITLE
Updated the gsoc link

### DIFF
--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -50,7 +50,7 @@ export const footerSections: Section[] = [
     title: 'Community',
     links: [
       { text: 'Community Content', href: 'https://owasp.org/www-community/' },
-      { text: 'Google Summer of Code', href: 'https://owasp.org/gsoc/gsoc2024' },
+      { text: 'Google Summer of Code', href: 'https://owasp.org/gsoc' },
       {
         text: 'Start a Local Chapter',
         href: 'https://owasporg.atlassian.net/servicedesk/customer/portal/8/group/20/create/90?src=-1419759666',


### PR DESCRIPTION
<!-- Thanks for contributing to OWASP Nest!-->

<!-- Don't forget to link your PR to an existing issue if any.-->
Resolves #639 

<!-- Describe the big picture of your changes.-->
Updated the "Google Summer of Code" link in the footer section.

1. Modified the footer in the application to reflect the updated link for Google Summer of Code.
2. Ensured the link points to the correct GSoC page.

**Visual Representation**:
**Before**:
1. The main page:
![image](https://github.com/user-attachments/assets/88119d97-eb05-40e7-89fc-9a8e993518d0)

2. The link it directed to:
![image](https://github.com/user-attachments/assets/daece2f6-39e2-4a62-a3a5-4d587f54e11f)


**After**:
1. The main page:
![image](https://github.com/user-attachments/assets/1f7ae69b-b7f5-48c0-ab3a-1b7dbbd4e9b7)

2.The link it directs to:
![image](https://github.com/user-attachments/assets/5a678756-f279-4294-8422-09ade7bfc2ff)


<!-- Thanks again for your contribution!-->
