### PR TITLE
Fix #2036: Remove underline and transition from ToggleableList

### DIFF
--- a/frontend/__tests__/unit/components/ToggleableList.test.tsx
+++ b/frontend/__tests__/unit/components/ToggleableList.test.tsx
@@ -169,7 +169,7 @@ describe('ToggleableList', () => {
     expect(header).toHaveClass('mb-4', 'text-2xl', 'font-semibold')
   })
 
-  it('applies correct CSS to button items', () => {
+  it('applies correct CSS to button items (no underline, no transition, only hover background)', () => {
     const randomItems = ['React', 'Vue', 'Angular']
     render(<ToggleableList items={randomItems} label="Styled Buttons" />)
     const button = screen.getByText('React')
@@ -180,14 +180,16 @@ describe('ToggleableList', () => {
       'px-3',
       'py-1',
       'text-sm',
+      'hover:bg-gray-200',
+      'dark:border-gray-300',
+      'dark:hover:bg-gray-700'
+    )
+    expect(button).not.toHaveClass(
+      'hover:underline',
       'transition-all',
       'duration-200',
       'ease-in-out',
-      'hover:scale-105',
-      'hover:bg-gray-200',
-      'hover:underline',
-      'dark:border-gray-300',
-      'dark:hover:bg-gray-700'
+      'hover:scale-105'
     )
   })
 })

--- a/frontend/src/components/ToggleableList.tsx
+++ b/frontend/src/components/ToggleableList.tsx
@@ -37,7 +37,7 @@ const ToggleableList = ({
         {(showAll ? items : items.slice(0, limit)).map((item, index) => (
           <button
             key={index}
-            className="rounded-lg border border-gray-400 px-3 py-1 text-sm transition-all duration-200 ease-in-out hover:scale-105 hover:bg-gray-200 hover:underline dark:border-gray-300 dark:hover:bg-gray-700"
+            className="rounded-lg border border-gray-400 px-3 py-1 text-sm hover:bg-gray-200 dark:border-gray-300 dark:hover:bg-gray-700"
             onClick={() => handleButtonClick({ item })}
           >
             {item}


### PR DESCRIPTION
Resolves #2036 

# Description:
This PRs changes the ToggleableList component so that buttons no longer show an underline or transition effects when hovered only the background color changes and adds corresponding tests to ensure this behavior.

## Checklist

- [x] I've read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md).
- [x] I've run `make check-test` locally; all checks and tests passed.
