### PR TITLE
Add structured data to Organization pages

### DIFF
--- a/frontend/src/app/organizations/[organizationKey]/layout.tsx
+++ b/frontend/src/app/organizations/[organizationKey]/layout.tsx
@@ -35,68 +35,57 @@ export async function generateMetadata({
 async function generateOrganizationStructuredData(organizationKey: string) {
   // https://developers.google.com/search/docs/appearance/structured-data/organization#structured-data-type-definitions
 
-  try {
-    const { data } = await apolloClient.query({
-      query: GET_ORGANIZATION_DATA,
-      variables: {
-        login: organizationKey,
+  const { data } = await apolloClient.query({
+    query: GET_ORGANIZATION_DATA,
+    variables: {
+      login: organizationKey,
+    },
+  })
+
+  const organization = data?.organization
+  if (!organization) return null
+
+  return {
+    '@context': 'https://schema.org' as const,
+    '@type': 'Organization' as const,
+    ...(organization.email && {
+      contactPoint: {
+        '@type': 'ContactPoint' as const,
+        email: organization.email,
       },
-    })
-
-    const organization = data?.organization
-    if (!organization) return null
-
-    const structuredData = {
-      '@context': 'https://schema.org' as const,
-      '@type': 'Organization' as const,
-      contactPoint: organization.email
-        ? {
-            '@type': 'ContactPoint' as const,
-            contactType: 'general inquiry',
-            email: organization.email,
-          }
-        : undefined,
-      description: organization.description,
-      email: organization.email,
-      foundingDate: organization.createdAt,
-      keywords: [
-        organization.name,
-        organization.login,
-        'application security',
-        'cybersecurity',
-        'open source',
-        'OWASP',
-      ].filter(Boolean),
-      location: organization.location
-        ? {
-            '@type': 'Place' as const,
-            name: organization.location,
-          }
-        : undefined,
-      logo: organization.avatarUrl
-        ? {
-            '@type': 'ImageObject' as const,
-            url: organization.avatarUrl,
-          }
-        : undefined,
+    }),
+    description: organization.description,
+    email: organization.email,
+    foundingDate: organization.createdAt,
+    keywords: [
+      organization.name,
+      organization.login,
+      'cybersecurity',
+      'open source',
+      'OWASP',
+    ].filter(Boolean),
+    ...(organization.location && {
+      location: {
+        '@type': 'Place' as const,
+        name: organization.location,
+      },
+    }),
+    ...(organization.avatarUrl && {
+      logo: {
+        '@type': 'ImageObject' as const,
+        url: organization.avatarUrl,
+      },
+    }),
+    ...(organization.login.toLowerCase() !== 'owasp' && {
       memberOf: {
         '@type': 'Organization' as const,
         name: 'OWASP Foundation',
         url: 'https://owasp.org',
       },
-      name: organization.name || organization.login,
-      sameAs: [organization.url].filter(Boolean),
-      url: `https://nest.owasp.org/organizations/${organizationKey}`,
-    }
-
-    // Remove undefined properties
-    Object.keys(structuredData).forEach(
-      (key) => structuredData[key] === undefined && delete structuredData[key]
-    )
-
-    return structuredData
-  } catch {
-    return null
+    }),
+    name: organization.name || organization.login,
+    sameAs: [organization.url].filter(Boolean),
+    url: `https://nest.owasp.org/organizations/${organizationKey}`,
   }
 }
 


### PR DESCRIPTION
Fixes #1768

Added structured data to organization profile pages: `/organizations/[organizationKey]`

Rich Results Test detects the data:
<img width="855" height="801" alt="image" src="https://github.com/user-attachments/assets/e36c5707-3738-43e5-bc87-d5a4043cfe36" />


