### PR TITLE
Rank OWASP Nest community users using total contributions.

### DIFF
--- a/backend/apps/github/index/user.py
+++ b/backend/apps/github/index/user.py
@@ -16,6 +16,7 @@ class UserIndex(IndexBase):
         "idx_bio",
         "idx_company",
         "idx_contributions",
+        "idx_contributions_count",
         "idx_created_at",
         "idx_email",
         "idx_followers_count",
@@ -40,6 +41,7 @@ class UserIndex(IndexBase):
         "attributeForDistinct": "idx_login",
         "minProximity": 4,
         "customRanking": [
+            "desc(idx_contributions_count)",
             "desc(idx_created_at)",
             "desc(idx_followers_count)",
         ],

--- a/backend/apps/github/models/mixins/user.py
+++ b/backend/apps/github/models/mixins/user.py
@@ -108,6 +108,14 @@ class UserIndexMixin:
         ]
 
     @property
+    def idx_contributions_count(self):
+        """Return contributions count for indexing."""
+        contributions_counts = [
+            rc.contributions_count for rc in RepositoryContributor.objects.filter(user=self)
+        ]
+        return sum(contributions_counts)
+
+    @property
     def idx_issues(self):
         """Return issues for indexing."""
         return [


### PR DESCRIPTION
<!-- Thanks for contributing to OWASP Nest!-->

<!-- Don't forget to link your PR to an existing issue if any.-->
Resolves #973

<!-- Describe the big picture of your changes.-->
- Added a property `idx_contributions_count` to the `UserIndexMixin` that returns the total number of contributions made by the contributor to OWASP.
- Included this property in the `UserIndex`.
- Placed the property at the top of the `customRanking`.

<!-- Thanks again for your contribution!-->
