### PR TITLE
Fixed sort button not triggering dropdown

### DIFF
--- a/frontend/src/components/SortBy.tsx
+++ b/frontend/src/components/SortBy.tsx
@@ -38,10 +38,10 @@ const SortBy = ({
           }}
         >
           <div className="flex items-center gap-2">
-            <SelectLabel className="font-small text-sm text-gray-600 dark:text-gray-300">
-              Sort By:
-            </SelectLabel>
             <SelectTrigger className="width-auto text-sm">
+              <SelectLabel className="font-small text-sm text-gray-600 hover:cursor-pointer dark:text-gray-300">
+                Sort By:
+              </SelectLabel>
               <SelectValueText
                 paddingRight={'1.4rem'}
                 width={'auto'}


### PR DESCRIPTION
Fixes Issue #910 
Fixed the "Sort By" text not triggering dropdown options on click.
