### PR TITLE
feat: rename RepositoriesCard to RepositoryCard and add cursor pointe…

### DIFF
--- a/frontend/__tests__/unit/components/CardDetailsPage.test.tsx
+++ b/frontend/__tests__/unit/components/CardDetailsPage.test.tsx
@@ -252,7 +252,7 @@ jest.mock('components/RecentReleases', () => ({
   ),
 }))
 
-jest.mock('components/RepositoriesCard', () => ({
+jest.mock('components/RepositoryCard', () => ({
   __esModule: true,
   default: ({
     repositories,

--- a/frontend/__tests__/unit/components/RepositoryCard.test.tsx
+++ b/frontend/__tests__/unit/components/RepositoryCard.test.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 import { render } from 'wrappers/testUtil'
 import type { Organization } from 'types/organization'
 import type { RepositoryCardProps } from 'types/project'
-import RepositoriesCard from 'components/RepositoriesCard'
+import RepositoryCard from 'components/RepositoryCard'
 
 jest.mock('next/navigation', () => ({
   useRouter: jest.fn(),
@@ -40,7 +40,7 @@ jest.mock('components/InfoItem', () => {
 const mockPush = jest.fn()
 const mockUseRouter = useRouter as jest.Mock
 
-describe('RepositoriesCard', () => {
+describe('RepositoryCard', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockUseRouter.mockReturnValue({
@@ -74,14 +74,14 @@ describe('RepositoriesCard', () => {
   })
 
   it('renders without crashing with empty repositories', () => {
-    render(<RepositoriesCard repositories={[]} />)
+    render(<RepositoryCard repositories={[]} />)
     expect(screen.queryByTestId('show-more-button')).not.toBeInTheDocument()
   })
 
   it('shows first 4 repositories initially when there are more than 4', () => {
     const repositories = Array.from({ length: 6 }, (_, i) => createMockRepository(i))
 
-    render(<RepositoriesCard repositories={repositories} />)
+    render(<RepositoryCard repositories={repositories} />)
 
     expect(screen.getByText('Repository 0')).toBeInTheDocument()
     expect(screen.getByText('Repository 3')).toBeInTheDocument()
@@ -92,7 +92,7 @@ describe('RepositoriesCard', () => {
   it('shows all repositories when there are 4 or fewer', () => {
     const repositories = Array.from({ length: 3 }, (_, i) => createMockRepository(i))
 
-    render(<RepositoriesCard repositories={repositories} />)
+    render(<RepositoryCard repositories={repositories} />)
 
     expect(screen.getByText('Repository 0')).toBeInTheDocument()
     expect(screen.getByText('Repository 1')).toBeInTheDocument()
@@ -102,7 +102,7 @@ describe('RepositoriesCard', () => {
   it('displays ShowMoreButton when there are more than 4 repositories', () => {
     const repositories = Array.from({ length: 6 }, (_, i) => createMockRepository(i))
 
-    render(<RepositoriesCard repositories={repositories} />)
+    render(<RepositoryCard repositories={repositories} />)
 
     expect(screen.getByTestId('show-more-button')).toBeInTheDocument()
   })
@@ -110,7 +110,7 @@ describe('RepositoriesCard', () => {
   it('does not display ShowMoreButton when there are 4 or fewer repositories', () => {
     const repositories = Array.from({ length: 4 }, (_, i) => createMockRepository(i))
 
-    render(<RepositoriesCard repositories={repositories} />)
+    render(<RepositoryCard repositories={repositories} />)
 
     expect(screen.queryByTestId('show-more-button')).not.toBeInTheDocument()
   })
@@ -118,7 +118,7 @@ describe('RepositoriesCard', () => {
   it('toggles between showing 4 and all repositories when clicked', () => {
     const repositories = Array.from({ length: 6 }, (_, i) => createMockRepository(i))
 
-    render(<RepositoriesCard repositories={repositories} />)
+    render(<RepositoryCard repositories={repositories} />)
 
     // Initially shows first 4
     expect(screen.getByText('Repository 0')).toBeInTheDocument()
@@ -142,7 +142,7 @@ describe('RepositoriesCard', () => {
   it('renders repository items with correct information', () => {
     const repositories = [createMockRepository(0)]
 
-    render(<RepositoriesCard repositories={repositories} />)
+    render(<RepositoryCard repositories={repositories} />)
 
     expect(screen.getByText('Repository 0')).toBeInTheDocument()
     expect(screen.getByTestId('info-item-Star')).toBeInTheDocument()
@@ -154,7 +154,7 @@ describe('RepositoriesCard', () => {
   it('navigates to correct URL when repository item is clicked', () => {
     const repositories = [createMockRepository(0)]
 
-    render(<RepositoriesCard repositories={repositories} />)
+    render(<RepositoryCard repositories={repositories} />)
 
     const repositoryButton = screen.getByText('Repository 0')
     fireEvent.click(repositoryButton)
@@ -174,7 +174,27 @@ describe('RepositoriesCard', () => {
       url: 'https://github.com/test/repo',
     }
 
-    expect(() => render(<RepositoriesCard repositories={[repository]} />)).not.toThrow()
+    expect(() => render(<RepositoryCard repositories={[repository]} />)).not.toThrow()
+  })
+
+  it('repository title button has cursor-pointer class', () => {
+    const repositories = [createMockRepository(0)]
+
+    const { container } = render(<RepositoryCard repositories={repositories} />)
+
+    const button = container.querySelector('button.cursor-pointer')
+    expect(button).toBeInTheDocument()
+    expect(button).toHaveClass('cursor-pointer')
+  })
+
+  it('repository title is rendered as a button element', () => {
+    const repositories = [createMockRepository(0)]
+
+    render(<RepositoryCard repositories={repositories} />)
+
+    const repositoryButton = screen.getByText('Repository 0').closest('button')
+    expect(repositoryButton).toBeInTheDocument()
+    expect(repositoryButton?.tagName).toBe('BUTTON')
   })
 
   describe('Archived Badge on Repository Cards', () => {
@@ -184,7 +204,7 @@ describe('RepositoriesCard', () => {
         isArchived: true,
       }
 
-      render(<RepositoriesCard repositories={[archivedRepo]} />)
+      render(<RepositoryCard repositories={[archivedRepo]} />)
 
       expect(screen.getByText('Archived')).toBeInTheDocument()
     })
@@ -195,7 +215,7 @@ describe('RepositoriesCard', () => {
         isArchived: false,
       }
 
-      render(<RepositoriesCard repositories={[activeRepo]} />)
+      render(<RepositoryCard repositories={[activeRepo]} />)
 
       expect(screen.queryByText('Archived')).not.toBeInTheDocument()
     })
@@ -205,7 +225,7 @@ describe('RepositoriesCard', () => {
         ...createMockRepository(0),
       }
 
-      render(<RepositoriesCard repositories={[repo]} />)
+      render(<RepositoryCard repositories={[repo]} />)
 
       expect(screen.queryByText('Archived')).not.toBeInTheDocument()
     })
@@ -218,7 +238,7 @@ describe('RepositoriesCard', () => {
         { ...createMockRepository(3) },
       ]
 
-      render(<RepositoriesCard repositories={repositories} />)
+      render(<RepositoryCard repositories={repositories} />)
 
       const badges = screen.getAllByText('Archived')
       expect(badges).toHaveLength(2)
@@ -230,7 +250,7 @@ describe('RepositoriesCard', () => {
         isArchived: true,
       }
 
-      render(<RepositoriesCard repositories={[archivedRepo]} />)
+      render(<RepositoryCard repositories={[archivedRepo]} />)
 
       const badge = screen.getByText('Archived')
       expect(badge).toHaveClass('px-2', 'py-1', 'text-xs')
@@ -242,7 +262,7 @@ describe('RepositoriesCard', () => {
         isArchived: true,
       }
 
-      render(<RepositoriesCard repositories={[archivedRepo]} />)
+      render(<RepositoryCard repositories={[archivedRepo]} />)
 
       const badge = screen.getByText('Archived')
       const icon = badge.querySelector('svg')
@@ -255,7 +275,7 @@ describe('RepositoriesCard', () => {
         isArchived: true,
       }
 
-      render(<RepositoriesCard repositories={[archivedRepo]} />)
+      render(<RepositoryCard repositories={[archivedRepo]} />)
 
       expect(screen.getByText('Repository 0')).toBeInTheDocument()
       expect(screen.getByTestId('info-item-Star')).toBeInTheDocument()
@@ -269,7 +289,7 @@ describe('RepositoriesCard', () => {
         isArchived: true,
       }
 
-      const { container } = render(<RepositoriesCard repositories={[archivedRepo]} />)
+      const { container } = render(<RepositoryCard repositories={[archivedRepo]} />)
 
       const headerContainer = container.querySelector('.flex.items-start.justify-between')
       expect(headerContainer).toBeInTheDocument()
@@ -281,7 +301,7 @@ describe('RepositoriesCard', () => {
         isArchived: null,
       }
 
-      render(<RepositoriesCard repositories={[repo]} />)
+      render(<RepositoryCard repositories={[repo]} />)
 
       expect(screen.queryByText('Archived')).not.toBeInTheDocument()
     })
@@ -292,7 +312,7 @@ describe('RepositoriesCard', () => {
         isArchived: i % 2 === 0,
       }))
 
-      render(<RepositoriesCard repositories={repositories} />)
+      render(<RepositoryCard repositories={repositories} />)
 
       expect(screen.getAllByText('Archived')).toHaveLength(2)
 
@@ -311,7 +331,7 @@ describe('RepositoriesCard', () => {
         isArchived: true,
       }
 
-      render(<RepositoriesCard repositories={[archivedRepo]} />)
+      render(<RepositoryCard repositories={[archivedRepo]} />)
 
       const repositoryButton = screen.getByText('Repository 0')
       fireEvent.click(repositoryButton)

--- a/frontend/src/components/CardDetailsPage.tsx
+++ b/frontend/src/components/CardDetailsPage.tsx
@@ -29,7 +29,7 @@ import ProgramActions from 'components/ProgramActions'
 import RecentIssues from 'components/RecentIssues'
 import RecentPullRequests from 'components/RecentPullRequests'
 import RecentReleases from 'components/RecentReleases'
-import RepositoriesCard from 'components/RepositoriesCard'
+import RepositoryCard from 'components/RepositoryCard'
 import SecondaryCard from 'components/SecondaryCard'
 import SponsorCard from 'components/SponsorCard'
 import StatusBadge from 'components/StatusBadge'
@@ -279,7 +279,7 @@ const DetailsCard = ({
         {(type === 'project' || type === 'user' || type === 'organization') &&
           repositories.length > 0 && (
             <SecondaryCard icon={faFolderOpen} title={<AnchorTitle title="Repositories" />}>
-              <RepositoriesCard maxInitialDisplay={4} repositories={repositories} />
+              <RepositoryCard maxInitialDisplay={4} repositories={repositories} />
             </SecondaryCard>
           )}
         {type === 'program' && modules.length > 0 && (

--- a/frontend/src/components/RepositoryCard.tsx
+++ b/frontend/src/components/RepositoryCard.tsx
@@ -2,13 +2,13 @@ import { faCodeFork, faStar, faUsers, faExclamationCircle } from '@fortawesome/f
 import { useRouter } from 'next/navigation'
 import type React from 'react'
 import { useState } from 'react'
-import type { RepositoriesCardProps, RepositoryCardProps } from 'types/project'
+import type { RepositoryCardListProps, RepositoryCardProps } from 'types/project'
 import InfoItem from 'components/InfoItem'
 import ShowMoreButton from 'components/ShowMoreButton'
 import StatusBadge from 'components/StatusBadge'
 import { TruncatedText } from 'components/TruncatedText'
 
-const RepositoriesCard: React.FC<RepositoriesCardProps> = ({
+const RepositoryCard: React.FC<RepositoryCardListProps> = ({
   maxInitialDisplay = 4,
   repositories,
 }) => {
@@ -42,7 +42,7 @@ const RepositoryItem = ({ details }: { details: RepositoryCardProps }) => {
       <div className="flex items-start justify-between gap-2">
         <button
           onClick={handleClick}
-          className="min-w-0 flex-1 text-start font-semibold text-blue-400 hover:underline"
+          className="min-w-0 flex-1 cursor-pointer text-start font-semibold text-blue-400 hover:underline"
         >
           <TruncatedText text={details?.name} />
         </button>
@@ -73,4 +73,4 @@ const RepositoryItem = ({ details }: { details: RepositoryCardProps }) => {
   )
 }
 
-export default RepositoriesCard
+export default RepositoryCard

--- a/frontend/src/types/project.ts
+++ b/frontend/src/types/project.ts
@@ -46,7 +46,7 @@ export type Project = {
   recentMilestones?: Milestone[]
 }
 
-export type RepositoriesCardProps = {
+export type RepositoryCardListProps = {
   maxInitialDisplay?: number
   repositories?: RepositoryCardProps[]
 }


### PR DESCRIPTION
## Proposed change

- Resolves #2447 

Renamed the `RepositoriesCard` component to `RepositoryCard` (singular) and added `cursor-pointer` class to repository title buttons as requested in the issue.

**Changes:**
- Renamed component file: `RepositoriesCard.tsx` → `RepositoryCard.tsx`
- Renamed component export: `RepositoriesCard` → `RepositoryCard`
- Added `cursor-pointer` Tailwind class to repository title button element
- Renamed type `RepositoryItemProps` → `RepositoryCardProps` for consistency with component naming
- Updated all component imports in `CardDetailsPage.tsx` and `page.tsx`
- Renamed test file: `RepositoriesCard.test.tsx` → `RepositoryCard.test.tsx`
- Added cursor pointer validation tests

**Files modified:** 9 files (5 modified, 2 renamed, 2 created as part of rename)

The cursor now changes to a pointer when hovering over repository titles, improving UX as requested.

## Checklist

- [x] I've read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md).
- [x] I've run `make check-test` locally; all checks and tests passed.



https://github.com/user-attachments/assets/04b40483-d0c0-4160-ae7b-5af9ea09feee

