### PR TITLE
Changed text selection colour for dark mode

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,6 +2,12 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer utilities {
+  .dark ::selection {
+    @apply bg-blue-500 text-white;
+  }
+}
+
 @layer base {
   :root {
     --background: #f4f6fc;


### PR DESCRIPTION
fixes: #1221 

current colour :

<img width="1155" alt="Screenshot 2025-03-31 at 12 56 20 AM" src="https://github.com/user-attachments/assets/bcf3f4e7-8011-4e78-8d5c-709a2730c335" />




After changing:

<img width="1155" alt="Screenshot 2025-03-31 at 12 56 27 AM" src="https://github.com/user-attachments/assets/61ac2280-258a-4cbf-9d34-969e2a0eaa78" />


