### PR TITLE
Improved AnchorTitle component used slug to get href from title

### DIFF
--- a/cspell/custom-dict.txt
+++ b/cspell/custom-dict.txt
@@ -4,10 +4,12 @@ Aissue
 Aupdated
 CCSP
 CISSP
+Cañón
 DRF
 GBP
 GSOC
 GTM
+Héllo
 Kateryna
 NETTACKER
 Nadu
@@ -23,6 +25,7 @@ Truncator
 Twitterbot
 WSL
 Whistleblower
+Wörld
 a2eeef
 algoliasearch
 ansa
@@ -105,3 +108,4 @@ xdg
 xdist
 xsser
 zsc
+éàëîôû

--- a/frontend/__tests__/unit/utils/slugify.test.ts
+++ b/frontend/__tests__/unit/utils/slugify.test.ts
@@ -1,55 +1,21 @@
 import slugify from 'utils/slugify'
 
 describe('slugify', () => {
-  test('should convert basic English text to a slug', () => {
-    expect(slugify('Hello World')).toBe('hello-world')
-  })
-
-  test('should handle extra spaces', () => {
-    expect(slugify('   Hello   World   ')).toBe('hello-world')
-  })
-
-  test('should replace special characters with hyphens', () => {
-    expect(slugify('Hello @ World #2025!')).toBe('hello-world-2025')
-  })
-
-  test('should handle multiple special characters together', () => {
-    expect(slugify('Hello---World___Test!!!')).toBe('hello-world-test')
-  })
-
-  test('should remove accents and diacritics', () => {
-    expect(slugify('Héllo Wörld Cañón')).toBe('hello-world-canon')
-  })
-
-  test('should trim leading and trailing hyphens', () => {
-    expect(slugify('---Hello World---')).toBe('hello-world')
-  })
-
-  test('should handle numbers correctly', () => {
-    expect(slugify('Project 2025 Version 2.0')).toBe('project-2025-version-2-0')
-  })
-
-  test('should collapse multiple spaces and symbols into one hyphen', () => {
-    expect(slugify('one    two    --    three')).toBe('one-two-three')
-  })
-
-  test('should return an empty string when given only symbols', () => {
-    expect(slugify('*** $$$ ###')).toBe('')
-  })
-
-  test('should return an empty string when given an empty string', () => {
-    expect(slugify('')).toBe('')
-  })
-
-  test('should lowercase all letters', () => {
-    expect(slugify('This Should BE Lowercase')).toBe('this-should-be-lowercase')
-  })
-
-  test('should handle strings with only accented characters', () => {
-    expect(slugify('éàëîôû')).toBe('eaeiou')
-  })
-
-  test('should not have multiple consecutive hyphens', () => {
-    expect(slugify('Hello     ---   World')).toBe('hello-world')
+  test.each([
+    ['accents and diacritics', 'Héllo Wörld Cañón', 'hello-world-canon'],
+    ['basic English text', 'Hello World', 'hello-world'],
+    ['collapse multiple spaces and symbols', 'one    two    --    three', 'one-two-three'],
+    ['empty string', '', ''],
+    ['extra spaces', '   Hello   World   ', 'hello-world'],
+    ['leading and trailing hyphens', '---Hello World---', 'hello-world'],
+    ['lowercase all letters', 'This Should BE Lowercase', 'this-should-be-lowercase'],
+    ['multiple special characters together', 'Hello---World___Test!!!', 'hello-world-test'],
+    ['no multiple consecutive hyphens', 'Hello     ---   World', 'hello-world'],
+    ['numbers correctly', 'Project 2025 Version 2.0', 'project-2025-version-2-0'],
+    ['only accented characters', 'éàëîôû', 'eaeiou'],
+    ['only symbols', '*** $$$ ###', ''],
+    ['special characters', 'Hello @ World #2025!', 'hello-world-2025'],
+  ])('should handle %s', (_description, input, expected) => {
+    expect(slugify(input)).toBe(expected)
   })
 })

--- a/frontend/__tests__/unit/utils/slugify.test.ts
+++ b/frontend/__tests__/unit/utils/slugify.test.ts
@@ -1,0 +1,55 @@
+import slugify from 'utils/slugify'
+
+describe('slugify', () => {
+  test('should convert basic English text to a slug', () => {
+    expect(slugify('Hello World')).toBe('hello-world')
+  })
+
+  test('should handle extra spaces', () => {
+    expect(slugify('   Hello   World   ')).toBe('hello-world')
+  })
+
+  test('should replace special characters with hyphens', () => {
+    expect(slugify('Hello @ World #2025!')).toBe('hello-world-2025')
+  })
+
+  test('should handle multiple special characters together', () => {
+    expect(slugify('Hello---World___Test!!!')).toBe('hello-world-test')
+  })
+
+  test('should remove accents and diacritics', () => {
+    expect(slugify('Héllo Wörld Cañón')).toBe('hello-world-canon')
+  })
+
+  test('should trim leading and trailing hyphens', () => {
+    expect(slugify('---Hello World---')).toBe('hello-world')
+  })
+
+  test('should handle numbers correctly', () => {
+    expect(slugify('Project 2025 Version 2.0')).toBe('project-2025-version-2-0')
+  })
+
+  test('should collapse multiple spaces and symbols into one hyphen', () => {
+    expect(slugify('one    two    --    three')).toBe('one-two-three')
+  })
+
+  test('should return an empty string when given only symbols', () => {
+    expect(slugify('*** $$$ ###')).toBe('')
+  })
+
+  test('should return an empty string when given an empty string', () => {
+    expect(slugify('')).toBe('')
+  })
+
+  test('should lowercase all letters', () => {
+    expect(slugify('This Should BE Lowercase')).toBe('this-should-be-lowercase')
+  })
+
+  test('should handle strings with only accented characters', () => {
+    expect(slugify('éàëîôû')).toBe('eaeiou')
+  })
+
+  test('should not have multiple consecutive hyphens', () => {
+    expect(slugify('Hello     ---   World')).toBe('hello-world')
+  })
+})

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -152,10 +152,7 @@ export default function Home() {
           icon={faCalendarAlt}
           title={
             <div className="flex items-center gap-2">
-              <AnchorTitle
-                title="Upcoming Events"
-                className="flex items-center leading-none"
-              />
+              <AnchorTitle title="Upcoming Events" className="flex items-center leading-none" />
             </div>
           }
           className="overflow-hidden"
@@ -201,10 +198,7 @@ export default function Home() {
             icon={faMapMarkerAlt}
             title={
               <div className="flex items-center gap-2">
-                <AnchorTitle
-                  title="New Chapters"
-                  className="flex items-center leading-none"
-                />
+                <AnchorTitle title="New Chapters" className="flex items-center leading-none" />
               </div>
             }
             className="overflow-hidden"
@@ -246,10 +240,7 @@ export default function Home() {
             icon={faFolder}
             title={
               <div className="flex items-center gap-2">
-                <AnchorTitle
-                  title="New Projects"
-                  className="flex items-center leading-none"
-                />
+                <AnchorTitle title="New Projects" className="flex items-center leading-none" />
               </div>
             }
             className="overflow-hidden"
@@ -293,10 +284,7 @@ export default function Home() {
               className="h-5 w-5"
               style={{ verticalAlign: 'middle' }}
             />
-            <AnchorTitle
-              title="Chapters Worldwide"
-              className="flex items-center leading-none"
-            />
+            <AnchorTitle title="Chapters Worldwide" className="flex items-center leading-none" />
           </div>
           <ChapterMapWrapper
             geoLocData={geoLocData}
@@ -325,10 +313,7 @@ export default function Home() {
           icon={faNewspaper}
           title={
             <div className="flex items-center gap-2">
-              <AnchorTitle
-                title="News & Opinions"
-                className="flex items-center leading-none"
-              />
+              <AnchorTitle title="News & Opinions" className="flex items-center leading-none" />
             </div>
           }
           className="overflow-hidden"

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -153,7 +153,6 @@ export default function Home() {
           title={
             <div className="flex items-center gap-2">
               <AnchorTitle
-                href="#upcoming-events"
                 title="Upcoming Events"
                 className="flex items-center leading-none"
               />
@@ -203,7 +202,6 @@ export default function Home() {
             title={
               <div className="flex items-center gap-2">
                 <AnchorTitle
-                  href="#new-chapters"
                   title="New Chapters"
                   className="flex items-center leading-none"
                 />
@@ -249,7 +247,6 @@ export default function Home() {
             title={
               <div className="flex items-center gap-2">
                 <AnchorTitle
-                  href="#new-projects"
                   title="New Projects"
                   className="flex items-center leading-none"
                 />
@@ -297,7 +294,6 @@ export default function Home() {
               style={{ verticalAlign: 'middle' }}
             />
             <AnchorTitle
-              href="#chapters-worldwide"
               title="Chapters Worldwide"
               className="flex items-center leading-none"
             />
@@ -330,7 +326,6 @@ export default function Home() {
           title={
             <div className="flex items-center gap-2">
               <AnchorTitle
-                href="#news-&-opinions"
                 title="News & Opinions"
                 className="flex items-center leading-none"
               />

--- a/frontend/src/components/AnchorTitle.tsx
+++ b/frontend/src/components/AnchorTitle.tsx
@@ -2,14 +2,21 @@ import { faLink } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import React, { useEffect, useCallback } from 'react'
 
+const slugify = (text: string) => 
+  text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-') 
+    .replace(/^-+|-+$/g, '') 
+    
 interface AnchorTitleProps {
-  href: string
   title: string
   className?: string
 }
 
-const AnchorTitle: React.FC<AnchorTitleProps> = ({ href, title }) => {
-  const id = href.replace('#', '') // TODO(arkid15r): refactor get href from title automatically.
+const AnchorTitle: React.FC<AnchorTitleProps> = ({title }) => {
+// TODO(arkid15r): refactor get href from title automatically.
+ const id = slugify(title) 
+  const href = `#${id}`
 
   const scrollToElement = useCallback(() => {
     const element = document.getElementById(id)

--- a/frontend/src/components/AnchorTitle.tsx
+++ b/frontend/src/components/AnchorTitle.tsx
@@ -1,21 +1,15 @@
 import { faLink } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import React, { useEffect, useCallback } from 'react'
+import slugify from 'utils/slugify'
 
-const slugify = (text: string) => 
-  text
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-') 
-    .replace(/^-+|-+$/g, '') 
-    
 interface AnchorTitleProps {
-  title: string
   className?: string
+  title: string
 }
 
-const AnchorTitle: React.FC<AnchorTitleProps> = ({title }) => {
-// TODO(arkid15r): refactor get href from title automatically.
- const id = slugify(title) 
+const AnchorTitle: React.FC<AnchorTitleProps> = ({ title }) => {
+  const id = slugify(title)
   const href = `#${id}`
 
   const scrollToElement = useCallback(() => {

--- a/frontend/src/components/CardDetailsPage.tsx
+++ b/frontend/src/components/CardDetailsPage.tsx
@@ -56,7 +56,7 @@ const DetailsCard = ({
         {summary && (
           <SecondaryCard
             icon={faCircleInfo}
-            title={<AnchorTitle href="#summary" title="Summary" />}
+            title={<AnchorTitle title="Summary" />}
           >
             <p>{summary}</p>
           </SecondaryCard>
@@ -65,7 +65,7 @@ const DetailsCard = ({
         {userSummary && (
           <SecondaryCard
             icon={faCircleInfo}
-            title={<AnchorTitle href="#summary" title="Summary" />}
+            title={<AnchorTitle title="Summary" />}
           >
             {userSummary}
           </SecondaryCard>
@@ -74,7 +74,7 @@ const DetailsCard = ({
         {heatmap && (
           <SecondaryCard
             icon={faSquarePollVertical}
-            title={<AnchorTitle href="#contribution-heatmap" title="Contribution Heatmap" />}
+            title={<AnchorTitle title="Contribution Heatmap" />}
           >
             {heatmap}
           </SecondaryCard>
@@ -82,7 +82,7 @@ const DetailsCard = ({
         <div className="grid grid-cols-1 gap-6 md:grid-cols-7">
           <SecondaryCard
             icon={faRectangleList}
-            title={<AnchorTitle href={`#${type}-details`} title={`${capitalize(type)} Details`} />}
+            title={<AnchorTitle title={`${capitalize(type)} Details`} />}
             className={`${type !== 'chapter' ? 'md:col-span-5' : 'md:col-span-3'} gap-2`}
           >
             {details?.map((detail) =>
@@ -108,7 +108,7 @@ const DetailsCard = ({
             type === 'organization') && (
             <SecondaryCard
               icon={faChartPie}
-              title={<AnchorTitle href="#statistics" title="Statistics" />}
+              title={<AnchorTitle title="Statistics" />}
               className="md:col-span-2"
             >
               {stats.map((stat, index) => (
@@ -148,14 +148,14 @@ const DetailsCard = ({
               <ToggleableList
                 items={languages}
                 icon={faCode}
-                label={<AnchorTitle href="#languages" title="Languages" />}
+                label={<AnchorTitle title="Languages" />}
               />
             )}
             {topics.length !== 0 && (
               <ToggleableList
                 items={topics}
                 icon={faTags}
-                label={<AnchorTitle href="#topics" title="Topics" />}
+                label={<AnchorTitle title="Topics" />}
               />
             )}
           </div>
@@ -196,7 +196,7 @@ const DetailsCard = ({
           repositories.length > 0 && (
             <SecondaryCard
               icon={faFolderOpen}
-              title={<AnchorTitle href="#repositories" title="Repositories" />}
+              title={<AnchorTitle title="Repositories" />}
               className="mt-6"
             >
               <RepositoriesCard repositories={repositories} />

--- a/frontend/src/components/CardDetailsPage.tsx
+++ b/frontend/src/components/CardDetailsPage.tsx
@@ -54,19 +54,13 @@ const DetailsCard = ({
           <span className="ml-2 rounded bg-red-200 px-2 py-1 text-sm text-red-800">Inactive</span>
         )}
         {summary && (
-          <SecondaryCard
-            icon={faCircleInfo}
-            title={<AnchorTitle title="Summary" />}
-          >
+          <SecondaryCard icon={faCircleInfo} title={<AnchorTitle title="Summary" />}>
             <p>{summary}</p>
           </SecondaryCard>
         )}
 
         {userSummary && (
-          <SecondaryCard
-            icon={faCircleInfo}
-            title={<AnchorTitle title="Summary" />}
-          >
+          <SecondaryCard icon={faCircleInfo} title={<AnchorTitle title="Summary" />}>
             {userSummary}
           </SecondaryCard>
         )}
@@ -152,11 +146,7 @@ const DetailsCard = ({
               />
             )}
             {topics.length !== 0 && (
-              <ToggleableList
-                items={topics}
-                icon={faTags}
-                label={<AnchorTitle title="Topics" />}
-              />
+              <ToggleableList items={topics} icon={faTags} label={<AnchorTitle title="Topics" />} />
             )}
           </div>
         )}

--- a/frontend/src/components/RecentIssues.tsx
+++ b/frontend/src/components/RecentIssues.tsx
@@ -21,7 +21,6 @@ const RecentIssues: React.FC<RecentIssuesProps> = ({ data, showAvatar = true }) 
       title={
         <div className="flex items-center gap-2">
           <AnchorTitle
-            href="#recent-issues"
             title="Recent Issues"
             className="flex items-center leading-none"
           />

--- a/frontend/src/components/RecentIssues.tsx
+++ b/frontend/src/components/RecentIssues.tsx
@@ -20,10 +20,7 @@ const RecentIssues: React.FC<RecentIssuesProps> = ({ data, showAvatar = true }) 
     <ItemCardList
       title={
         <div className="flex items-center gap-2">
-          <AnchorTitle
-            title="Recent Issues"
-            className="flex items-center leading-none"
-          />
+          <AnchorTitle title="Recent Issues" className="flex items-center leading-none" />
         </div>
       }
       data={data}

--- a/frontend/src/components/RecentPullRequests.tsx
+++ b/frontend/src/components/RecentPullRequests.tsx
@@ -22,7 +22,6 @@ const RecentPullRequests: React.FC<RecentPullRequestsProps> = ({ data, showAvata
       title={
         <div className="flex items-center gap-2">
           <AnchorTitle
-            href="#recent-pull-requests"
             title="Recent Pull Requests"
             className="flex items-center leading-none"
           />

--- a/frontend/src/components/RecentPullRequests.tsx
+++ b/frontend/src/components/RecentPullRequests.tsx
@@ -21,10 +21,7 @@ const RecentPullRequests: React.FC<RecentPullRequestsProps> = ({ data, showAvata
     <ItemCardList
       title={
         <div className="flex items-center gap-2">
-          <AnchorTitle
-            title="Recent Pull Requests"
-            className="flex items-center leading-none"
-          />
+          <AnchorTitle title="Recent Pull Requests" className="flex items-center leading-none" />
         </div>
       }
       data={data}

--- a/frontend/src/components/RecentReleases.tsx
+++ b/frontend/src/components/RecentReleases.tsx
@@ -30,7 +30,6 @@ const RecentReleases: React.FC<RecentReleasesProps> = ({
       title={
         <div className="flex items-center gap-2">
           <AnchorTitle
-            href="#recent-releases"
             title="Recent Releases"
             className="flex items-center leading-none"
           />

--- a/frontend/src/components/RecentReleases.tsx
+++ b/frontend/src/components/RecentReleases.tsx
@@ -29,10 +29,7 @@ const RecentReleases: React.FC<RecentReleasesProps> = ({
       icon={faTag}
       title={
         <div className="flex items-center gap-2">
-          <AnchorTitle
-            title="Recent Releases"
-            className="flex items-center leading-none"
-          />
+          <AnchorTitle title="Recent Releases" className="flex items-center leading-none" />
         </div>
       }
     >

--- a/frontend/src/components/TopContributors.tsx
+++ b/frontend/src/components/TopContributors.tsx
@@ -43,7 +43,7 @@ const TopContributors = ({
       icon={icon}
       title={
         <div className="flex items-center gap-2">
-          <AnchorTitle href="#top-contributors" title={label} className="flex items-center" />
+          <AnchorTitle title={label} className="flex items-center" />
         </div>
       }
     >

--- a/frontend/src/utils/slugify.ts
+++ b/frontend/src/utils/slugify.ts
@@ -1,0 +1,8 @@
+export default function slugify(text: string): string {
+  return text
+    .normalize('NFKD') // Normalize accented characters
+    .replace(/[\u0300-\u036F]/g, '') // Remove diacritics
+    .replace(/[^a-zA-Z0-9]+/g, '-') // Only allow letters and numbers, replace others with hyphen
+    .replace(/^-+|-+$/g, '') // Trim leading/trailing hyphens
+    .toLowerCase()
+}

--- a/frontend/src/utils/slugify.ts
+++ b/frontend/src/utils/slugify.ts
@@ -2,7 +2,8 @@ export default function slugify(text: string): string {
   return text
     .normalize('NFKD') // Normalize accented characters
     .replace(/[\u0300-\u036F]/g, '') // Remove diacritics
-    .replace(/[^a-zA-Z0-9]+/g, '-') // Only allow letters and numbers, replace others with hyphen
-    .replace(/^-+|-+$/g, '') // Trim leading/trailing hyphens
+    .replace(/[^a-zA-Z0-9]+/g, '-') // Replace non-alphanumeric with hyphens
+    .replace(/^-+/, '') // Trim leading hyphens
+    .replace(/-+$/, '') // Trim trailing hyphens
     .toLowerCase()
 }


### PR DESCRIPTION
<!-- Thanks for contributing to OWASP Nest! -->

<!-- Don't forget to link your PR to an existing issue if any. -->
Resolves #1430

<!-- Describe the big picture of your changes. -->
### Overview
This PR improves the `AnchorTitle` component by simplifying its props.  
Previously, `AnchorTitle` accepted both `title` and `href` props. However, since the `href` can be consistently derived from the `title`, we no longer require `href` to be passed manually.

### Changes Made
- **Removed** the `href` prop from `AnchorTitle`.
- **Added** logic to automatically generate the `href` by slugifying the provided `title`.
- **Updated** related usage and tests accordingly.
- **Cleaned up** an old TODO left in the code regarding this exact enhancement.

### Why This Change
- Reduces the surface area of the component's API.
- Prevents potential mismatches between `title` and `href`.
- Aligns with the original design intention captured in the TODO comment.
- Improves maintainability and developer experience.

<!-- Thanks again for your contribution! -->
