### PR TITLE
docs: add Next.js to tech stack after migration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thank you for considering contributing to the **OWASP Nest** project! This docum
 Nest is a full-stack web application built using:
 
 - **Backend**: Python, Django
-- **Frontend**: TypeScript, React, Tailwind CSS, Next.js 
+- **Frontend**: TypeScript, Next.js, React, Tailwind CSS
 - **Search**: Algolia
 
 The project uses a **containerized approach** for both development and production environments. Docker is required to run Nest locally.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thank you for considering contributing to the **OWASP Nest** project! This docum
 Nest is a full-stack web application built using:
 
 - **Backend**: Python, Django
-- **Frontend**: TypeScript, React, Tailwind CSS
+- **Frontend**: TypeScript, React, Tailwind CSS, Next.js 
 - **Search**: Algolia
 
 The project uses a **containerized approach** for both development and production environments. Docker is required to run Nest locally.


### PR DESCRIPTION
Docs Update: Added Next.js to the tech stack section as the project has recently been migrated to Next.js, but the documentation had not been updated to reflect this change. Keeping the docs in sync with the current implementation ensures clarity for new contributors and accurate project representation.