### PR TITLE
fix: Prevent publishing blog posts that have future publish date

### DIFF
--- a/backend/apps/owasp/models/post.py
+++ b/backend/apps/owasp/models/post.py
@@ -3,8 +3,8 @@
 from datetime import UTC, datetime
 
 from django.db import models
+from django.utils import timezone
 from django.utils.dateparse import parse_datetime
-from django.utils.timezone import now
 
 from apps.common.models import BulkSaveModel, TimestampedModel
 
@@ -37,7 +37,11 @@ class Post(BulkSaveModel, TimestampedModel):
     @staticmethod
     def recent_posts():
         """Get recent posts."""
-        return Post.objects.filter(published_at__lte=now()).order_by("-published_at")
+        return Post.objects.filter(
+            published_at__lte=timezone.now(),
+        ).order_by(
+            "-published_at",
+        )
 
     @staticmethod
     def update_data(data, *, save: bool = True) -> "Post":


### PR DESCRIPTION
<!-- Thanks for contributing to OWASP Nest!-->

## Proposed change

<!-- Don't forget to link your PR to an existing issue if any.-->
Resolves #2327 

<!-- Describe the big picture of your changes.-->
Update recent_posts method to filter posts by publish date and order by most recent

This PR updates the recent_posts() static method in the Post model to ensure only posts published up to the current time are returned, ordered by most recent first.

## Checklist

- [x] I've read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md).
- [x] I've run `make check-test` locally; all checks and tests passed.
