### PR TITLE
Fix tooltip conflicts for duplicate contributors

### DIFF
--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -115,6 +115,7 @@ const Card = ({
             <ContributorAvatar
               key={contributor.login || `contributor-${index}`}
               contributor={contributor}
+              uniqueKey={index.toString()}
             />
           ))}
         </div>

--- a/frontend/src/components/ContributorAvatar.tsx
+++ b/frontend/src/components/ContributorAvatar.tsx
@@ -5,7 +5,7 @@ import { Tooltip } from 'components/ui/tooltip'
 
 type ContributorProps = {
   contributor: TopContributorsTypeAlgolia | TopContributorsTypeGraphql
-  uniqueKey: string 
+  uniqueKey: string
 }
 
 const isAlgoliaContributor = (

--- a/frontend/src/components/ContributorAvatar.tsx
+++ b/frontend/src/components/ContributorAvatar.tsx
@@ -5,6 +5,7 @@ import { Tooltip } from 'components/ui/tooltip'
 
 type ContributorProps = {
   contributor: TopContributorsTypeAlgolia | TopContributorsTypeGraphql
+  uniqueKey: string 
 }
 
 const isAlgoliaContributor = (
@@ -18,7 +19,7 @@ const isAlgoliaContributor = (
   )
 }
 
-const ContributorAvatar = memo(({ contributor }: ContributorProps) => {
+const ContributorAvatar = memo(({ contributor, uniqueKey }: ContributorProps) => {
   const isAlgolia = isAlgoliaContributor(contributor)
 
   const avatarUrl = isAlgolia
@@ -39,7 +40,7 @@ const ContributorAvatar = memo(({ contributor }: ContributorProps) => {
 
   return (
     <Tooltip
-      id={`avatar-tooltip-${login}`}
+      id={`avatar-tooltip-${login}-${uniqueKey}`}
       content={`${contributionsCount} contributions${repositoryInfo} by ${displayName}`}
       openDelay={100}
       closeDelay={100}


### PR DESCRIPTION
<!-- Thanks for contributing to OWASP Nest!-->

<!-- Don't forget to link your PR to an existing issue if any.-->
Resolves #1058

<!-- Describe the big picture of your changes.-->
This PR resolves an issue where tooltips would behave incorrectly if the same contributor appeared in multiple cards. The fix appends a unique identifier to the tooltip id, ensuring each tooltip instance is distinct.

1. Added a uniqueKey prop to ContributorAvatar.
2. Modified the tooltip id to include uniqueKey.
3. Updated parent component usage to pass a unique identifier.


https://github.com/user-attachments/assets/fb1ff195-e5b5-44c7-8d19-3194e2fce785


<!-- Thanks again for your contribution!-->
