### PR TITLE
feat: add return type hints to model manager methods (#2647)

### DIFF
--- a/backend/apps/github/models/managers/issue.py
+++ b/backend/apps/github/models/managers/issue.py
@@ -10,7 +10,7 @@ from django.utils import timezone
 class OpenIssueManager(models.Manager):
     """Open issues."""
 
-    def get_queryset(self):
+    def get_queryset(self) -> models.QuerySet:
         """Get queryset."""
         return (
             super()
@@ -29,7 +29,7 @@ class OpenIssueManager(models.Manager):
         )
 
     @property
-    def assignable(self):
+    def assignable(self) -> models.QuerySet:
         """Return assignable issues.
 
         Includes all unassigned issues and assigned issues with no activity within 90 days.
@@ -43,6 +43,6 @@ class OpenIssueManager(models.Manager):
         )
 
     @property
-    def without_summary(self):
+    def without_summary(self) -> models.QuerySet:
         """Return issues without summary."""
         return self.get_queryset().filter(summary="")

--- a/backend/apps/github/models/managers/milestone.py
+++ b/backend/apps/github/models/managers/milestone.py
@@ -6,7 +6,7 @@ from django.db import models
 class OpenMilestoneManager(models.Manager):
     """Open milestone manager."""
 
-    def get_queryset(self):
+    def get_queryset(self) -> models.QuerySet:
         """Get open milestones."""
         return super().get_queryset().filter(state="open")
 
@@ -14,6 +14,6 @@ class OpenMilestoneManager(models.Manager):
 class ClosedMilestoneManager(models.Manager):
     """Closed milestone manager."""
 
-    def get_queryset(self):
+    def get_queryset(self) -> models.QuerySet:
         """Get closed milestones."""
         return super().get_queryset().filter(state="closed")

--- a/backend/apps/github/models/managers/organization.py
+++ b/backend/apps/github/models/managers/organization.py
@@ -9,7 +9,7 @@ from apps.owasp.constants import OWASP_ORGANIZATION_NAME
 class RelatedOrganizationsManager(models.Manager):
     """OWASP related organizations manager."""
 
-    def get_queryset(self):
+    def get_queryset(self) -> models.QuerySet:
         """Get OWASP related organizations."""
         return (
             super()

--- a/backend/apps/github/models/managers/pull_request.py
+++ b/backend/apps/github/models/managers/pull_request.py
@@ -6,7 +6,7 @@ from django.db import models
 class OpenPullRequestManager(models.Manager):
     """Open pull requests."""
 
-    def get_queryset(self):
+    def get_queryset(self) -> models.QuerySet:
         """Get queryset."""
         return (
             super()

--- a/backend/apps/github/models/managers/repository_contributor.py
+++ b/backend/apps/github/models/managers/repository_contributor.py
@@ -10,7 +10,7 @@ from apps.github.models.user import User
 class RepositoryContributorQuerySet(models.QuerySet):
     """Repository contributor queryset."""
 
-    def by_humans(self):
+    def by_humans(self) -> "RepositoryContributorQuerySet":
         """Return human repository contributors only."""
         return self.exclude(
             Q(user__is_bot=True)
@@ -19,7 +19,7 @@ class RepositoryContributorQuerySet(models.QuerySet):
             | Q(user__login__endswith="-bot")
         )
 
-    def to_community_repositories(self):
+    def to_community_repositories(self) -> "RepositoryContributorQuerySet":
         """Return community repositories contributors only."""
         return self.exclude(
             Q(repository__is_fork=True)
@@ -31,7 +31,7 @@ class RepositoryContributorQuerySet(models.QuerySet):
 class RepositoryContributorManager(models.Manager):
     """Repository contributor manager."""
 
-    def get_queryset(self):
+    def get_queryset(self) -> RepositoryContributorQuerySet:
         """Get queryset."""
         return RepositoryContributorQuerySet(
             self.model,
@@ -41,10 +41,10 @@ class RepositoryContributorManager(models.Manager):
             "user",
         )
 
-    def by_humans(self):
+    def by_humans(self) -> RepositoryContributorQuerySet:
         """Return human contributors only."""
         return self.get_queryset().by_humans()
 
-    def to_community_repositories(self):
+    def to_community_repositories(self) -> RepositoryContributorQuerySet:
         """Return community repository contributors only."""
         return self.get_queryset().to_community_repositories()

--- a/backend/apps/owasp/models/managers/chapter.py
+++ b/backend/apps/owasp/models/managers/chapter.py
@@ -7,7 +7,7 @@ from django.db.models import Q
 class ActiveChapterManager(models.Manager):
     """Active chapters."""
 
-    def get_queryset(self):
+    def get_queryset(self) -> models.QuerySet:
         """Get queryset."""
         return (
             super()
@@ -20,7 +20,7 @@ class ActiveChapterManager(models.Manager):
         )
 
     @property
-    def without_geo_data(self):
+    def without_geo_data(self) -> models.QuerySet:
         """Return chapters that don't have geo data."""
         return self.get_queryset().filter(
             Q(latitude__isnull=True) | Q(longitude__isnull=True),

--- a/backend/apps/owasp/models/managers/committee.py
+++ b/backend/apps/owasp/models/managers/committee.py
@@ -6,11 +6,11 @@ from django.db import models
 class ActiveCommitteeManager(models.Manager):
     """Active committees."""
 
-    def get_queryset(self):
+    def get_queryset(self) -> models.QuerySet:
         """Get queryset."""
         return super().get_queryset().filter(is_active=True)
 
     @property
-    def without_summary(self):
+    def without_summary(self) -> models.QuerySet:
         """Return committees without summary."""
         return self.get_queryset().filter(summary="")

--- a/backend/apps/owasp/models/managers/project.py
+++ b/backend/apps/owasp/models/managers/project.py
@@ -6,11 +6,11 @@ from django.db import models
 class ActiveProjectManager(models.Manager):
     """Active projects."""
 
-    def get_queryset(self):
+    def get_queryset(self) -> models.QuerySet:
         """Get queryset."""
         return super().get_queryset().filter(is_active=True)
 
     @property
-    def without_summary(self):
+    def without_summary(self) -> models.QuerySet:
         """Return projects without summary."""
         return self.get_queryset().filter(summary="")


### PR DESCRIPTION
<!-- Thanks for contributing to OWASP Nest!-->

## Proposed change
Resolves #2647
<!-- Don't forget to link your PR to an existing issue if any.-->
Resolves #(put the issue number here)
<!-- Describe the big picture of your changes.-->
Add the PR description here.
Adds -> models.QuerySet return-type annotations to all manager methods under:
`backend/apps/owasp/models/managers/*.py`
`backend/apps/github/models/managers/*.py`
Covers get_queryset() and property helpers such as without_geo_data and assignable in chapter, committee, project, issue, milestone, organization, pull_request, and repository_contributor managers. No extra imports were introduced; the existing models namespace is reused.

## Checklist

- [x] I've read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md).
- [x] I've run `make check-test` locally; all checks and tests passed.
