### PR TITLE
test: Add unit tests for ProjectsDashboardNavBar component

### DIFF
--- a/frontend/__tests__/unit/components/ProjectsDashboardNavBar.test.tsx
+++ b/frontend/__tests__/unit/components/ProjectsDashboardNavBar.test.tsx
@@ -46,13 +46,10 @@ describe('ProjectsDashboardNavbar', () => {
   })
 
   it('should not apply active state to any link when on an unrelated path', () => {
-    
     ;(nextNavigation.usePathname as jest.Mock).mockReturnValue('/some/other/unrelated/path')
 
-    
     const { getByRole } = render(<ProjectsDashboardNavBar />)
 
-    
     expect(getByRole('link', { name: /overview/i })).not.toHaveAttribute('aria-current', 'page')
     expect(getByRole('link', { name: /metrics/i })).not.toHaveAttribute('aria-current', 'page')
   })

--- a/frontend/__tests__/unit/components/ProjectsDashboardNavBar.test.tsx
+++ b/frontend/__tests__/unit/components/ProjectsDashboardNavBar.test.tsx
@@ -1,0 +1,47 @@
+import { render } from '@testing-library/react'
+import * as nextNavigation from 'next/navigation'
+import ProjectsDashboardNavBar from 'components/ProjectsDashboardNavBar'
+import '@testing-library/jest-dom'
+
+jest.mock('next/navigation', () => ({
+  usePathname: jest.fn(),
+}))
+
+describe('ProjectsDashboardNavbar', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should render both navigation links with correct hrefs', () => {
+    ;(nextNavigation.usePathname as jest.Mock).mockReturnValue('/')
+
+    const { getByRole } = render(<ProjectsDashboardNavBar />)
+
+    const overviewLink = getByRole('link', { name: /overview/i })
+    const metricsLink = getByRole('link', { name: /metrics/i })
+
+    expect(overviewLink).toBeInTheDocument()
+    expect(overviewLink).toHaveAttribute('href', '/projects/dashboard')
+
+    expect(metricsLink).toBeInTheDocument()
+    expect(metricsLink).toHaveAttribute('href', '/projects/dashboard/metrics')
+  })
+
+  it('should apply active state to the Overview link on the correct path', () => {
+    ;(nextNavigation.usePathname as jest.Mock).mockReturnValue('/projects/dashboard')
+
+    const { getByRole } = render(<ProjectsDashboardNavBar />)
+
+    expect(getByRole('link', { name: /overview/i })).toHaveAttribute('aria-current', 'page')
+    expect(getByRole('link', { name: /metrics/i })).not.toHaveAttribute('aria-current', 'page')
+  })
+
+  it('should apply active state to the metrics link on the correct path', () => {
+    ;(nextNavigation.usePathname as jest.Mock).mockReturnValue('/projects/dashboard/metrics')
+
+    const { getByRole } = render(<ProjectsDashboardNavBar />)
+
+    expect(getByRole('link', { name: /metrics/i })).toHaveAttribute('aria-current', 'page')
+    expect(getByRole('link', { name: /overview/i })).not.toHaveAttribute('aria-current', 'page')
+  })
+})

--- a/frontend/__tests__/unit/components/ProjectsDashboardNavBar.test.tsx
+++ b/frontend/__tests__/unit/components/ProjectsDashboardNavBar.test.tsx
@@ -44,4 +44,16 @@ describe('ProjectsDashboardNavbar', () => {
     expect(getByRole('link', { name: /metrics/i })).toHaveAttribute('aria-current', 'page')
     expect(getByRole('link', { name: /overview/i })).not.toHaveAttribute('aria-current', 'page')
   })
+
+  it('should not apply active state to any link when on an unrelated path', () => {
+    
+    ;(nextNavigation.usePathname as jest.Mock).mockReturnValue('/some/other/unrelated/path')
+
+    
+    const { getByRole } = render(<ProjectsDashboardNavBar />)
+
+    
+    expect(getByRole('link', { name: /overview/i })).not.toHaveAttribute('aria-current', 'page')
+    expect(getByRole('link', { name: /metrics/i })).not.toHaveAttribute('aria-current', 'page')
+  })
 })


### PR DESCRIPTION

Resolves #1921 

This pull request introduces comprehensive unit tests for the ProjectsDashboardNavBar component, which previously had no test coverage. The goal is to improve overall code quality and ensure the component's navigation logic is reliable.

Changes Made:
1. Added Test Suite: Created a new test file at frontend/__tests__/unit/components/ProjectsDashboardNavBar.test.tsx.

2. Test Coverage: The new tests verify the following key behaviors:

3. The component renders successfully without errors.

4. Both "Overview" and "Metrics" navigation links are displayed with the correct href attributes.

5. The correct link is marked as active with the aria-current="page" attribute based on the current URL path.

6. No links are marked as active when the URL path is unrelated.

- [x ] I've read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md).
- [x ] I've run `make check-test` locally; all checks and tests passed.
