### PR TITLE
Fix inactive label alignment

### DIFF
--- a/frontend/src/components/CardDetailsPage.tsx
+++ b/frontend/src/components/CardDetailsPage.tsx
@@ -50,11 +50,15 @@ const DetailsCard = ({
   return (
     <div className="min-h-screen bg-white p-8 text-gray-600 dark:bg-[#212529] dark:text-gray-300">
       <div className="mx-auto max-w-6xl">
-        <h1 className="mb-6 mt-4 text-4xl font-bold">{title}</h1>
+        <div className="mb-6 flex flex-row items-center">
+          <h1 className="mb-6 mt-4 text-4xl font-bold">{title}</h1>
+          {!isActive && (
+            <span className="ml-4 justify-center rounded bg-red-200 px-2 py-1 text-sm text-red-800">
+              Inactive
+            </span>
+          )}
+        </div>
         <p className="mb-6 text-xl">{description}</p>
-        {!isActive && (
-          <span className="ml-2 rounded bg-red-200 px-2 py-1 text-sm text-red-800">Inactive</span>
-        )}
         {summary && (
           <SecondaryCard icon={faCircleInfo} title={<AnchorTitle title="Summary" />}>
             <p>{summary}</p>

--- a/frontend/src/components/CardDetailsPage.tsx
+++ b/frontend/src/components/CardDetailsPage.tsx
@@ -50,9 +50,9 @@ const DetailsCard = ({
   return (
     <div className="min-h-screen bg-white p-8 text-gray-600 dark:bg-[#212529] dark:text-gray-300">
       <div className="mx-auto max-w-6xl">
-        <div className="mb-6 flex flex-row items-center">
-          <h1 className="mb-6 mt-4 text-4xl font-bold">{title}</h1>
-          {!isActive && (
+        <div className="mt-4 flex flex-row items-center">
+          <h1 className="text-4xl font-bold">{title}</h1>
+          {isActive && (
             <span className="ml-4 justify-center rounded bg-red-200 px-2 py-1 text-sm text-red-800">
               Inactive
             </span>

--- a/frontend/src/components/CardDetailsPage.tsx
+++ b/frontend/src/components/CardDetailsPage.tsx
@@ -52,7 +52,7 @@ const DetailsCard = ({
       <div className="mx-auto max-w-6xl">
         <div className="mt-4 flex flex-row items-center">
           <h1 className="text-4xl font-bold">{title}</h1>
-          {isActive && (
+          {!isActive && (
             <span className="ml-4 justify-center rounded bg-red-200 px-2 py-1 text-sm text-red-800">
               Inactive
             </span>


### PR DESCRIPTION
Fixed inactive label alignment on the DetailsCard.
Before and after:

![Screenshot 2025-06-21 at 2 41 55 PM](https://github.com/user-attachments/assets/8333b192-b68d-4ccb-bcec-62761b67a217)
![Screenshot 2025-06-21 at 2 49 56 PM](https://github.com/user-attachments/assets/ffd54ccd-ab9c-4401-9ea6-407f6ac67a6d)
