### PR TITLE
fixed the modal window where the close button was focused earlier

### DIFF
--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -41,7 +41,7 @@ const Modal: React.FC<ModalProps> = ({
       >
         <DialogCloseTrigger
           asChild={false}
-          className="absolute right-4 top-4 text-gray-400 hover:text-gray-600 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 dark:text-gray-500 dark:hover:text-gray-400 dark:focus:ring-gray-600"
+          className="absolute right-4 top-4 text-gray-400 hover:text-gray-600 hover:outline-none hover:ring-2 hover:ring-gray-500 hover:ring-offset-2 dark:text-gray-500 dark:hover:text-gray-400 dark:hover:ring-gray-600"
           aria-label="Close modal"
         >
           <FontAwesomeIcon icon={faX} size="xs" onClick={onClose} />


### PR DESCRIPTION
<!-- Thanks for contributing to OWASP Nest!-->

<!-- Don't forget to link your PR to an existing issue if any.-->
Resolves #1193

<!-- Describe the big picture of your changes.-->
- Previously, when opening the modal, the close button was automatically focused. After this fix, it will only be highlighted when hovered. Here is a recording clip for reference.
- 

https://github.com/user-attachments/assets/bf35949c-d8cc-49e4-be34-2ade00046d71



<!-- Thanks again for your contribution!-->
