### PR TITLE
fix: align footer to bottom

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -71,12 +71,14 @@ export default function RootLayout({
         style={{ minHeight: '100vh' }}
       >
         <Providers>
-          <AutoScrollToTop />
-          <Header isGitHubAuthEnabled={IS_GITHUB_AUTH_ENABLED} />
-          <BreadCrumbs />
-          {children}
-          <Footer />
-          <ScrollToTop />
+          <div className="flex min-h-screen flex-col">
+            <AutoScrollToTop />
+            <Header isGitHubAuthEnabled={IS_GITHUB_AUTH_ENABLED} />
+            <BreadCrumbs />
+            <main className="flex flex-1 flex-col justify-center">{children}</main>
+            <Footer />
+            <ScrollToTop />
+          </div>
         </Providers>
       </body>
       <GoogleAnalytics gaId={GTM_ID} />


### PR DESCRIPTION
<!-- Thanks for contributing to OWASP Nest!-->

## Proposed change

<!-- Don't forget to link your PR to an existing issue if any.-->
Resolves #2033 

<!-- Describe the big picture of your changes.-->
Footer sticks to bottom when screen height is over 1100px

<img width="908" height="752" alt="Screenshot 2025-09-11 022822" src="https://github.com/user-attachments/assets/14c352a2-ff9d-4b23-b29f-898dffd01692" />


## Checklist

- [x] I've read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md).
- [x] I've run `make check-test` locally; all checks and tests passed.
