### PR TITLE
Changed light mode icon because it was misleading

### DIFF
--- a/frontend/src/components/ModeToggle.tsx
+++ b/frontend/src/components/ModeToggle.tsx
@@ -1,4 +1,4 @@
-import { faMoon, faSun } from '@fortawesome/free-regular-svg-icons'
+import { faMoon, faLightbulb } from '@fortawesome/free-regular-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Button } from '@heroui/button'
 import { Tooltip } from '@heroui/tooltip'
@@ -28,7 +28,7 @@ export default function ModeToggle() {
         >
           <div className="absolute inset-0 flex items-center justify-center">
             <FontAwesomeIcon
-              icon={theme === 'dark' ? faSun : faMoon}
+              icon={theme === 'dark' ? faLightbulb : faMoon}
               className="h-5 w-5 transform text-gray-900 transition-all duration-300 hover:rotate-12 dark:text-gray-100"
               fixedWidth
             />


### PR DESCRIPTION
Description

This PR updates the Light Mode toggle icon in the UI.

What Was Changed

Replaced the old sun/gear-style icon (which looked like a settings icon):
Added the new light bulb icon (more intuitive for Light Mode):

before 
<img width="290" height="60" alt="Screenshot 2025-11-25 at 12 04 54 AM" src="https://github.com/user-attachments/assets/810d5657-d3a7-44e2-abde-cd4f3854a0a1" />

After
<img width="406" height="57" alt="Screenshot 2025-11-25 at 12 05 11 AM" src="https://github.com/user-attachments/assets/05313ad4-55ca-4e63-9dd1-c82b6091a434" />


🧠 Why This Change

The previous icon was visually misleading and confused users as it closely resembled the settings icon.
The new icon provides clearer UX and better represents Light Mode functionality.

🧪 Testing

Verified UI behavior in both Light and Dark modes
Ensured toggle works with no functional regressions

📝 Checklist

 I've read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md)
 I've run make check-test locally; all checks and tests passed.
 
 Issue:-##2713
