### PR TITLE
feat: Enhance Ruff per-file ignores with documentation links

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -153,11 +153,6 @@ select = ["ALL"]
     "D101", # https://docs.astral.sh/ruff/rules/undocumented-public-class/
     "D104"  # https://docs.astral.sh/ruff/rules/undocumented-public-package/
 ]
-"**/rest/v1/*.py" = [
-    "ARG001", # https://docs.astral.sh/ruff/rules/unused-function-argument/
-    "B008",   # https://docs.astral.sh/ruff/rules/function-call-in-default-argument/
-    "D106"    # https://docs.astral.sh/ruff/rules/undocumented-public-nested-class/
-]
 "**/apps.py" = [
     "D100", # https://docs.astral.sh/ruff/rules/undocumented-public-module/
     "D101", # https://docs.astral.sh/ruff/rules/undocumented-public-class/
@@ -188,6 +183,11 @@ select = ["ALL"]
 ]
 "**/models/*.py" = [
     "D106" # https://docs.astral.sh/ruff/rules/undocumented-public-nested-class/
+]
+"**/rest/v1/*.py" = [
+    "ARG001", # https://docs.astral.sh/ruff/rules/unused-function-argument/
+    "B008",   # https://docs.astral.sh/ruff/rules/function-call-in-default-argument/
+    "D106"    # https://docs.astral.sh/ruff/rules/undocumented-public-nested-class/
 ]
 "**/tests/**/*.py" = [
     "D100",    # https://docs.astral.sh/ruff/rules/undocumented-public-module/

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -144,18 +144,60 @@ ignore = [
 select = ["ALL"]
 
 [tool.ruff.lint.per-file-ignores]
-"**/__init__.py" = ["D104", "F401"]
-"**/admin.py" = ["D100", "D101", "D104"]
-"**/rest/v1/*.py" = ["ARG001", "B008", "D106"]
-"**/apps.py" = ["D100", "D101", "D104"]
-"**/graphql/**/nodes.py" = ["D106"]
-"**/graphql/nodes/*.py" = ["D106"]
-"**/graphql/queries/*.py" = ["N805"]
-"**/management/commands/*.py" = ["D101", "D102", "T201"]
-"**/migrations/*.py" = ["D100", "D101", "D104", "E501"]
-"**/models.py" = ["D106"]
-"**/models/*.py" = ["D106"]
-"**/tests/**/*.py" = ["D100", "D101", "D102", "D103", "D107", "PLR2004", "S101"]
+"**/__init__.py" = [
+    "D104", # https://docs.astral.sh/ruff/rules/undocumented-public-package/
+    "F401"  # https://docs.astral.sh/ruff/rules/unused-import/
+]
+"**/admin.py" = [
+    "D100", # https://docs.astral.sh/ruff/rules/undocumented-public-module/
+    "D101", # https://docs.astral.sh/ruff/rules/undocumented-public-class/
+    "D104"  # https://docs.astral.sh/ruff/rules/undocumented-public-package/
+]
+"**/rest/v1/*.py" = [
+    "ARG001", # https://docs.astral.sh/ruff/rules/unused-function-argument/
+    "B008",   # https://docs.astral.sh/ruff/rules/function-call-in-default-argument/
+    "D106"    # https://docs.astral.sh/ruff/rules/undocumented-public-nested-class/
+]
+"**/apps.py" = [
+    "D100", # https://docs.astral.sh/ruff/rules/undocumented-public-module/
+    "D101", # https://docs.astral.sh/ruff/rules/undocumented-public-class/
+    "D104"  # https://docs.astral.sh/ruff/rules/undocumented-public-package/
+]
+"**/graphql/**/nodes.py" = [
+    "D106" # https://docs.astral.sh/ruff/rules/undocumented-public-nested-class/
+]
+"**/graphql/nodes/*.py" = [
+    "D106" # https://docs.astral.sh/ruff/rules/undocumented-public-nested-class/
+]
+"**/graphql/queries/*.py" = [
+    "N805" # https://docs.astral.sh/ruff/rules/invalid-first-argument-name-for-method/
+]
+"**/management/commands/*.py" = [
+    "D101", # https://docs.astral.sh/ruff/rules/undocumented-public-class/
+    "D102", # https://docs.astral.sh/ruff/rules/undocumented-public-method/
+    "T201"  # https://docs.astral.sh/ruff/rules/print/
+]
+"**/migrations/*.py" = [
+    "D100", # https://docs.astral.sh/ruff/rules/undocumented-public-module/
+    "D101", # https://docs.astral.sh/ruff/rules/undocumented-public-class/
+    "D104", # https://docs.astral.sh/ruff/rules/undocumented-public-package/
+    "E501"  # https://docs.astral.sh/ruff/rules/line-too-long/
+]
+"**/models.py" = [
+    "D106" # https://docs.astral.sh/ruff/rules/undocumented-public-nested-class/
+]
+"**/models/*.py" = [
+    "D106" # https://docs.astral.sh/ruff/rules/undocumented-public-nested-class/
+]
+"**/tests/**/*.py" = [
+    "D100",    # https://docs.astral.sh/ruff/rules/undocumented-public-module/
+    "D101",    # https://docs.astral.sh/ruff/rules/undocumented-public-class/
+    "D102",    # https://docs.astral.sh/ruff/rules/undocumented-public-method/
+    "D103",    # https://docs.astral.sh/ruff/rules/undocumented-public-function/
+    "D107",    # https://docs.astral.sh/ruff/rules/undocumented-public-init/
+    "PLR2004", # https://docs.astral.sh/ruff/rules/magic-value-comparison/
+    "S101"     # https://docs.astral.sh/ruff/rules/assert/
+]
 
 [build-system]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION

## Proposed change

Updated the `[tool.ruff.lint.per-file-ignores]` section in `backend/pyproject.toml` to include direct links to the Ruff documentation for each ignored rule.

Resolves #1770

This change aims to enhance the maintainability and clarity of the Ruff linting configuration by providing immediate access to the official documentation for each specific rule being ignored on a per-file basis.

## Checklist

- [X] I've read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md).
- [X] I've run `make check-test` locally; all checks and tests passed.
