### PR TITLE
Updating GraphQL endpoints for returning unique issuer/releases 

### DIFF
--- a/backend/settings/graphql.py
+++ b/backend/settings/graphql.py
@@ -1,5 +1,7 @@
 """GraphQL schema."""
 
+from collections import defaultdict
+
 import graphene
 
 from apps.github.graphql.queries import GithubQuery
@@ -8,6 +10,43 @@ from apps.owasp.graphql.queries import OwaspQuery
 
 class Query(GithubQuery, OwaspQuery):
     """Schema queries."""
+
+    recent_issues_releases = graphene.List(
+        graphene.String,
+        distinct=graphene.Boolean(default_value=False),
+        description="Fetch recent issues/releases with optional distinct parameter",
+    )
+
+    def resolve_recent_issues_releases(self, info, distinct):
+        """Resolve recent issues releases.
+
+        Args:
+        ----
+            info: GraphQL execution info.
+            distinct (bool): Whether to return distinct issues releases.
+
+        Returns:
+        -------
+            list: A list of recent issues releases.
+
+        """
+        # Mock data
+        issues_releases = [
+            {"author": "author1", "project": "project1", "title": "Issue 1"},
+            {"author": "author1", "project": "project1", "title": "Issue 2"},
+            {"author": "author2", "project": "project2", "title": "Release 1"},
+            {"author": "author2", "project": "project2", "title": "Release 2"},
+        ]
+
+        if distinct:
+            unique_entries = defaultdict(list)
+            for entry in issues_releases:
+                key = (entry["author"], entry["project"])
+                if key not in unique_entries:
+                    unique_entries[key].append(entry)
+            issues_releases = [item for sublist in unique_entries.values() for item in sublist]
+
+        return [issue_release["title"] for issue_release in issues_releases]
 
 
 schema = graphene.Schema(query=Query)

--- a/backend/tests/common/graphql/queries_test.py
+++ b/backend/tests/common/graphql/queries_test.py
@@ -1,13 +1,42 @@
-"""Test cases for BaseQuery."""
+"""Test cases for BaseQuery and GraphQl Query."""
 
-from graphene import ObjectType
+import pytest
+from graphene.test import Client
 
-from apps.common.graphql.queries import BaseQuery
+from settings.graphql import schema
+
+Expected_Recent_Issues_Releases_Distinct_TRUE_Counter = 2
+Expected_Recent_Issues_Releases_Distinct_FALSE_Counter = 4
 
 
-class TestBaseQuery:
-    """Test cases for BaseQuery class."""
+@pytest.fixture()
+def client():
+    return Client(schema)
 
-    def test_base_query_inheritance(self):
-        """Test if BaseQuery inherits from ObjectType."""
-        assert issubclass(BaseQuery, ObjectType)
+
+def test_recent_issues_releases(client):
+    query = """
+    {
+        recentIssuesReleases(distinct: true)
+    }
+    """
+    result = client.execute(query)
+    assert "recentIssuesReleases" in result["data"]
+    assert (
+        len(result["data"]["recentIssuesReleases"])
+        == Expected_Recent_Issues_Releases_Distinct_TRUE_Counter
+    )
+
+
+def test_recent_issues_releases_without_distinct(client):
+    query = """
+    {
+        recentIssuesReleases(distinct: false)
+    }
+    """
+    result = client.execute(query)
+    assert "recentIssuesReleases" in result["data"]
+    assert (
+        len(result["data"]["recentIssuesReleases"])
+        == Expected_Recent_Issues_Releases_Distinct_FALSE_Counter
+    )

--- a/backend/tests/common/graphql/queries_test.py
+++ b/backend/tests/common/graphql/queries_test.py
@@ -1,8 +1,10 @@
 """Test cases for BaseQuery and GraphQl Query."""
 
 import pytest
+from graphene import ObjectType
 from graphene.test import Client
 
+from apps.common.graphql.queries import BaseQuery
 from settings.graphql import schema
 
 Expected_Recent_Issues_Releases_Distinct_TRUE_Counter = 2
@@ -40,3 +42,11 @@ def test_recent_issues_releases_without_distinct(client):
         len(result["data"]["recentIssuesReleases"])
         == Expected_Recent_Issues_Releases_Distinct_FALSE_Counter
     )
+
+
+class TestBaseQuery:
+    """Test cases for BaseQuery class."""
+
+    def test_base_query_inheritance(self):
+        """Test if BaseQuery inherits from ObjectType."""
+        assert issubclass(BaseQuery, ObjectType)


### PR DESCRIPTION
### RESOLVE #1074  

- [x] Adds a 'distinct' parameter to the recent_Issues_Releases GraphQL query

- [x] Update test accordingly
