### PR TITLE
Replace print() with Proper Logging in Management Commands

### DIFF
--- a/backend/apps/owasp/management/commands/owasp_enrich_projects.py
+++ b/backend/apps/owasp/management/commands/owasp_enrich_projects.py
@@ -47,7 +47,7 @@ class Command(BaseCommand):
         offset = options["offset"]
         for idx, project in enumerate(active_projects[offset:]):
             prefix = f"{idx + offset + 1} of {active_projects_count - offset}"
-            print(f"{prefix:<10} {project.owasp_url}")
+            logger.info("%-10s %s", prefix, project.owasp_url)
 
             # Generate summary
             if update_summary and (prompt := Prompt.get_owasp_project_summary()):

--- a/backend/apps/owasp/management/commands/owasp_scrape_chapters.py
+++ b/backend/apps/owasp/management/commands/owasp_scrape_chapters.py
@@ -32,7 +32,7 @@ class Command(BaseCommand):
         chapters = []
         for idx, chapter in enumerate(active_chapters[offset:]):
             prefix = f"{idx + offset + 1} of {active_chapters_count}"
-            print(f"{prefix:<10} {chapter.owasp_url}")
+            logger.info("%-10s %s", prefix, chapter.owasp_url)
 
             scraper = OwaspScraper(chapter.owasp_url)
             if scraper.page_tree is None:

--- a/backend/apps/owasp/management/commands/owasp_scrape_committees.py
+++ b/backend/apps/owasp/management/commands/owasp_scrape_committees.py
@@ -32,7 +32,7 @@ class Command(BaseCommand):
         committees = []
         for idx, committee in enumerate(active_committees[offset:]):
             prefix = f"{idx + offset + 1} of {active_committees_count}"
-            print(f"{prefix:<10} {committee.owasp_url}")
+            logger.info("%-10s %s", prefix, committee.owasp_url)
 
             scraper = OwaspScraper(committee.owasp_url)
             if scraper.page_tree is None:

--- a/backend/apps/owasp/management/commands/owasp_scrape_projects.py
+++ b/backend/apps/owasp/management/commands/owasp_scrape_projects.py
@@ -44,7 +44,7 @@ class Command(BaseCommand):
         projects = []
         for idx, project in enumerate(active_projects[offset:]):
             prefix = f"{idx + offset + 1} of {active_projects_count}"
-            print(f"{prefix:<10} {project.owasp_url}")
+            logger.info("%-10s %s", prefix, project.owasp_url)
 
             scraper = OwaspScraper(project.owasp_url)
             if scraper.page_tree is None:

--- a/backend/apps/slack/management/commands/slack_sync_messages.py
+++ b/backend/apps/slack/management/commands/slack_sync_messages.py
@@ -454,7 +454,7 @@ class Command(BaseCommand):
 
             Message.bulk_save(messages.copy())
             if include_replies and messages:
-                print("Fetching message replies...")
+                logger.info("Fetching message replies...")
                 for message in messages:
                     if not message.has_replies:
                         continue
@@ -546,6 +546,12 @@ class Command(BaseCommand):
             )
 
         if replies_count := len(replies):
+            logger.info(
+                "Saving %s repl%s for %s",
+                replies_count,
+                pluralize(replies_count, "y,ies"),
+                message.url,
+            )
             print(
                 f"Saving {replies_count} repl{pluralize(replies_count, 'y,ies')} for {message.url}"
             )


### PR DESCRIPTION
<!-- Thanks for contributing to OWASP Nest!-->

## Proposed change

<!-- Don't forget to link your PR to an existing issue if any.-->
Resolves #2628

<!-- Describe the big picture of your changes.-->
Replaced all print() statements in OWASP management commands with proper logging in -

- `owasp_scrape_projects.py`
- `owasp_scrape_chapters.py`
- `owasp_scrape_committees.py`
- `owasp_enrich_projects.py`
- `slack_sync_messages.py`


## Checklist

- [x] I've read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md).
- [x] I've run `make check-test` locally; all checks and tests passed.
