### PR TITLE
fixed robot txt to allow scrapper facebook or twitter

### DIFF
--- a/cspell/custom-dict.txt
+++ b/cspell/custom-dict.txt
@@ -17,6 +17,7 @@ cva
 dismissable
 dsn
 env
+facebookexternalhit
 GBP
 geocoders
 geoloc
@@ -62,6 +63,7 @@ slackbot
 SLF
 Truncator
 tsc
+Twitterbot
 Whistleblower
 winsrdf
 wsgi

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,4 +1,10 @@
 User-agent: *
 Disallow:
 
+User-agent: facebookexternalhit
+Disallow:
+
+User-agent: Twitterbot
+Disallow:
+
 Sitemap: https://nest.owasp.org/sitemap.xml


### PR DESCRIPTION
<!-- Thanks for contributing to OWASP Nest!-->

<!-- Don't forget to link your PR to an existing issue if any.-->
Resolves #615 

<!-- Describe the big picture of your changes.-->
Add the PR description here.
- [x] improved robot.txt to allow crawler hits from facebook and the twitter
<!-- Thanks again for your contribution!-->
