### PR TITLE
Added a link to the repository name that navigates to /repositories/

### DIFF
--- a/frontend/src/components/RecentReleases.tsx
+++ b/frontend/src/components/RecentReleases.tsx
@@ -1,6 +1,6 @@
 import { faCalendar, faFileCode } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import Image from "next/image"
+import Image from 'next/image'
 import Link from 'next/link'
 import React from 'react'
 import { ProjectReleaseType } from 'types/project'

--- a/frontend/src/components/RecentReleases.tsx
+++ b/frontend/src/components/RecentReleases.tsx
@@ -1,6 +1,6 @@
 import { faCalendar, faFileCode } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import Image from 'next/image'
+import Image from "next/image"
 import Link from 'next/link'
 import React from 'react'
 import { ProjectReleaseType } from 'types/project'
@@ -59,7 +59,12 @@ const RecentReleases: React.FC<RecentReleasesProps> = ({
                     <FontAwesomeIcon icon={faCalendar} className="mr-2 h-4 w-4" />
                     <span>{formatDate(item.publishedAt)}</span>
                     <FontAwesomeIcon icon={faFileCode} className="ml-4 mr-2 h-4 w-4" />
-                    <span>{item.repositoryName}</span>
+                    <Link
+                        className="text-blue-400 hover:underline"
+                        href={`/repositories/${item?.repositoryName.toLowerCase() || ''}`}
+                    >
+                      <span>{item.repositoryName}</span>
+                    </Link>
                   </div>
                 </div>
               </div>

--- a/frontend/src/components/RecentReleases.tsx
+++ b/frontend/src/components/RecentReleases.tsx
@@ -60,7 +60,7 @@ const RecentReleases: React.FC<RecentReleasesProps> = ({
                     <span>{formatDate(item.publishedAt)}</span>
                     <FontAwesomeIcon icon={faFileCode} className="ml-4 mr-2 h-4 w-4" />
                     <Link
-                      className="text-blue-400 hover:underline"
+                      className="text-gray-600 hover:underline dark:text-gray-400"
                       href={`/repositories/${item?.repositoryName ? item.repositoryName.toLowerCase() : ''}`}
                     >
                       <span>{item.repositoryName}</span>

--- a/frontend/src/components/RecentReleases.tsx
+++ b/frontend/src/components/RecentReleases.tsx
@@ -60,8 +60,8 @@ const RecentReleases: React.FC<RecentReleasesProps> = ({
                     <span>{formatDate(item.publishedAt)}</span>
                     <FontAwesomeIcon icon={faFileCode} className="ml-4 mr-2 h-4 w-4" />
                     <Link
-                        className="text-blue-400 hover:underline"
-                        href={`/repositories/${item?.repositoryName.toLowerCase() || ''}`}
+                      className="text-blue-400 hover:underline"
+                      href={`/repositories/${item?.repositoryName ? item.repositoryName.toLowerCase() : ''}`}
                     >
                       <span>{item.repositoryName}</span>
                     </Link>


### PR DESCRIPTION
<!-- Thanks for contributing to OWASP Nest!-->

Added clickable repository links in the Recent Releases block on the main page.
Links navigate to /repositories/[repositoryName], with repository names converted to lowercase for consistency.


<!-- Thanks again for your contribution!-->
