### PR TITLE
Feature/migrate scraper to GitHub md files

### DIFF
--- a/backend/apps/owasp/management/commands/owasp_scrape_projects.py
+++ b/backend/apps/owasp/management/commands/owasp_scrape_projects.py
@@ -46,18 +46,20 @@ class Command(BaseCommand):
             prefix = f"{idx + offset + 1} of {active_projects_count}"
             print(f"{prefix:<10} {project.owasp_url}")
 
+            project.leaders_raw = project.get_leaders()
+
             scraper = OwaspScraper(project.owasp_url)
             if scraper.page_tree is None:
                 project.deactivate()
                 continue
 
-            project.audience = scraper.get_audience()
+            project.audience = project.get_audience()
 
             # Get GitHub URLs.
             scraped_urls = sorted(
                 {
                     repository_url
-                    for url in set(scraper.get_urls(domain="github.com"))
+                    for url in set(project.get_urls(domain="github.com"))
                     if (repository_url := normalize_url(project.get_related_url(url)))
                     and repository_url not in {project.github_url, project.owasp_url}
                 }

--- a/backend/tests/apps/owasp/management/commands/owasp_scrape_projects_test.py
+++ b/backend/tests/apps/owasp/management/commands/owasp_scrape_projects_test.py
@@ -33,8 +33,8 @@ class TestOwaspScrapeProjects:
         """Test audience validation logic."""
         mock_scraper = mock.Mock(spec=OwaspScraper)
         mock_scraper.page_tree = True
-        mock_scraper.get_urls.return_value = []
-        mock_scraper.get_audience.return_value = ["builder", "breaker", "defender"]
+        mock_project.get_urls.return_value = []
+        mock_project.get_audience.return_value = ["builder", "breaker", "defender"]
 
         mock_active_projects = mock.MagicMock()
         mock_active_projects.__iter__.return_value = iter([mock_project])
@@ -71,12 +71,12 @@ class TestOwaspScrapeProjects:
     def test_urls(self, mock_github, mock_bulk_save, command, mock_project, offset, project_count):
         """Tests the existing URL scraping logic, ensuring it still passes."""
         mock_scraper = mock.Mock(spec=OwaspScraper)
-        mock_scraper.get_urls.return_value = [
+        mock_project.get_urls.return_value = [
             "https://github.com/org/repo1",
             "https://github.com/org/repo2",
             "https://invalid.com/repo3",
         ]
-        mock_scraper.get_audience.return_value = []
+        mock_project.get_audience.return_value = []
         mock_scraper.verify_url.side_effect = lambda url: None if "invalid" in url else url
         mock_scraper.page_tree = True
 


### PR DESCRIPTION
<!-- Thanks for contributing to OWASP Nest!-->
Resolves #2088

## Proposed change
migrate scraper logic of `audience` and `urls` to Github .md files

## Checklist

- [x] I've read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md).
- [x] I've run `make check-test` locally; all checks and tests passed.
