### PR TITLE
fix: improve Sort By dropdown styling consistency

### DIFF
--- a/frontend/src/components/SortBy.tsx
+++ b/frontend/src/components/SortBy.tsx
@@ -15,17 +15,21 @@ const SortBy = ({
   return (
     <div className="flex items-center gap-2">
       {/* Sort Attribute Dropdown */}
-      <div className="inline-flex h-12 items-center rounded-lg bg-gray-200 dark:bg-[#323232]">
+      <div className="inline-flex h-12 items-center rounded-lg border border-gray-300 bg-gray-100 pl-3 shadow-sm transition-all duration-200 hover:shadow-md dark:border-gray-600 dark:bg-[#323232]">
         <Select
           className=""
           labelPlacement="outside-left"
           size="md"
           label="Sort By :"
           classNames={{
-            label:
-              'font-small text-sm text-gray-600 hover:cursor-pointer dark:text-gray-300 pl-[1.4rem] w-auto',
-            trigger: 'bg-gray-200 dark:bg-[#323232] pl-0 text-nowrap w-32',
-            popoverContent: 'text-md min-w-36 dark:bg-[#323232] rounded-none p-0',
+            label: 'font-medium text-sm text-gray-700 dark:text-gray-300 w-auto select-none pe-0',
+            trigger:
+              'bg-transparent data-[hover=true]:bg-transparent focus:outline-none focus:ring-0 border-none shadow-none text-nowrap w-32 min-h-8 h-8 text-sm font-medium text-gray-800 dark:text-gray-200 hover:text-gray-900 dark:hover:text-gray-100 transition-all duration-0',
+            value: 'text-gray-800 dark:text-gray-200 font-medium',
+            selectorIcon: 'text-gray-500 dark:text-gray-400 transition-transform duration-200',
+            popoverContent:
+              'bg-white dark:bg-[#2a2a2a] border border-gray-200 dark:border-gray-600 rounded-md shadow-lg min-w-36 p-1 focus:outline-none',
+            listbox: 'p-0 focus:outline-none',
           }}
           selectedKeys={sortOptions
             .filter((item: { key: string; label: string }) => item.key === selectedSortOption)
@@ -38,7 +42,7 @@ const SortBy = ({
             <SelectItem
               key={option.key}
               classNames={{
-                base: 'text-sm hover:bg-[#D1DBE6] dark:hover:bg-[#454545] rounded-none px-3 py-0.5',
+                base: 'text-sm text-gray-700 dark:text-gray-300 hover:bg-transparent dark:hover:bg-transparent focus:bg-gray-100 dark:focus:bg-[#404040] focus:outline-none rounded-sm px-3 py-2 cursor-pointer transition-colors duration-150 data-[selected=true]:bg-blue-50 dark:data-[selected=true]:bg-blue-900/20 data-[selected=true]:text-blue-600 dark:data-[selected=true]:text-blue-400 data-[focus=true]:bg-gray-100 dark:data-[focus=true]:bg-[#404040]',
               }}
             >
               {option.label}
@@ -58,17 +62,17 @@ const SortBy = ({
         >
           <button
             onClick={() => onOrderChange(selectedOrder === 'asc' ? 'desc' : 'asc')}
-            className="inline-flex h-9 w-9 items-center justify-center rounded-lg bg-gray-200 p-0 shadow-xs hover:bg-gray-300 dark:bg-[#323232] dark:text-gray-300 dark:hover:bg-[#454545]"
+            className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-gray-300 bg-gray-100 p-0 shadow-sm transition-all duration-200 hover:bg-gray-200 hover:shadow-md focus:ring-2 focus:ring-gray-300 focus:ring-offset-1 focus:outline-none dark:border-gray-600 dark:bg-[#323232] dark:hover:bg-[#404040] dark:focus:ring-gray-500"
           >
             {selectedOrder === 'asc' ? (
               <FontAwesomeIcon
                 icon={faArrowUpWideShort}
-                className="h-4 w-4 text-gray-600 dark:text-gray-200"
+                className="h-4 w-4 text-gray-600 dark:text-gray-300"
               />
             ) : (
               <FontAwesomeIcon
                 icon={faArrowDownWideShort}
-                className="h-4 w-4 text-gray-600 dark:text-gray-200"
+                className="h-4 w-4 text-gray-600 dark:text-gray-300"
               />
             )}
           </button>


### PR DESCRIPTION
- Remove blue outline and inconsistent hover backgrounds
- Add proper focus/active states styles to match the design system
- Improve light/dark mode theme integration
- Fix trigger background blending issues


Fixes #1372

Before Changes:
| Light Mode | Dark Mode |
|--------|--------|
| <img width="348" height="223" alt="image" src="https://github.com/user-attachments/assets/62801042-4b48-401f-9fd8-80fff72f442d" /> | <img width="327" height="225" alt="image" src="https://github.com/user-attachments/assets/f44b1ef6-b21a-43bd-acc6-5039a265a9b5" /> |
| <img width="351" height="274" alt="image" src="https://github.com/user-attachments/assets/598593f5-375d-4d00-a808-3f41b42d1378" /> | <img width="310" height="263" alt="image" src="https://github.com/user-attachments/assets/c4f2ae4e-f5f5-4f93-a38e-6d1a18d39c0f" /> | 

After Changes:
| Light Mode | Dark Mode |
|--------|--------|
| <img width="309" height="230" alt="image" src="https://github.com/user-attachments/assets/f165c8ef-84fa-4d65-a97d-1759dc249863" /> | <img width="355" height="214" alt="image" src="https://github.com/user-attachments/assets/24b08842-9fc5-4fbb-b121-9a4fce2507ec" /> |
| <img width="351" height="328" alt="image" src="https://github.com/user-attachments/assets/6676036b-b8cf-4561-add3-6678b19c2873" /> | <img width="339" height="329" alt="image" src="https://github.com/user-attachments/assets/a9630e6e-90b3-4c89-aa53-863135b1d628" /> | 