### PR TITLE
Fix .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-**/__pycache__
 .ash_history
 .bash_history
 .cache
@@ -17,6 +16,7 @@
 .vscode
 *.log
 *.pem
+**/__pycache__
 backend/data
 backend/staticfiles
 build


### PR DESCRIPTION
<!-- Thanks for contributing to OWASP Nest!-->

## Proposed change

<!-- Don't forget to link your PR to an existing issue if any.-->
Resolves #2364

<!-- Describe the big picture of your changes.-->
This PR fixes a minor .dockerignore misconfiguration (#2364). I added `**/` to the pattern `__pycache__` in the .dockerignore file to recursively ignore `__pycache__`. Since I am not very familiar with this project, I left other patterns as they are. Please let me know (or directly update my PR) if any other lines should include `**/` as well.

## Checklist

- [x] I've read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md).
- [x] I've run `make check-test` locally; all checks and tests passed.
