### PR TITLE
Fix #1792 Added a tooltip to show the entire number on hover

### DIFF
--- a/frontend/src/components/InfoBlock.tsx
+++ b/frontend/src/components/InfoBlock.tsx
@@ -2,6 +2,7 @@ import type { IconProp } from '@fortawesome/fontawesome-svg-core'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import millify from 'millify'
 import { pluralize } from 'utils/pluralize'
+import { Tooltip } from '@heroui/tooltip'
 
 const InfoBlock = ({
   className = '',
@@ -31,7 +32,15 @@ const InfoBlock = ({
       <div>
         <div className="text-sm md:text-base">
           {label && <div className="text-sm font-medium">{label}</div>}
-          {formattedValue}
+          <Tooltip
+            content={`${value.toLocaleString()} ${name}`}
+            delay={100}
+            closeDelay={100}
+            showArrow
+            placement="top"
+          >
+            {formattedValue}
+          </Tooltip>
         </div>
       </div>
     </div>

--- a/frontend/src/components/InfoItem.tsx
+++ b/frontend/src/components/InfoItem.tsx
@@ -2,6 +2,7 @@ import { IconDefinition } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import millify from 'millify'
 import { pluralize } from 'utils/pluralize'
+import { Tooltip } from '@heroui/tooltip'
 
 const InfoItem = ({
   icon,
@@ -25,7 +26,15 @@ const InfoItem = ({
         <FontAwesomeIcon icon={icon} className="mr-2 h-4 w-4" />
         {name}
       </span>
-      <span className="font-medium">{formattedValue}</span>
+      <Tooltip
+        content={`${value.toLocaleString()} ${name}`}
+        delay={100}
+        closeDelay={100}
+        showArrow
+        placement="top"
+      >
+        <span className="font-medium">{formattedValue}</span>
+      </Tooltip>
     </div>
   )
 }


### PR DESCRIPTION
Resolves #1792 

# Description
This PR enhances the user experience on the profile page by adding informative tooltips to the statistics and repository counter. Previously, these counters displayed rounded values. Users can now hover over each counter to view the full, non-rounded number.

## Key Changes
- Added tooltips to statistics and repository counters to show the exact full number on hover.
- Ensured tooltip styling is consistent with existing design elements.

## Checklist

- [x] I've read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md).
- [x] I've run `make check-test` locally; all checks and tests passed.
