### PR TITLE
Fixed issue where tooltips were only appearing on the first card.

### DIFF
--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -49,7 +49,7 @@ const Card = ({
           {/* Display project level badge (if available) */}
           {level && (
             <Tooltip
-              id="level-tooltip"
+              id={`level-tooltip-${title}`}
               content={`${level.level} project`}
               openDelay={100}
               closeDelay={100}


### PR DESCRIPTION
<!-- Thanks for contributing to OWASP Nest!-->

<!-- Don't forget to link your PR to an existing issue if any.-->
Resolves #997 

<!-- Describe the big picture of your changes.-->
The id of the tooltip should be unique to identity each of them seperately
<!-- Thanks again for your contribution!-->
