### PR TITLE
Add unit tests for GitHub admin files

### DIFF
--- a/backend/tests/apps/github/admin/issue_test.py
+++ b/backend/tests/apps/github/admin/issue_test.py
@@ -15,7 +15,7 @@ def issue_admin_instance():
 class TestIssueAdmin:
     """Test suite for the IssueAdmin class."""
 
-    def test_custom_field_github_url_unit(self, issue_admin_instance):
+    def test_custom_field_github_url(self, issue_admin_instance):
         """Test that custom_field_github_url generates the correct HTML link."""
         mock_issue = MagicMock()
         mock_issue.url = "https://github.com/mock-org/mock-repo/issues/1"

--- a/backend/tests/apps/github/admin/issue_test.py
+++ b/backend/tests/apps/github/admin/issue_test.py
@@ -12,18 +12,22 @@ def issue_admin_instance():
     return IssueAdmin(model=Issue, admin_site=AdminSite())
 
 
-def test_custom_field_github_url_unit(issue_admin_instance):
-    mock_issue = MagicMock()
-    mock_issue.url = "https://github.com/mock-org/mock-repo/issues/1"
+class TestIssueAdmin:
+    """Test suite for the IssueAdmin class."""
 
-    result = issue_admin_instance.custom_field_github_url(mock_issue)
+    def test_custom_field_github_url_unit(self, issue_admin_instance):
+        """Test that custom_field_github_url generates the correct HTML link."""
+        mock_issue = MagicMock()
+        mock_issue.url = "https://github.com/mock-org/mock-repo/issues/1"
 
-    expected_html = (
-        "<a href='https://github.com/mock-org/mock-repo/issues/1' target='_blank'>↗️</a>"
-    )
+        result = issue_admin_instance.custom_field_github_url(mock_issue)
 
-    assert result == expected_html
+        expected_html = (
+            "<a href='https://github.com/mock-org/mock-repo/issues/1' target='_blank'>↗️</a>"
+        )
 
+        assert result == expected_html
 
-def test_list_display_contains_custom_field(issue_admin_instance):
-    assert "custom_field_github_url" in issue_admin_instance.list_display
+    def test_list_display_contains_custom_field(self, issue_admin_instance):
+        """Test that the list_display includes custom fields."""
+        assert "custom_field_github_url" in issue_admin_instance.list_display

--- a/backend/tests/apps/github/admin/issue_test.py
+++ b/backend/tests/apps/github/admin/issue_test.py
@@ -1,0 +1,29 @@
+from unittest.mock import MagicMock
+
+import pytest
+from django.contrib.admin.sites import AdminSite
+
+from apps.github.admin.issue import IssueAdmin
+from apps.github.models.issue import Issue
+
+
+@pytest.fixture
+def issue_admin_instance():
+    return IssueAdmin(model=Issue, admin_site=AdminSite())
+
+
+def test_custom_field_github_url_unit(issue_admin_instance):
+    mock_issue = MagicMock()
+    mock_issue.url = "https://github.com/mock-org/mock-repo/issues/1"
+
+    result = issue_admin_instance.custom_field_github_url(mock_issue)
+
+    expected_html = (
+        "<a href='https://github.com/mock-org/mock-repo/issues/1' target='_blank'>↗️</a>"
+    )
+
+    assert result == expected_html
+
+
+def test_list_display_contains_custom_field(issue_admin_instance):
+    assert "custom_field_github_url" in issue_admin_instance.list_display

--- a/backend/tests/apps/github/admin/pull_request_test.py
+++ b/backend/tests/apps/github/admin/pull_request_test.py
@@ -15,7 +15,7 @@ def pull_request_admin_instance():
 class TestPullRequestAdmin:
     """Test suite for the PullRequestAdmin class."""
 
-    def test_custom_field_github_url_unit(self, pull_request_admin_instance):
+    def test_custom_field_github_url(self, pull_request_admin_instance):
         """Test that custom_field_github_url generates the correct HTML link."""
         mock_pull_request = MagicMock()
         mock_pull_request.url = "https://github.com/mock-org/mock-repo/pull/42"

--- a/backend/tests/apps/github/admin/pull_request_test.py
+++ b/backend/tests/apps/github/admin/pull_request_test.py
@@ -1,0 +1,27 @@
+from unittest.mock import MagicMock
+
+import pytest
+from django.contrib.admin.sites import AdminSite
+
+from apps.github.admin.pull_request import PullRequestAdmin
+from apps.github.models.pull_request import PullRequest
+
+
+@pytest.fixture
+def pull_request_admin_instance():
+    return PullRequestAdmin(model=PullRequest, admin_site=AdminSite())
+
+
+def test_custom_field_github_url_unit(pull_request_admin_instance):
+    mock_pull_request = MagicMock()
+    mock_pull_request.url = "https://github.com/mock-org/mock-repo/pull/42"
+
+    result = pull_request_admin_instance.custom_field_github_url(mock_pull_request)
+
+    expected_html = "<a href='https://github.com/mock-org/mock-repo/pull/42' target='_blank'>↗️</a>"
+
+    assert result == expected_html
+
+
+def test_list_display_contains_custom_field(pull_request_admin_instance):
+    assert "custom_field_github_url" in pull_request_admin_instance.list_display

--- a/backend/tests/apps/github/admin/pull_request_test.py
+++ b/backend/tests/apps/github/admin/pull_request_test.py
@@ -12,16 +12,22 @@ def pull_request_admin_instance():
     return PullRequestAdmin(model=PullRequest, admin_site=AdminSite())
 
 
-def test_custom_field_github_url_unit(pull_request_admin_instance):
-    mock_pull_request = MagicMock()
-    mock_pull_request.url = "https://github.com/mock-org/mock-repo/pull/42"
+class TestPullRequestAdmin:
+    """Test suite for the PullRequestAdmin class."""
 
-    result = pull_request_admin_instance.custom_field_github_url(mock_pull_request)
+    def test_custom_field_github_url_unit(self, pull_request_admin_instance):
+        """Test that custom_field_github_url generates the correct HTML link."""
+        mock_pull_request = MagicMock()
+        mock_pull_request.url = "https://github.com/mock-org/mock-repo/pull/42"
 
-    expected_html = "<a href='https://github.com/mock-org/mock-repo/pull/42' target='_blank'>↗️</a>"
+        result = pull_request_admin_instance.custom_field_github_url(mock_pull_request)
 
-    assert result == expected_html
+        expected_html = (
+            "<a href='https://github.com/mock-org/mock-repo/pull/42' target='_blank'>↗️</a>"
+        )
 
+        assert result == expected_html
 
-def test_list_display_contains_custom_field(pull_request_admin_instance):
-    assert "custom_field_github_url" in pull_request_admin_instance.list_display
+    def test_list_display_contains_custom_field(self, pull_request_admin_instance):
+        """Test that the list_display includes custom fields."""
+        assert "custom_field_github_url" in pull_request_admin_instance.list_display

--- a/backend/tests/apps/github/admin/repository_test.py
+++ b/backend/tests/apps/github/admin/repository_test.py
@@ -1,0 +1,39 @@
+from unittest.mock import MagicMock
+
+import pytest
+from django.contrib.admin.sites import AdminSite
+
+from apps.github.admin.repository import RepositoryAdmin
+from apps.github.models.repository import Repository
+
+
+@pytest.fixture
+def repository_admin_instance():
+    return RepositoryAdmin(model=Repository, admin_site=AdminSite())
+
+
+def test_custom_field_title_unit(repository_admin_instance):
+    mock_repository = MagicMock()
+    mock_repository.owner.login = "mock-owner"
+    mock_repository.name = "mock-repo"
+
+    result = repository_admin_instance.custom_field_title(mock_repository)
+
+    assert result == "mock-owner/mock-repo"
+
+
+def test_custom_field_github_url_unit(repository_admin_instance):
+    mock_repository = MagicMock()
+    mock_repository.owner.login = "mock-owner"
+    mock_repository.name = "mock-repo"
+
+    result = repository_admin_instance.custom_field_github_url(mock_repository)
+
+    expected_html = "<a href='https://github.com/mock-owner/mock-repo' target='_blank'>↗️</a>"
+    assert result == expected_html
+
+
+def test_list_display_contains_custom_fields(repository_admin_instance):
+    admin_list_display = repository_admin_instance.list_display
+    assert "custom_field_title" in admin_list_display
+    assert "custom_field_github_url" in admin_list_display

--- a/backend/tests/apps/github/admin/repository_test.py
+++ b/backend/tests/apps/github/admin/repository_test.py
@@ -12,28 +12,31 @@ def repository_admin_instance():
     return RepositoryAdmin(model=Repository, admin_site=AdminSite())
 
 
-def test_custom_field_title_unit(repository_admin_instance):
-    mock_repository = MagicMock()
-    mock_repository.owner.login = "mock-owner"
-    mock_repository.name = "mock-repo"
+class TestRepositoryAdmin:
+    """Test suite for the RepositoryAdmin class."""
 
-    result = repository_admin_instance.custom_field_title(mock_repository)
+    def test_custom_field_title_unit(self, repository_admin_instance):
+        mock_repository = MagicMock()
+        mock_repository.owner.login = "mock-owner"
+        mock_repository.name = "mock-repo"
 
-    assert result == "mock-owner/mock-repo"
+        result = repository_admin_instance.custom_field_title(mock_repository)
 
+        assert result == "mock-owner/mock-repo"
 
-def test_custom_field_github_url_unit(repository_admin_instance):
-    mock_repository = MagicMock()
-    mock_repository.owner.login = "mock-owner"
-    mock_repository.name = "mock-repo"
+    def test_custom_field_github_url_unit(self, repository_admin_instance):
+        """Test that custom_field_github_url generates the correct HTML link."""
+        mock_repository = MagicMock()
+        mock_repository.owner.login = "mock-owner"
+        mock_repository.name = "mock-repo"
 
-    result = repository_admin_instance.custom_field_github_url(mock_repository)
+        result = repository_admin_instance.custom_field_github_url(mock_repository)
 
-    expected_html = "<a href='https://github.com/mock-owner/mock-repo' target='_blank'>↗️</a>"
-    assert result == expected_html
+        expected_html = "<a href='https://github.com/mock-owner/mock-repo' target='_blank'>↗️</a>"
+        assert result == expected_html
 
-
-def test_list_display_contains_custom_fields(repository_admin_instance):
-    admin_list_display = repository_admin_instance.list_display
-    assert "custom_field_title" in admin_list_display
-    assert "custom_field_github_url" in admin_list_display
+    def test_list_display_contains_custom_fields(self, repository_admin_instance):
+        """Test that the list_display includes custom fields."""
+        admin_list_display = repository_admin_instance.list_display
+        assert "custom_field_title" in admin_list_display
+        assert "custom_field_github_url" in admin_list_display

--- a/backend/tests/apps/github/admin/repository_test.py
+++ b/backend/tests/apps/github/admin/repository_test.py
@@ -15,7 +15,7 @@ def repository_admin_instance():
 class TestRepositoryAdmin:
     """Test suite for the RepositoryAdmin class."""
 
-    def test_custom_field_title_unit(self, repository_admin_instance):
+    def test_custom_field_title(self, repository_admin_instance):
         mock_repository = MagicMock()
         mock_repository.owner.login = "mock-owner"
         mock_repository.name = "mock-repo"
@@ -24,19 +24,20 @@ class TestRepositoryAdmin:
 
         assert result == "mock-owner/mock-repo"
 
-    def test_custom_field_github_url_unit(self, repository_admin_instance):
+    def test_custom_field_github_url(self, repository_admin_instance):
         """Test that custom_field_github_url generates the correct HTML link."""
         mock_repository = MagicMock()
         mock_repository.owner.login = "mock-owner"
         mock_repository.name = "mock-repo"
 
         result = repository_admin_instance.custom_field_github_url(mock_repository)
-
         expected_html = "<a href='https://github.com/mock-owner/mock-repo' target='_blank'>↗️</a>"
+
         assert result == expected_html
 
     def test_list_display_contains_custom_fields(self, repository_admin_instance):
         """Test that the list_display includes custom fields."""
         admin_list_display = repository_admin_instance.list_display
+
         assert "custom_field_title" in admin_list_display
         assert "custom_field_github_url" in admin_list_display


### PR DESCRIPTION

## Proposed change

This PR introduces unit tests for several ModelAdmin classes in `apps/github/admin/` to increase test coverage from 0%.

Resolves #1795 

**Added New Test Files:** Created `tests/apps/github/admin/issue_test.py`, `pull_request_test.py`, and `repository_test.py`.

**Implemented Unit Tests:** Wrote tests for the custom methods (`custom_field_title`, `custom_field_github_url`) found in `IssueAdmin`, `PullRequestAdmin`, and `RepositoryAdmin`.

**Used Mocking:** The tests use `unittest.mock.MagicMock` to simulate Django model objects. This ensures the tests are fast and do not require a database connection, following best practices for unit testing.

New test coverage status 
<img width="1122" height="165" alt="Screenshot 2025-07-24 211925" src="https://github.com/user-attachments/assets/6109f6bb-1659-4907-ac99-8df0c2229458" />


## Checklist

- [X] I've read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md).
- [X] I've run `make check-test` locally; all checks and tests passed.
