### PR TITLE
Add auto-scroll to top on pathname change

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { Geist, Geist_Mono } from 'next/font/google'
 import React from 'react'
 import { Providers } from 'wrappers/provider'
 import { GTM_ID, IS_GITHUB_AUTH_ENABLED } from 'utils/credentials'
+import AutoScrollToTop from 'components/AutoScrollToTop'
 import BreadCrumbs from 'components/BreadCrumbs'
 import Footer from 'components/Footer'
 import Header from 'components/Header'
@@ -66,6 +67,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
         style={{ minHeight: '100vh' }}
       >
+        <AutoScrollToTop />
         <Providers>
           <Header isGitHubAuthEnabled={IS_GITHUB_AUTH_ENABLED} />
           <BreadCrumbs />

--- a/frontend/src/components/AutoScrollToTop.tsx
+++ b/frontend/src/components/AutoScrollToTop.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+import { useEffect } from 'react'
+
+export default function AutoScrollToTop() {
+  const pathname = usePathname()
+
+  useEffect(() => {
+    window.scrollTo(0, 0)
+  }, [pathname])
+
+  return null
+}


### PR DESCRIPTION
Added an `AutoScrollToTop` component to `RootLayout` to have pages scroll to top on route change. 

> This is a known behavior in Next.js (React) apps due to the way client-side routing works. When you navigate between pages using next/link or useRouter().push(), Next.js performs a soft navigation—it loads the new page content without refreshing the browser or resetting the scroll position unless explicitly told to do so.