### PR TITLE
Improve chapters/project leaders presentation

### DIFF
--- a/backend/apps/owasp/graphql/nodes/common.py
+++ b/backend/apps/owasp/graphql/nodes/common.py
@@ -3,11 +3,17 @@
 import strawberry
 
 from apps.github.graphql.nodes.repository_contributor import RepositoryContributorNode
+from apps.github.graphql.nodes.user import UserNode
 
 
 @strawberry.type
 class GenericEntityNode:
     """Base node class for OWASP entities with common fields and resolvers."""
+
+    @strawberry.field
+    def leaders_temp(self) -> list[UserNode]:
+        """Resolve leaders logins."""
+        return self.leaders.all()
 
     @strawberry.field
     def leaders(self) -> list[str]:

--- a/frontend/src/app/about/page.tsx
+++ b/frontend/src/app/about/page.tsx
@@ -14,24 +14,20 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Tooltip } from '@heroui/tooltip'
 import Image from 'next/image'
 import Link from 'next/link'
-import { useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
-import FontAwesomeIconWrapper from 'wrappers/FontAwesomeIconWrapper'
 import { ErrorDisplay, handleAppError } from 'app/global-error'
 import { GET_PROJECT_METADATA, GET_TOP_CONTRIBUTORS } from 'server/queries/projectQueries'
-import { GET_LEADER_DATA } from 'server/queries/userQueries'
 import type { Contributor } from 'types/contributor'
 import type { Project } from 'types/project'
-import type { User } from 'types/user'
 import { aboutText, technologies } from 'utils/aboutData'
 import { capitalize } from 'utils/capitalize'
 import AnchorTitle from 'components/AnchorTitle'
 import AnimatedCounter from 'components/AnimatedCounter'
+import LeadersListBlock from 'components/LeadersListBlock'
 import LoadingSpinner from 'components/LoadingSpinner'
 import Markdown from 'components/MarkdownWrapper'
 import SecondaryCard from 'components/SecondaryCard'
 import TopContributorsList from 'components/TopContributorsList'
-import UserCard from 'components/UserCard'
 
 const leaders = {
   arkid15r: 'CCSP, CISSP, CSSLP',
@@ -112,15 +108,9 @@ const About = () => {
           ))}
         </SecondaryCard>
 
-        <SecondaryCard icon={faArrowUpRightFromSquare} title={<AnchorTitle title="Leaders" />}>
-          <div className="flex w-full flex-col items-center justify-around overflow-hidden md:flex-row">
-            {Object.keys(leaders).map((username) => (
-              <div key={username}>
-                <LeaderData username={username} />
-              </div>
-            ))}
-          </div>
-        </SecondaryCard>
+        {leaders && (
+          <LeadersListBlock leaders={leaders} icon={faArrowUpRightFromSquare} label="Leaders" />
+        )}
 
         {topContributors && (
           <TopContributorsList
@@ -238,42 +228,6 @@ const About = () => {
         </div>
       </div>
     </div>
-  )
-}
-
-const LeaderData = ({ username }: { username: string }) => {
-  const { data, loading, error } = useQuery(GET_LEADER_DATA, {
-    variables: { key: username },
-  })
-  const router = useRouter()
-
-  if (loading) return <p>Loading {username}...</p>
-  if (error) return <p>Error loading {username}'s data</p>
-
-  const user = data?.user
-
-  if (!user) {
-    return <p>No data available for {username}</p>
-  }
-
-  const handleButtonClick = (user: User) => {
-    router.push(`/members/${user.login}`)
-  }
-
-  return (
-    <UserCard
-      avatar={user.avatarUrl}
-      button={{
-        icon: <FontAwesomeIconWrapper icon="fa-solid fa-right-to-bracket" />,
-        label: 'View Profile',
-        onclick: () => handleButtonClick(user),
-      }}
-      className="h-64 w-40 bg-inherit"
-      company={user.company}
-      description={leaders[user.login]}
-      location={user.location}
-      name={user.name || username}
-    />
   )
 }
 

--- a/frontend/src/app/projects/[projectKey]/page.tsx
+++ b/frontend/src/app/projects/[projectKey]/page.tsx
@@ -103,6 +103,7 @@ const ProjectDetailsPage = () => {
       stats={projectStats}
       summary={project.summary}
       title={project.name}
+      leaders={project.leadersTemp}
       topContributors={topContributors}
       topics={project.topics}
       type="project"

--- a/frontend/src/components/CardDetailsPage.tsx
+++ b/frontend/src/components/CardDetailsPage.tsx
@@ -11,6 +11,7 @@ import {
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import Link from 'next/link'
 import type { DetailsCardProps } from 'types/card'
+import { LeadersListBlockProps } from 'types/leaders'
 import { capitalize } from 'utils/capitalize'
 import { IS_PROJECT_HEALTH_ENABLED } from 'utils/credentials'
 import { getSocialIcon } from 'utils/urlIconMappings'
@@ -19,6 +20,7 @@ import ChapterMapWrapper from 'components/ChapterMapWrapper'
 import HealthMetrics from 'components/HealthMetrics'
 import InfoBlock from 'components/InfoBlock'
 import LeadersList from 'components/LeadersList'
+import LeadersListBlock from 'components/LeadersListBlock'
 import Milestones from 'components/Milestones'
 import RecentIssues from 'components/RecentIssues'
 import RecentPullRequests from 'components/RecentPullRequests'
@@ -49,6 +51,7 @@ const DetailsCard = ({
   stats,
   summary,
   title,
+  leaders,
   topContributors,
   topics,
   type,
@@ -196,6 +199,15 @@ const DetailsCard = ({
               <ToggleableList items={topics} icon={faTags} label={<AnchorTitle title="Topics" />} />
             )}
           </div>
+        )}
+        {leaders && (
+          <LeadersListBlock
+            label="Leaders"
+            leaders={leaders.reduce((acc, user) => {
+              acc[user.login] = ''
+              return acc
+            }, {} as LeadersListBlockProps)}
+          />
         )}
         {topContributors && (
           <TopContributorsList

--- a/frontend/src/components/LeadersListBlock.tsx
+++ b/frontend/src/components/LeadersListBlock.tsx
@@ -1,0 +1,71 @@
+'use client'
+import { useQuery } from '@apollo/client'
+import { IconProp } from '@fortawesome/fontawesome-svg-core'
+import { User } from '@sentry/nextjs'
+import { useRouter } from 'next/navigation'
+import FontAwesomeIconWrapper from 'wrappers/FontAwesomeIconWrapper'
+import { GET_LEADER_DATA } from 'server/queries/userQueries'
+import { LeadersListBlockProps } from 'types/leaders'
+import AnchorTitle from 'components/AnchorTitle'
+import SecondaryCard from 'components/SecondaryCard'
+import UserCard from 'components/UserCard'
+
+const LeadersListBlock = ({
+  leaders,
+  label = 'Leaders',
+  icon,
+}: {
+  leaders: LeadersListBlockProps
+  label?: string
+  icon?: IconProp
+}) => {
+  const LeaderData = ({ username }: { username: string }) => {
+    const { data, loading, error } = useQuery(GET_LEADER_DATA, {
+      variables: { key: username },
+    })
+    const router = useRouter()
+
+    if (loading) return <p>Loading {username}...</p>
+    if (error) return <p>Error loading {username}'s data</p>
+
+    const user = data?.user
+
+    if (!user) {
+      return <p>No data available for {username}</p>
+    }
+
+    const handleButtonClick = (user: User) => {
+      router.push(`/members/${user.login}`)
+    }
+
+    return (
+      <UserCard
+        avatar={user.avatarUrl}
+        button={{
+          icon: <FontAwesomeIconWrapper icon="fa-solid fa-right-to-bracket" />,
+          label: 'View Profile',
+          onclick: () => handleButtonClick(user),
+        }}
+        className="h-64 w-40 bg-inherit"
+        company={user.company}
+        description={leaders[user.login]}
+        location={user.location}
+        name={user.name || username}
+      />
+    )
+  }
+
+  return (
+    <SecondaryCard icon={icon} title={<AnchorTitle title={label} />}>
+      <div className="flex w-full flex-col items-center justify-around overflow-hidden md:flex-row">
+        {Object.keys(leaders).map((username) => (
+          <div key={username}>
+            <LeaderData username={username} />
+          </div>
+        ))}
+      </div>
+    </SecondaryCard>
+  )
+}
+
+export default LeadersListBlock

--- a/frontend/src/server/queries/projectQueries.ts
+++ b/frontend/src/server/queries/projectQueries.ts
@@ -10,6 +10,9 @@ export const GET_PROJECT_DATA = gql`
       key
       languages
       leaders
+      leadersTemp {
+        login
+      }
       level
       name
       healthMetrics(limit: 30) {

--- a/frontend/src/types/card.ts
+++ b/frontend/src/types/card.ts
@@ -11,6 +11,7 @@ import type { Milestone } from 'types/milestone'
 import type { RepositoryCardProps } from 'types/project'
 import type { PullRequest } from 'types/pullRequest'
 import type { Release } from 'types/release'
+import type { User } from 'types/user'
 
 export type CardProps = {
   button: Button
@@ -53,6 +54,7 @@ export interface DetailsCardProps {
   stats?: Stats[]
   summary?: string
   title?: string
+  leaders?: User[]
   topContributors?: Contributor[]
   topics?: string[]
   type: string

--- a/frontend/src/types/leaders.ts
+++ b/frontend/src/types/leaders.ts
@@ -1,3 +1,7 @@
 export type LeadersListProps = {
   leaders: string
 }
+
+export type LeadersListBlockProps = {
+  [key: string]: string
+}

--- a/frontend/src/types/project.ts
+++ b/frontend/src/types/project.ts
@@ -5,6 +5,7 @@ import type { Milestone } from 'types/milestone'
 import type { Organization } from 'types/organization'
 import type { PullRequest } from 'types/pullRequest'
 import type { Release } from 'types/release'
+import { User } from 'types/user'
 
 export type ProjectStats = {
   contributors: number
@@ -25,6 +26,7 @@ export type Project = {
   key: string
   languages: string[]
   leaders: string[]
+  leadersTemp: User[]
   level: string
   name: string
   openIssuesCount?: number


### PR DESCRIPTION
Resolves #1431 

Hello, I need help @arkid15r ,

here's what I did in this PR: 
- exposed leaders (m2m relationship with github.User) as `leaders_temp` field
- extracted the `Leaders` Block in a component
- used it in about page and projects page (chapters left out for now)

questions/blockers:
1. I had to use `leaders_temp` as i could not come up with a different name. There's already a `leaders` field exposed but it's misleading as its actually `leaders_raw` in the database which is just `string[]`. I'm not sure what to name it. I think renaming the existing `leaders` to `leaders_raw` or `leaders_names` would be a good approach.
2. The original `Leaders` block requires data in the following format:
```ts
const leaders = {
  arkid15r: 'CCSP, CISSP, CSSLP',
  kasya: 'CC',
  mamicidal: 'CISSP',
}
```
however, I'm not sure how to get the `CCSP, CISSP, CSSLP` part from the database. 
3. since `leaders_temp` is of type `User[]` we need to convert it in the above format (type `LeadersListBlockProps`). in this implementation, I have just reduced it using code. But I'm not sure if this is a good approach, please let me know.

Please let me know what you think, I will update the code and the related tests accordingly.