### PR TITLE
feat: Add sorting by project level

### DIFF
--- a/backend/apps/owasp/index/registry/project.py
+++ b/backend/apps/owasp/index/registry/project.py
@@ -92,6 +92,8 @@ class ProjectIndex(IndexBase):
             "stars_count_desc": ["desc(idx_stars_count)"],
             "updated_at_asc": ["asc(idx_updated_at)"],
             "updated_at_desc": ["desc(idx_updated_at)"],
+            "level_raw_asc": ["asc(idx_level_raw)"],
+            "level_raw_desc": ["desc(idx_level_raw)"],
         }
 
         IndexBase.configure_replicas("projects", replicas)

--- a/frontend/src/utils/sortingOptions.ts
+++ b/frontend/src/utils/sortingOptions.ts
@@ -5,4 +5,5 @@ export const sortOptionsProject = [
   { label: 'Last Updated', key: 'updated_at' },
   { label: 'Name', key: 'name' },
   { label: 'Stars', key: 'stars_count' },
+  { label: 'Level', key: 'level_raw' },
 ]


### PR DESCRIPTION
<!-- Thanks for contributing to OWASP Nest!-->

## Proposed change

<!-- Don't forget to link your PR to an existing issue if any.-->
Resolves ##2581

<!-- Describe the big picture of your changes.-->
 This pull request introduces a new feature that allows users to sort projects by their "level" attribute.
   This includes modifications to the backend API to support level-based sorting and updates to the frontend to 
   provide a UI control for this new sorting option.

## Checklist

- [ x] I've read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md).
- [ x] I've run `make check-test` locally; all checks and tests passed.
<img width="1634" height="889" alt="screenshot-2025-11-10_12-01-04" src="https://github.com/user-attachments/assets/44ec4ce0-fdbb-4fa7-adb7-5de22caa0707" />

