### PR TITLE
Add explanations for Ruff lint ignore 

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -122,25 +122,25 @@ target-version = "py313"
 [tool.ruff.lint]
 extend-select = ["I"]
 ignore = [
-    "ANN",  # TODO(arkid15r): remove when all annotations are added.
-    "ARG002",
-    "C901",
-    "COM812",
-    "D407",
-    "DJ012",
-    "ERA001",
-    "FBT002",
-    "FIX002",
-    "PD",
-    "PERF203",
-    "PLC0414",
-    "PLC0415",  # TODO(arkid15r): remove when all imports are at the top level.
-    "PLR0912",
-    "PLR0913",
-    "PLR0915",
-    "RUF012",
-    "SLF001",
-    "TD003",
+    "ANN",      # ANN: Missing type annotations.
+    "ARG002",   # ARG002: Unused method argument.
+    "C901",     # C901: Cyclomatic complexity too high.
+    "COM812",   # COM812: Missing trailing comma.
+    "D407",     # D407: Incorrect docstring section header.
+    "DJ012",    # DJ012: Django - using old staticfiles tag.
+    "ERA001",   # ERA001: Commented-out code detected.
+    "FBT002",   # FBT002: Boolean positional argument in function definition.
+    "FIX002",   # FIX002: Unresolved FIXME comment.
+    "PD",       # PD: Pandas - best practices violations.
+    "PERF203",  # PERF203: Performance - inefficient use of len() in loop.
+    "PLC0414",  # PLC0414: Pylint - useless import alias.
+    "PLC0415",  # PLC0415: Pylint - import not at top-level.
+    "PLR0912",  # PLR0912: Pylint - too many branches.
+    "PLR0913",  # PLR0913: Pylint - too many arguments.
+    "PLR0915",  # PLR0915: Pylint - too many statements.
+    "RUF012",   # RUF012: Ruff - mutable class attribute as default.
+    "SLF001",   # SLF001: Private member access.
+    "TD003",    # TD003: TODO comment missing issue link.
 ]
 select = ["ALL"]
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -122,25 +122,25 @@ target-version = "py313"
 [tool.ruff.lint]
 extend-select = ["I"]
 ignore = [
-    "ANN",      # ANN: Missing type annotations.
-    "ARG002",   # ARG002: Unused method argument.
-    "C901",     # C901: Cyclomatic complexity too high.
-    "COM812",   # COM812: Missing trailing comma.
-    "D407",     # D407: Incorrect docstring section header.
-    "DJ012",    # DJ012: Django - using old staticfiles tag.
-    "ERA001",   # ERA001: Commented-out code detected.
-    "FBT002",   # FBT002: Boolean positional argument in function definition.
-    "FIX002",   # FIX002: Unresolved FIXME comment.
-    "PD",       # PD: Pandas - best practices violations.
-    "PERF203",  # PERF203: Performance - inefficient use of len() in loop.
-    "PLC0414",  # PLC0414: Pylint - useless import alias.
-    "PLC0415",  # PLC0415: Pylint - import not at top-level.
-    "PLR0912",  # PLR0912: Pylint - too many branches.
-    "PLR0913",  # PLR0913: Pylint - too many arguments.
-    "PLR0915",  # PLR0915: Pylint - too many statements.
-    "RUF012",   # RUF012: Ruff - mutable class attribute as default.
-    "SLF001",   # SLF001: Private member access.
-    "TD003",    # TD003: TODO comment missing issue link.
+    "ANN",      # https://docs.astral.sh/ruff/rules/#flake8-annotations-ann/
+    "ARG002",   # https://docs.astral.sh/ruff/rules/unused-method-argument/
+    "C901",     # https://docs.astral.sh/ruff/rules/complex-structure/
+    "COM812",   # https://docs.astral.sh/ruff/rules/missing-trailing-comma/
+    "D407",     # https://docs.astral.sh/ruff/rules/missing-dashed-underline-after-section/
+    "DJ012",    # https://docs.astral.sh/ruff/rules/django-unordered-body-content-in-model/
+    "ERA001",   # https://docs.astral.sh/ruff/rules/commented-out-code/
+    "FBT002",   # https://docs.astral.sh/ruff/rules/boolean-default-value-positional-argument/
+    "FIX002",   # https://docs.astral.sh/ruff/rules/line-contains-todo/
+    "PD",       # https://docs.astral.sh/ruff/rules/#pandas-vet-pd
+    "PERF203",  # https://docs.astral.sh/ruff/rules/try-except-in-loop/
+    "PLC0414",  # https://docs.astral.sh/ruff/rules/useless-import-alias/
+    "PLC0415",  # https://docs.astral.sh/ruff/rules/import-outside-top-level/
+    "PLR0912",  # https://docs.astral.sh/ruff/rules/too-many-branches/
+    "PLR0913",  # https://docs.astral.sh/ruff/rules/too-many-arguments/
+    "PLR0915",  # https://docs.astral.sh/ruff/rules/too-many-statements/
+    "RUF012",   # https://docs.astral.sh/ruff/rules/mutable-class-default/
+    "SLF001",   # https://docs.astral.sh/ruff/rules/private-member-access/
+    "TD003",    # https://docs.astral.sh/ruff/rules/missing-todo-link/
 ]
 select = ["ALL"]
 


### PR DESCRIPTION


## Proposed change
Added concise explanations as comments to each item in the `ruff` lint `ignore` list. This improves code clarity and maintainability for future developers.

Resolves  #1739

Added comments to the `ignore` list within the `tool.ruff.lint` section, explaining the purpose of each ignored Ruff rule. This enhances the clarity of `pyproject.toml` regarding linting configurations.


## Checklist

- [X] I've read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md).
- [ ] I've run `make check-test` locally; all checks and tests passed.
    * **Note on local tests:** `make check` passed successfully. However, `make test` failed locally with a `TLS handshake timeout` / `EOF` error when trying to pull the `mcr.microsoft.com/playwright` Docker image. This appears to be an environmental issue specific to my local machine's network/Docker setup and not related to the code changes in this PR. I expect the CI pipeline to pass these tests on the project's build environment.
