### PR TITLE
fix: Add pointer cursor to Languages/Topics #2672

### DIFF
--- a/frontend/src/components/ToggleableList.tsx
+++ b/frontend/src/components/ToggleableList.tsx
@@ -39,7 +39,7 @@ const ToggleableList = ({
         {(showAll ? items : items.slice(0, limit)).map((item) => (
           <button
             key={item}
-            className="rounded-lg border border-gray-400 px-3 py-1 text-sm hover:bg-gray-200 dark:border-gray-300 dark:hover:bg-gray-700"
+            className="cursor-pointer rounded-lg border border-gray-400 px-3 py-1 text-sm hover:bg-gray-200 disabled:cursor-default dark:border-gray-300 dark:hover:bg-gray-700"
             onClick={() => !isDisabled && handleButtonClick({ item })}
             aria-label={`Search for projects with ${item}`}
             disabled={isDisabled}


### PR DESCRIPTION
## Proposed change


Resolves #2672 
fix: Add pointer cursor to Languages/Topics #2672
<!-- Describe the big picture of your changes.-->
Currently, the "Languages" and "Topics" items on the projects page (e.g., https://nest.owasp.org/projects/coraza-web-application-firewall) show the default cursor. This PR adds the `cursor-pointer` style to these items to indicate they are interactive.

## Checklist

- [x] I've read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md).
- [x] I've run `make check-test` locally; all checks and tests passed.
