### PR TITLE
Store member count for slack channels

### DIFF
--- a/backend/apps/slack/models/conversation.py
+++ b/backend/apps/slack/models/conversation.py
@@ -69,6 +69,7 @@ class Conversation(TimestampedModel):
         self.purpose = conversation_data.get("purpose", {}).get("value", "")
         self.slack_creator_id = conversation_data.get("creator", "")
         self.topic = conversation_data.get("topic", {}).get("value", "")
+        self.total_members_count = conversation_data.get("num_members", 0)
 
         self.workspace = workspace
 


### PR DESCRIPTION
Fetching using the [conversations.info](https://api.slack.com/methods/conversations.info#arg_include_num_members) API method was not required as [converstaions.list](https://docs.slack.dev/reference/methods/conversations.list) already returns a `num_members` field.

Due to this, I think we don't need to fetch the channel data again.