### PR TITLE
Fix: map tooltip color in dark mode

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -215,8 +215,8 @@
   }
 
   .dark .leaflet-popup-content-wrapper {
-    background-color: #2c3e50;
-    color: white;
+    background-color: #2c3e50 !important;
+    color: white !important;
   }
 
   .dark .leaflet-popup-close-button span {
@@ -283,7 +283,7 @@
   }
 
   .dark .leaflet-popup-tip {
-    background-color: #2c3e50;
+    background-color: #2c3e50 !important;
   }
 
   .leaflet-marker-icon {


### PR DESCRIPTION
<!-- Thanks for contributing to OWASP Nest!-->

## Proposed change
Fix map tooltip color in dark mode

<!-- Don't forget to link your PR to an existing issue if any.-->
Resolves #2168 

<!-- Describe the big picture of your changes.-->
I have modified the global.css file to give higher precedence to **.dark .leaflet-popup-content-wrapper** and **.dark .leaflet-popup-tip** classes' style rules so as to override the conflicting style rules.

## Checklist

- [x] I've read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md).
- [x] I've run `make check-test` locally; all checks and tests passed.
