### PR TITLE
Move Sign In to mobile side nav; hide in header on small screens

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -2,6 +2,7 @@
 import { faHeart as faRegularHeart } from '@fortawesome/free-regular-svg-icons'
 import { faStar as faRegularStar } from '@fortawesome/free-regular-svg-icons'
 import { faBars, faTimes } from '@fortawesome/free-solid-svg-icons'
+import { faGithub } from '@fortawesome/free-brands-svg-icons'
 import { faHeart as faSolidHeart } from '@fortawesome/free-solid-svg-icons'
 import { faStar as faSolidStar } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -16,11 +17,14 @@ import ModeToggle from 'components/ModeToggle'
 import NavButton from 'components/NavButton'
 import NavDropdown from 'components/NavDropDown'
 import UserMenu from 'components/UserMenu'
+import { signIn } from 'next-auth/react'
+import { useDjangoSession } from 'hooks/useDjangoSession'
 
 export default function Header({ isGitHubAuthEnabled }: { readonly isGitHubAuthEnabled: boolean }) {
   const pathname = usePathname()
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const toggleMobileMenu = () => setMobileMenuOpen(!mobileMenuOpen)
+  const { status } = useDjangoSession()
 
   useEffect(() => {
     const handleResize = () => {
@@ -224,6 +228,15 @@ export default function Header({ isGitHubAuthEnabled }: { readonly isGitHubAuthE
           </div>
 
           <div className="flex flex-col gap-y-2">
+            {isGitHubAuthEnabled && status === 'unauthenticated' && (
+              <button
+                onClick={() => signIn('github', { callbackUrl: '/', prompt: 'login' })}
+                className="group focus-visible:ring-ring relative flex h-10 cursor-pointer items-center justify-center gap-2 overflow-hidden rounded-md bg-[#87a1bc] p-4 text-sm font-medium whitespace-pre text-black hover:ring-1 hover:ring-[#b0c7de] hover:ring-offset-0 focus-visible:ring-1 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50 md:flex dark:bg-slate-900 dark:text-white dark:hover:bg-slate-900/90 dark:hover:ring-[#46576b]"
+              >
+                <FontAwesomeIcon icon={faGithub} />
+                <span>Sign In</span>
+              </button>
+            )}
             <NavButton
               href="https://github.com/OWASP/Nest"
               defaultIcon={faRegularStar}

--- a/frontend/src/components/UserMenu.tsx
+++ b/frontend/src/components/UserMenu.tsx
@@ -47,7 +47,7 @@ export default function UserMenu({
     return (
       <button
         onClick={() => signIn('github', { callbackUrl: '/', prompt: 'login' })}
-        className="group relative flex h-10 items-center justify-center gap-2 rounded-md bg-[#87a1bc] p-4 text-sm font-medium text-black hover:ring-1 hover:ring-[#b0c7de] dark:bg-slate-900 dark:text-white dark:hover:bg-slate-900/90 dark:hover:ring-[#46576b]"
+        className="group relative flex h-10 items-center justify-center gap-2 rounded-md bg-[#87a1bc] p-4 text-sm font-medium text-black hover:ring-1 hover:ring-[#b0c7de] max-md:hidden dark:bg-slate-900 dark:text-white dark:hover:bg-slate-900/90 dark:hover:ring-[#46576b]"
       >
         <FontAwesomeIcon icon={faGithub} />
         Sign In


### PR DESCRIPTION
Title: Move Sign In to mobile side nav; hide in header on small screens

Summary
- Hides the header “Sign In” button on small screens.
- Adds a matching “Sign In” button to the mobile side nav (top of the action buttons) when unauthenticated and GitHub auth is enabled.
- Preserves desktop behavior; mobile UX aligns with design intent.

Changes
- frontend/src/components/UserMenu.tsx
  - Add `max-md:hidden` to the unauthenticated header sign-in button so it does not appear on small viewports.
- frontend/src/components/Header.tsx
  - Import `faGithub` and `signIn`.
  - Use `useDjangoSession()` to detect unauthenticated state.
  - Render a GitHub “Sign In” button at the top of the side nav buttons on mobile.

Rationale
- On mobile, user actions live in the side nav; the sign-in entry should be consistently placed with other actions.
- Reduces header clutter on small screens while keeping sign-in quickly accessible.

Testing / Verification
1) Unauthenticated, small viewport (mobile):
   - Open the hamburger menu: “Sign In” appears at the top of the button stack.
   - The header no longer shows “Sign In”.
2) Unauthenticated, desktop viewport:
   - Header still shows “Sign In” on the right side, unchanged.
3) Authenticated, any viewport:
   - User avatar/user menu renders as before; mobile side nav sign-in button no longer appears.

Notes
- Styling matches existing action buttons to maintain visual consistency.
- No server/API changes.

Closes: #2226

