### PR TITLE
fixed image not rendering in the links preview

### DIFF
--- a/frontend/src/components/MetadataManager.tsx
+++ b/frontend/src/components/MetadataManager.tsx
@@ -7,7 +7,7 @@ const DEFAULT_METADATA: DefaultMetadata = {
   defaultDescription:
     'OWASP Nest is a comprehensive platform designed to enhance collaboration and contribution within the OWASP community.',
   twitterHandle: '@owasp',
-  defaultIcon: '/img/owasp_icon_white_background.png',
+  defaultIcon: 'https://nest.owasp.org/img/owasp_icon_white_background.png',
 }
 
 const MetadataManager: React.FC<MetadataManagerProps> = ({


### PR DESCRIPTION
<!-- Thanks for contributing to OWASP Nest!-->

<!-- Don't forget to link your PR to an existing issue if any.-->
Resolves #615 
hey ark , i thought /img/owasp_icon_white_background.png would be enough to get the image in meta tag but it looks like we need to provide the whole url to the image.
we can use github url of image or we can use our website public image whatever you prefer i have added our website origin ur.
if you'd like to have github link of the image we can do that too .

for this pr, i have fixed image url with the public image url of our website.
- [x] I have tested it .


![Screenshot from 2025-02-14 12-12-36](https://github.com/user-attachments/assets/8ffeee23-dad8-4f0d-83d8-c6e69f9a855c)
![image](https://github.com/user-attachments/assets/af83480b-af1a-441c-b995-e5b5b15154d2)


<!-- Describe the big picture of your changes.-->
Add the PR description here.

<!-- Thanks again for your contribution!-->
