### PR TITLE
Changed light mode icon because it was misleading

### DIFF
--- a/frontend/src/components/ModeToggle.tsx
+++ b/frontend/src/components/ModeToggle.tsx
@@ -1,4 +1,4 @@
-import { faMoon, faSun } from '@fortawesome/free-regular-svg-icons'
+import { faMoon, faLightbulb } from '@fortawesome/free-regular-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Button } from '@heroui/button'
 import { Tooltip } from '@heroui/tooltip'
@@ -28,7 +28,7 @@ export default function ModeToggle() {
         >
           <div className="absolute inset-0 flex items-center justify-center">
             <FontAwesomeIcon
-              icon={theme === 'dark' ? faSun : faMoon}
+              icon={theme === 'dark' ? faLightbulb : faMoon}
               className="h-5 w-5 transform text-gray-900 transition-all duration-300 hover:rotate-12 dark:text-gray-100"
               fixedWidth
             />


### PR DESCRIPTION
Description

This PR updates the Light Mode toggle icon in the UI.

What Was Changed

Replaced the old sun/gear-style icon (which looked like a settings icon):
Added the new light bulb icon (more intuitive for Light Mode):

before
<img width="304" height="69" alt="Screenshot 2025-11-26 at 7 20 54 PM" src="https://github.com/user-attachments/assets/280696ab-65cb-4063-855a-a9c158e865b0" />



After
<img width="450" height="66" alt="Screenshot 2025-11-26 at 7 20 41 PM" src="https://github.com/user-attachments/assets/bf01e63c-8063-40ec-9e15-10f7be5aa92a" />


🧠 Why This Change

The previous icon was visually misleading and confused users as it closely resembled the settings icon.
The new icon provides clearer UX and better represents Light Mode functionality.

🧪 Testing

Verified UI behavior in both Light and Dark modes
Ensured toggle works with no functional regressions

📝 Checklist

I've read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md)
I've run make check-test locally; all checks and tests passed.

Fixed:-https://github.com/OWASP/Nest/issues/2713