### PR TITLE
fixed pre-commit and  removed i-sort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,8 +34,3 @@ repos:
         entry: djlint --reformat
         types:
           - html
-
-  - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -1249,22 +1249,6 @@ files = [
 ]
 
 [[package]]
-name = "isort"
-version = "6.0.0"
-description = "A Python utility / library to sort Python imports."
-optional = false
-python-versions = ">=3.9.0"
-groups = ["dev"]
-files = [
-    {file = "isort-6.0.0-py3-none-any.whl", hash = "sha256:567954102bb47bb12e0fae62606570faacddd441e45683968c8d1734fb1af892"},
-    {file = "isort-6.0.0.tar.gz", hash = "sha256:75d9d8a1438a9432a7d7b54f2d3b45cad9a4a0fdba43617d9873379704a8bdf1"},
-]
-
-[package.extras]
-colors = ["colorama"]
-plugins = ["setuptools"]
-
-[[package]]
 name = "jiter"
 version = "0.8.2"
 description = "Fast iterable JSON parser."
@@ -2902,4 +2886,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "3e0231f0b4062636eb32acad3fbdf3dcc16dcf3f0db30436dbbe363b7be5e1b8"
+content-hash = "1cb1a5e09c9e70000d07a1c0bc7f77a970fba83dfbba763202cebbaff263fd68"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -65,11 +65,6 @@ format_css = true
 format_js = true
 indent = 4
 
-[tool.isort]
-known_first_party = ["apps"]
-known_third_party = ["django", "rest_framework"]
-multi_line_output = 3
-profile = "black"
 
 [tool.pytest.ini_options]
 DJANGO_CONFIGURATION = "Test"
@@ -94,6 +89,7 @@ log_level = "INFO"
 
 [tool.ruff]
 line-length = 99
+extend-select = ["I"]
 
 [tool.ruff.lint]
 ignore = [

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -41,7 +41,7 @@ pygithub = "^2.5.0"
 python = "^3.13"
 pyyaml = "^6.0.2"
 requests = "^2.32.3"
-sentry-sdk = {extras = ["django"], version = "^2.20.0"}
+sentry-sdk = { extras = ["django"], version = "^2.20.0" }
 slack-bolt = "^1.22.0"
 
 
@@ -88,9 +88,9 @@ log_level = "INFO"
 
 [tool.ruff]
 line-length = 99
-extend-select = ["I"]
 
 [tool.ruff.lint]
+extend-select = ["I"]
 ignore = [
     "ANN",
     "ARG002",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -47,7 +47,6 @@ slack-bolt = "^1.22.0"
 
 [tool.poetry.group.dev.dependencies]
 djlint = "^1.36.4"
-isort = "^6.0.0"
 pre-commit = "^4.1.0"
 ruff = "^0.9.3"
 


### PR DESCRIPTION
<!-- Thanks for contributing to OWASP Nest!-->

<!-- Don't forget to link your PR to an existing issue if any.-->
Resolves #717 



Add the PR description here.
- As we know that isort + more of the precommit already replaced by the ruff
- for reference: [plone discussion](https://community.plone.org/t/drop-black-isort-flake8-and-use-ruff/16413)
- for reference official - [ruff](https://docs.astral.sh/ruff/)


![Screenshot from 2025-02-03 02-51-34](https://github.com/user-attachments/assets/f8491cf4-d27c-4f25-920d-fcc6fba5962c)

- [x] Cleanup Done 
- [x] Tested it is working 
 
 
 ### Preview/Screencast
 
[Screencast from 03-02-25 04:17:32 PM IST.webm](https://github.com/user-attachments/assets/1f35b54c-95f1-4eb8-86c0-1b18d2ec7af5)

<!-- Thanks again for your contribution!-->
