### PR TITLE
Changed light mode icon because it was misleading

### DIFF
--- a/frontend/src/components/ModeToggle.tsx
+++ b/frontend/src/components/ModeToggle.tsx
@@ -1,4 +1,4 @@
-import { faMoon, faSun } from '@fortawesome/free-regular-svg-icons'
+import { faMoon, faLightbulb } from '@fortawesome/free-regular-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Button } from '@heroui/button'
 import { Tooltip } from '@heroui/tooltip'
@@ -28,7 +28,7 @@ export default function ModeToggle() {
         >
           <div className="absolute inset-0 flex items-center justify-center">
             <FontAwesomeIcon
-              icon={theme === 'dark' ? faSun : faMoon}
+              icon={theme === 'dark' ? faLightbulb : faMoon}
               className="h-5 w-5 transform text-gray-900 transition-all duration-300 hover:rotate-12 dark:text-gray-100"
               fixedWidth
             />


### PR DESCRIPTION
Summary

This PR updates the Light Mode toggle icon in the UI.
The previous icon (⚙️-style gear sun) was visually misleading and looked like a settings icon, which caused confusion.

Replaced the old sun/gear-like icon

before
<img width="302" height="44" alt="Screenshot 2025-11-24 at 11 54 57 PM" src="https://github.com/user-attachments/assets/d6562ab2-b22d-4964-bc14-fcb2c76bc40d" />

After
<img width="424" height="50" alt="Screenshot 2025-11-24 at 11 55 17 PM" src="https://github.com/user-attachments/assets/5a5e1d8b-d15c-4047-aba1-4b937d901b42" />

Added the clean and clear light bulb icon to represent Light Mode


Reason

The previous icon did not clearly represent Light Mode and visually conflicted with the settings icon.
The new icon is simpler, more intuitive, and improves UI clarity.


Checklist

 I've read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md)
 I've run make check-test locally; all checks and tests passed.