### PR TITLE
ci: add a summary to monitor docker image size for backend and frontend

### DIFF
--- a/.github/workflows/run-ci-cd.yaml
+++ b/.github/workflows/run-ci-cd.yaml
@@ -306,6 +306,15 @@ jobs:
           echo "NEXT_SERVER_CSRF_URL=${{ secrets.NEXT_SERVER_CSRF_URL }}" >> frontend/.env
           echo "NEXT_SERVER_GRAPHQL_URL=${{ secrets.NEXT_SERVER_GRAPHQL_URL }}" >> frontend/.env
 
+      - name: Get backend image size
+        id: size-backend
+        run: |
+          IMAGE_ID=$(docker images -q ${{ env.DOCKERHUB_USERNAME }}/owasp-nest-backend:staging)
+          RAW_SIZE=$(docker image inspect "$IMAGE_ID" --format='{{.Size}}')
+          HR_SIZE=$(numfmt --to=iec --suffix=B "$RAW_SIZE")
+          echo "raw_size=$RAW_SIZE" >> $GITHUB_OUTPUT
+          echo "hr_size=$HR_SIZE" >> $GITHUB_OUTPUT
+
       - name: Build frontend image
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
@@ -319,6 +328,28 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: ${{ env.DOCKERHUB_USERNAME }}/owasp-nest-frontend:staging
+
+      - name: Get frontend image size
+        id: size-frontend
+        run: |
+          IMAGE_ID=$(docker images -q ${{ env.DOCKERHUB_USERNAME }}/owasp-nest-frontend:staging)
+          RAW_SIZE=$(docker image inspect "$IMAGE_ID" --format='{{.Size}}')
+          HR_SIZE=$(numfmt --to=iec --suffix=B "$RAW_SIZE")
+          echo "raw_size=$RAW_SIZE" >> $GITHUB_OUTPUT
+          echo "hr_size=$HR_SIZE" >> $GITHUB_OUTPUT
+
+      - name: Summarize Docker image sizes
+        run: |
+          echo "## Docker Images Size Report"
+          echo ""
+          echo "Backend: ${{ steps.size-backend.outputs.hr_size }} (${{ steps.size-backend.outputs.raw_size }} bytes)"
+          echo "Frontend: ${{ steps.size-frontend.outputs.hr_size }} (${{ steps.size-frontend.outputs.raw_size }} bytes)"
+          {
+            echo "## Docker Images Size Report"
+            echo ""
+            echo "**Backend:** ${{ steps.size-backend.outputs.hr_size }} (${{ steps.size-backend.outputs.raw_size }} bytes)"
+            echo "**Frontend:** ${{ steps.size-frontend.outputs.hr_size }} (${{ steps.size-frontend.outputs.raw_size }} bytes)"
+          } >> $GITHUB_STEP_SUMMARY
 
   scan-staging-images:
     name: Scan Staging Images


### PR DESCRIPTION
Resolves #1519

# Description

Added two steps to monitor the docker image sizes for both frontend and backend. 

These two steps are followed by a `summary` step that posts a summary message within the job using the [GITHUB_STEP_SUMMARY](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary) environment variable.

**Note**:
- Echoed twice in the `summary` step, the first echo is for debugging/viewing in Github UI purposes.

Added these steps for `staging` environment only for now, I think it will be the same thing for the `production` environment, upon a green flag, I'll make another commit for the same.