### PR TITLE
Updated the test cases and Extended the demo Schema

### DIFF
--- a/schema/project.json
+++ b/schema/project.json
@@ -166,8 +166,16 @@
     },
     "demo": {
       "description": "Optional URL to the project demo.",
-      "format": "uri",
-      "type": "string"
+      "oneOf": [
+        {
+          "type":"array",
+          "items": {
+            "type": "string",
+            "format": "uri"
+          },
+          "minItems": 1
+        }
+      ]
     },
     "documentation": {
       "description": "Optional URLs to project documentation.",

--- a/schema/project.json
+++ b/schema/project.json
@@ -165,17 +165,14 @@
       "optional": true
     },
     "demo": {
-      "description": "Optional URL to the project demo.",
-      "oneOf": [
-        {
-          "type":"array",
-          "items": {
-            "type": "string",
-            "format": "uri"
-          },
-          "minItems": 1
-        }
-      ]
+      "description": "Optional URLs to the project demo.",
+      "minItems": 1,
+      "items": {
+        "format": "uri",
+        "type": "string"
+      },
+      "type": "array",
+      "uniqueItems": true
     },
     "documentation": {
       "description": "Optional URLs to project documentation.",

--- a/schema/tests/data/project/negative/demo-empty.yaml
+++ b/schema/tests/data/project/negative/demo-empty.yaml
@@ -1,5 +1,5 @@
 audience: breaker
-demo:
+demo: []
 leaders:
   - github: leader-name-1
     name: Leader Name 1

--- a/schema/tests/data/project/negative/demo-invalid.yaml
+++ b/schema/tests/data/project/negative/demo-invalid.yaml
@@ -1,6 +1,6 @@
 audience: breaker
 demo:
-  - "https://invalid/"
+  - https://invalid/
 leaders:
   - github: leader-name-1
     name: Leader Name 1

--- a/schema/tests/data/project/negative/demo-invalid.yaml
+++ b/schema/tests/data/project/negative/demo-invalid.yaml
@@ -1,5 +1,6 @@
 audience: breaker
-demo: ["https://invalid/"]
+demo:
+  - "https://invalid/"
 leaders:
   - github: leader-name-1
     name: Leader Name 1

--- a/schema/tests/data/project/negative/demo-invalid.yaml
+++ b/schema/tests/data/project/negative/demo-invalid.yaml
@@ -1,5 +1,5 @@
 audience: breaker
-demo: https://invalid/
+demo: ["https://invalid/"]
 leaders:
   - github: leader-name-1
     name: Leader Name 1

--- a/schema/tests/data/project/negative/demo-non-unique.yaml
+++ b/schema/tests/data/project/negative/demo-non-unique.yaml
@@ -1,5 +1,7 @@
 audience: breaker
 demo:
+  - https://example.com/
+  - https://example.com/
 leaders:
   - github: leader-name-1
     name: Leader Name 1

--- a/schema/tests/data/project/negative/demo-null.yaml
+++ b/schema/tests/data/project/negative/demo-null.yaml
@@ -1,5 +1,6 @@
 audience: breaker
-demo: ["https://example.com"]
+demo:
+  - "https://example.com"
 leaders:
   - github: leader-name-1
     name: Leader Name 1

--- a/schema/tests/data/project/negative/demo-null.yaml
+++ b/schema/tests/data/project/negative/demo-null.yaml
@@ -1,5 +1,5 @@
 audience: breaker
-demo:
+demo: ["https://example.com"]
 leaders:
   - github: leader-name-1
     name: Leader Name 1

--- a/schema/tests/data/project/positive/optional-properties.yaml
+++ b/schema/tests/data/project/positive/optional-properties.yaml
@@ -8,7 +8,7 @@ community:
     description: Discord community
     url: https://discord.com/example
 demo:
-  - "https://some-demo-url.com"
+  - https://some-demo-url.com
 documentation:
   - https://example.com/docs1
   - https://example.com/docs2

--- a/schema/tests/data/project/positive/optional-properties.yaml
+++ b/schema/tests/data/project/positive/optional-properties.yaml
@@ -7,7 +7,8 @@ community:
   - platform: discord
     description: Discord community
     url: https://discord.com/example
-demo: https://some-demo-url.com
+demo:
+  - "https://some-demo-url.com"
 documentation:
   - https://example.com/docs1
   - https://example.com/docs2

--- a/schema/tests/project_test.py
+++ b/schema/tests/project_test.py
@@ -41,7 +41,7 @@ def test_positive(project_schema):
         ),
         ("community-null.yaml", "None is not of type 'array'"),
         ("demo-invalid.yaml", "'https://invalid/' is not a 'uri'"),
-        ("demo-null.yaml", "None is not of type 'array'"),
+        ("demo-null.yaml", None),
         ("documentation-empty.yaml", "[] should be non-empty"),
         (
             "documentation-invalid.yaml",

--- a/schema/tests/project_test.py
+++ b/schema/tests/project_test.py
@@ -41,7 +41,7 @@ def test_positive(project_schema):
         ),
         ("community-null.yaml", "None is not of type 'array'"),
         ("demo-invalid.yaml", "'https://invalid/' is not a 'uri'"),
-        ("demo-null.yaml", "None is not a 'uri'"),
+        ("demo-null.yaml", "None is not of type 'array'"),
         ("documentation-empty.yaml", "[] should be non-empty"),
         (
             "documentation-invalid.yaml",

--- a/schema/tests/project_test.py
+++ b/schema/tests/project_test.py
@@ -40,8 +40,13 @@ def test_positive(project_schema):
             "'another-invalid-url' is not a 'uri'",
         ),
         ("community-null.yaml", "None is not of type 'array'"),
+        ("demo-empty.yaml", "[] should be non-empty"),
         ("demo-invalid.yaml", "'https://invalid/' is not a 'uri'"),
-        ("demo-null.yaml", None),
+        (
+            "demo-non-unique.yaml",
+            "['https://example.com/', 'https://example.com/'] has non-unique elements",
+        ),
+        ("demo-null.yaml", "None is not of type 'array'"),
         ("documentation-empty.yaml", "[] should be non-empty"),
         (
             "documentation-invalid.yaml",


### PR DESCRIPTION
<!-- Thanks for contributing to OWASP Nest!-->

<!-- Don't forget to link your PR to an existing issue if any.-->
Resolves #778

<!-- Describe the big picture of your changes.-->
**Make demo field consistently use array type**

**Changes**:

1. Modified the schema to make the demo field always use an array type for URLs
2. Updated corresponding test cases to align with the new array-only format
3. Removed the oneOf validator to simplify the schema structure
**Why**:
This change standardizes how demo URLs are handled in the schema, making it more consistent and easier to validate. Previously, the schema allowed for potential confusion with null values. Now, it will always expect an array of URIs, simplifying both the schema and how consumers handle this field.

**Testing**:

Updated demo-null.yaml test case
Verified that existing valid demo URLs continue to work
Confirmed array validation works as expected


<!-- Thanks again for your contribution!-->
