### PR TITLE
Update : sync jobs now run on main repo and main branch only

### DIFF
--- a/.github/workflows/sync-nest-data.yaml
+++ b/.github/workflows/sync-nest-data.yaml
@@ -11,6 +11,7 @@ env:
 jobs:
   update-data:
     name: Run data sync
+    if : github.repository == 'OWASP/Nest' && github.ref == 'refs/heads/main'
     env:
       ANSIBLE_HOST_KEY_CHECKING: False
       STAGING_HOST_IP_ADDRESS: '${{ secrets.STAGING_HOST_IP_ADDRESS }}'

--- a/.github/workflows/sync-nest-data.yaml
+++ b/.github/workflows/sync-nest-data.yaml
@@ -11,7 +11,7 @@ env:
 jobs:
   update-data:
     name: Run data sync
-    if : github.repository == 'OWASP/Nest' && github.ref == 'refs/heads/main'
+    if: github.repository == 'OWASP/Nest'
     env:
       ANSIBLE_HOST_KEY_CHECKING: False
       STAGING_HOST_IP_ADDRESS: '${{ secrets.STAGING_HOST_IP_ADDRESS }}'


### PR DESCRIPTION
<!-- Thanks for contributing to OWASP Nest!-->

<!-- Don't forget to link your PR to an existing issue if any.-->
Resolves #661 

added a condition that checks whether the repo is the OWASP/Nest or not and also the branch is main or not, this ensures that the sync will only be done in the main repo and main branch and not on the forks, which resolves the issue :) 

<!-- Thanks again for your contribution!-->
