### PR TITLE
Fix equality checks with floating point values

### DIFF
--- a/backend/tests/apps/ai/agent/tools/rag/generator_test.py
+++ b/backend/tests/apps/ai/agent/tools/rag/generator_test.py
@@ -1,5 +1,6 @@
 """Tests for the RAG Generator."""
 
+import math
 import os
 from unittest.mock import MagicMock, patch
 
@@ -320,4 +321,4 @@ class TestGenerator:
     def test_constants(self):
         """Test class constants have expected values."""
         assert Generator.MAX_TOKENS == 2000
-        assert Generator.TEMPERATURE == 0.5
+        assert math.isclose(Generator.TEMPERATURE, 0.5)

--- a/backend/tests/apps/slack/common/question_detector_test.py
+++ b/backend/tests/apps/slack/common/question_detector_test.py
@@ -1,5 +1,6 @@
 """Tests for question detector functionality."""
 
+import math
 import os
 from unittest.mock import MagicMock, patch
 
@@ -182,7 +183,7 @@ class TestQuestionDetector:
     def test_class_constants(self, detector):
         """Test that class constants are properly defined."""
         assert detector.MAX_TOKENS == 10
-        assert detector.TEMPERATURE == 0.1
+        assert math.isclose(detector.TEMPERATURE, 0.1)
         assert detector.CHAT_MODEL == "gpt-4o-mini"
 
     def test_openai_client_initialization(self, detector):


### PR DESCRIPTION
Fix for equality checks with floating point values in backend tests.

## Checklist

- [x] I've read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md).
- [x] I've run `make check-test` locally; all checks and tests passed.
