### PR TITLE
feat: Add project sorting by level

### DIFF
--- a/backend/apps/common/index.py
+++ b/backend/apps/common/index.py
@@ -22,14 +22,14 @@ EXCLUDED_LOCAL_INDEX_NAMES = (
     "projects_contributors_count_desc",
     "projects_forks_count_asc",
     "projects_forks_count_desc",
+    "projects_level_raw_asc",
+    "projects_level_raw_desc",
     "projects_name_asc",
     "projects_name_desc",
     "projects_stars_count_asc",
     "projects_stars_count_desc",
     "projects_updated_at_asc",
     "projects_updated_at_desc",
-    "projects_level_raw_asc",
-    "projects_level_raw_desc",
 )
 LOCAL_INDEX_LIMIT = 1000
 

--- a/backend/apps/owasp/index/registry/project.py
+++ b/backend/apps/owasp/index/registry/project.py
@@ -86,14 +86,14 @@ class ProjectIndex(IndexBase):
             "contributors_count_desc": ["desc(idx_contributors_count)"],
             "forks_count_asc": ["asc(idx_forks_count)"],
             "forks_count_desc": ["desc(idx_forks_count)"],
+            "level_raw_asc": ["asc(idx_level_raw)"],
+            "level_raw_desc": ["desc(idx_level_raw)"],
             "name_asc": ["asc(idx_name)"],
             "name_desc": ["desc(idx_name)"],
             "stars_count_asc": ["asc(idx_stars_count)"],
             "stars_count_desc": ["desc(idx_stars_count)"],
             "updated_at_asc": ["asc(idx_updated_at)"],
             "updated_at_desc": ["desc(idx_updated_at)"],
-            "level_raw_asc": ["asc(idx_level_raw)"],
-            "level_raw_desc": ["desc(idx_level_raw)"],
         }
 
         IndexBase.configure_replicas("projects", replicas)

--- a/frontend/src/utils/sortingOptions.ts
+++ b/frontend/src/utils/sortingOptions.ts
@@ -3,7 +3,7 @@ export const sortOptionsProject = [
   { label: 'Contributors', key: 'contributors_count' },
   { label: 'Forks', key: 'forks_count' },
   { label: 'Last Updated', key: 'updated_at' },
+  { label: 'Level', key: 'level_raw' },
   { label: 'Name', key: 'name' },
   { label: 'Stars', key: 'stars_count' },
-  { label: 'Level', key: 'level_raw' },
 ]


### PR DESCRIPTION
<!-- Thanks for contributing to OWASP Nest!-->

## Proposed change

<!-- Don't forget to link your PR to an existing issue if any.-->
Resolves #2581
<img width="1634" height="889" alt="image" src="https://github.com/user-attachments/assets/4410fa0a-1cda-4f55-9f6e-ae02e5e52047" />


<!-- Describe the big picture of your changes.-->

This PR extends the project directory sorting options by adding the ability to sort projects by their level.
Changes Made:
Backend: Added level_raw_asc and level_raw_desc replica configurations to enable sorting by project level in Algolia
Backend: Added the new sorting indices to the local exclusion list to optimize local development performance
Frontend: Added "Level" as a sorting option in the project directory dropdown



## Checklist

- [ x] I've read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md).
- [ x] I've run `make check-test` locally; all checks and tests passed.
