### PR TITLE
added created badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ![Forks](https://img.shields.io/github/forks/owasp/nest?style=for-the-badge&label=Forks) ![Stars](https://img.shields.io/github/stars/owasp/nest?style=for-the-badge&label=Stars)
 
-[![CREATED](https://img.shields.io/badge/CREATED-AUG,%202024-blue?style=for-the-badge)](https://nest.owasp.org/)
+[![CREATED](https://img.shields.io/badge/created-aug,%202024-blue?style=for-the-badge)](https://github.com/OWASP/Nest/commit/2a213c2efcfc2f8889c2f1d330da0d2e6f649fc1)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
 
 ![Forks](https://img.shields.io/github/forks/owasp/nest?style=for-the-badge&label=Forks) ![Stars](https://img.shields.io/github/stars/owasp/nest?style=for-the-badge&label=Stars)
 
+[![CREATED](https://img.shields.io/badge/CREATED-AUG,%202024-blue?style=for-the-badge)](https://nest.owasp.org/)
+
 </div>
 
 **OWASP Nest** is a comprehensive platform designed to enhance collaboration and contribution within the OWASP community. The application serves as a central hub for exploring OWASP projects and ways to contribute to them, empowering contributors to find opportunities that align with their interests and expertise.


### PR DESCRIPTION
This PR adds a new badge labeled **"CREATED: AUG, 2024"** at the bottom of the existing badge section. This helps in clearly indicating when the project or repository was created.

Changes Introduced : 
1. Added a new badge with the text "CREATED: AUG, 2024"
2. Positioned it at the bottom of all existing badges
3. Ensured styling remains consistent with the other badges
![image](https://github.com/user-attachments/assets/4efe249e-4e35-4f33-8fd6-1ba5b91337be)

Related Issue

Resolves #1187