### PR TITLE
Fix: Prevent Accidental Map Zooming While Scrolling on Landing Page

### DIFF
--- a/frontend/__tests__/unit/components/ChapterMap.test.tsx
+++ b/frontend/__tests__/unit/components/ChapterMap.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react'
+import { render, fireEvent } from '@testing-library/react'
 import { Chapter } from 'types/chapter'
 import ChapterMap from 'components/ChapterMap'
 
@@ -6,6 +6,11 @@ const mockMap = {
   setView: jest.fn().mockReturnThis(),
   addLayer: jest.fn().mockReturnThis(),
   fitBounds: jest.fn().mockReturnThis(),
+  on: jest.fn().mockReturnThis(),
+  scrollWheelZoom: {
+    enable: jest.fn(),
+    disable: jest.fn(),
+  },
 }
 
 const mockMarker = {
@@ -95,12 +100,16 @@ describe('ChapterMap', () => {
 
   describe('rendering', () => {
     it('renders the map container with correct id and style', () => {
-      render(<ChapterMap {...defaultProps} />)
+      const { container } = render(<ChapterMap {...defaultProps} />)
 
       const mapContainer = document.getElementById('chapter-map')
       expect(mapContainer).toBeInTheDocument()
       expect(mapContainer).toHaveAttribute('id', 'chapter-map')
-      expect(mapContainer).toHaveStyle('width: 100%; height: 400px;')
+      expect(mapContainer).toHaveClass('h-full', 'w-full')
+
+      // Check that the parent container has the correct styles applied
+      const parentContainer = container.firstChild as HTMLElement
+      expect(parentContainer).toHaveClass('relative')
     })
 
     it('renders with empty data without crashing', () => {
@@ -123,6 +132,7 @@ describe('ChapterMap', () => {
           [90, 180],
         ],
         maxBoundsViscosity: 1.0,
+        scrollWheelZoom: false,
       })
       expect(mockMap.setView).toHaveBeenCalledWith([20, 0], 2)
     })
@@ -149,6 +159,12 @@ describe('ChapterMap', () => {
       render(<ChapterMap {...defaultProps} />)
       expect(L.markerClusterGroup).toHaveBeenCalled()
       expect(mockMap.addLayer).toHaveBeenCalledWith(mockMarkerClusterGroup)
+    })
+
+    it('sets up event listeners for map interaction', () => {
+      render(<ChapterMap {...defaultProps} />)
+      expect(mockMap.on).toHaveBeenCalledWith('click', expect.any(Function))
+      expect(mockMap.on).toHaveBeenCalledWith('mouseout', expect.any(Function))
     })
   })
 
@@ -221,6 +237,58 @@ describe('ChapterMap', () => {
     })
   })
 
+  describe('Interactive Overlay', () => {
+    it('displays overlay with "Click to interact with map" message initially', () => {
+      const { getByText } = render(<ChapterMap {...defaultProps} />)
+      expect(getByText('Click to interact with map')).toBeInTheDocument()
+    })
+
+    it('removes overlay when clicked', () => {
+      const { getByText, queryByText } = render(<ChapterMap {...defaultProps} />)
+
+      const overlay = getByText('Click to interact with map').closest('div[role="button"]')
+      fireEvent.click(overlay!)
+
+      expect(queryByText('Click to interact with map')).not.toBeInTheDocument()
+    })
+
+    it('enables scroll wheel zoom when overlay is clicked', () => {
+      const { getByText } = render(<ChapterMap {...defaultProps} />)
+
+      const overlay = getByText('Click to interact with map').closest('div[role="button"]')
+      fireEvent.click(overlay!)
+
+      expect(mockMap.scrollWheelZoom.enable).toHaveBeenCalled()
+    })
+
+    it('handles keyboard interaction with Enter key', () => {
+      const { getByText } = render(<ChapterMap {...defaultProps} />)
+
+      const overlay = getByText('Click to interact with map').closest('div[role="button"]')
+      fireEvent.keyDown(overlay!, { key: 'Enter' })
+
+      expect(mockMap.scrollWheelZoom.enable).toHaveBeenCalled()
+    })
+
+    it('handles keyboard interaction with Space key', () => {
+      const { getByText } = render(<ChapterMap {...defaultProps} />)
+
+      const overlay = getByText('Click to interact with map').closest('div[role="button"]')
+      fireEvent.keyDown(overlay!, { key: ' ' })
+
+      expect(mockMap.scrollWheelZoom.enable).toHaveBeenCalled()
+    })
+
+    it('has proper accessibility attributes', () => {
+      const { getByText } = render(<ChapterMap {...defaultProps} />)
+
+      const overlay = getByText('Click to interact with map').closest('div[role="button"]')
+      expect(overlay).toHaveAttribute('role', 'button')
+      expect(overlay).toHaveAttribute('tabIndex', '0')
+      expect(overlay).toHaveAttribute('aria-label', 'Click to interact with map')
+    })
+  })
+
   describe('Local View', () => {
     it('sets local view when showLocal is true', () => {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -281,10 +349,15 @@ describe('ChapterMap', () => {
     it('applies custom styles correctly', () => {
       const customStyle = { width: '800px', height: '600px', border: '1px solid red' }
 
-      render(<ChapterMap {...defaultProps} style={customStyle} />)
+      const { container } = render(<ChapterMap {...defaultProps} style={customStyle} />)
 
+      // Custom styles should be applied to the parent container
+      const parentContainer = container.firstChild as HTMLElement
+      expect(parentContainer).toHaveStyle('width: 800px; height: 600px; border: 1px solid red;')
+
+      // Map container should have Tailwind classes
       const mapContainer = document.getElementById('chapter-map')
-      expect(mapContainer).toHaveStyle('width: 800px; height: 600px; border: 1px solid red;')
+      expect(mapContainer).toHaveClass('h-full', 'w-full')
     })
   })
 


### PR DESCRIPTION
## Proposed change

Implemented a click-to-activate interaction pattern that prevents accidental zooming while preserving full map functionality

- Disabled default scroll wheel zoom in Leaflet map configuration 
- Added interactive overlay with visual indicator "Click to interact with map"
- Map becomes interactive only when user clicks, indicating intent

## Video Demonstration
https://github.com/user-attachments/assets/c4acdc15-6cbc-4253-b075-5b4e8189fbb0

## Checklist
- [x] I've read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md).
- [x] I've run `make check-test` locally; all checks and tests passed.

