### PR TITLE
Fix #2020: Mentioned Algolia in Search

### DIFF
--- a/frontend/src/components/MultiSearch.tsx
+++ b/frontend/src/components/MultiSearch.tsx
@@ -286,13 +286,13 @@ const MultiSearchBar: React.FC<MultiSearchBarProps> = ({
               </div>
             ))}
             <a
-              href="https://www.algolia.com"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center justify-center gap-2 bg-white py-2 text-gray-500 hover:text-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:hover:text-gray-200"
               aria-label="Search by Algolia (opens in a new tab)"
+              className="flex items-center justify-center gap-2 bg-white py-2 text-gray-500 hover:text-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:hover:text-gray-200"
+              href="https://www.algolia.com"
+              rel="noopener noreferrer"
+              target="_blank"
             >
-              <FontAwesomeIcon icon={faAlgolia} className="h-5 w-5" aria-hidden="true" />
+              <FontAwesomeIcon icon={faAlgolia} className="h-3 w-3" aria-hidden="true" />
               <span className="text-xs">Search by Algolia</span>
             </a>
           </div>


### PR DESCRIPTION
Resolves #2020 

# Description
Added Algolia logo followed by “Search by Algolia” in the search results to acknowledge their free search service.

<img width="1920" height="1200" alt="Screenshot from 2025-08-09 19-59-39" src="https://github.com/user-attachments/assets/1a718633-cb35-4b7c-ae54-f053c674c0e2" />

## Checklist

- [x] I've read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md).
- [x] I've run `make check-test` locally; all checks and tests passed.
