### PR TITLE
Fix #2156: Address SonarQube security hotspots

### DIFF
--- a/.github/workflows/run-ci-cd.yaml
+++ b/.github/workflows/run-ci-cd.yaml
@@ -481,7 +481,7 @@ jobs:
           # Cache
           umask 077
           cat > .env.cache <<EOF
-          REDIS_PASSWORD=$DJANGO_REDIS_PASSWORD"
+          REDIS_PASSWORD=$DJANGO_REDIS_PASSWORD
           EOF
 
           # Database


### PR DESCRIPTION
Resolves #2156 

# Description:
This PR updates the GitHub Actions workflow to avoid expanding secrets directly in run blocks. Environment variables are now set using the env: block

## Checklist
- [x] I've read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md).
- [x] I've run `make check-test` locally; all checks and tests passed.