### PR TITLE
fix: add missing type="button" attributes to button elements

### DIFF
--- a/frontend/src/components/Release.tsx
+++ b/frontend/src/components/Release.tsx
@@ -74,6 +74,7 @@ const Release: React.FC<ReleaseProps> = ({
           <div className="flex flex-1 items-center overflow-hidden">
             <FontAwesomeIcon icon={faFolderOpen} className="mr-2 h-5 w-4" />
             <button
+              type="button"
               className="cursor-pointer overflow-hidden text-ellipsis whitespace-nowrap text-gray-600 hover:underline dark:text-gray-400"
               disabled={!release.organizationName || !release.repositoryName}
               onClick={() => {

--- a/frontend/src/components/Search.tsx
+++ b/frontend/src/components/Search.tsx
@@ -86,6 +86,7 @@ const SearchBar: React.FC<SearchProps> = ({
             />
             {searchQuery && (
               <button
+                type="button"
                 className="absolute top-1/2 right-2 -translate-y-1/2 rounded-full p-1 hover:bg-gray-100 focus:ring-2 focus:ring-gray-300 focus:outline-hidden"
                 onClick={handleClearSearch}
                 aria-label="Clear search"

--- a/frontend/src/components/SortBy.tsx
+++ b/frontend/src/components/SortBy.tsx
@@ -61,6 +61,7 @@ const SortBy = ({
           closeDelay={100}
         >
           <button
+            type="button"
             onClick={() => onOrderChange(selectedOrder === 'asc' ? 'desc' : 'asc')}
             className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-gray-300 bg-gray-100 p-0 shadow-sm transition-all duration-200 hover:bg-gray-200 hover:shadow-md focus:ring-2 focus:ring-gray-300 focus:ring-offset-1 focus:outline-none dark:border-gray-600 dark:bg-[#323232] dark:hover:bg-[#404040] dark:focus:ring-gray-500"
             aria-label={

--- a/frontend/src/components/ToggleableList.tsx
+++ b/frontend/src/components/ToggleableList.tsx
@@ -39,6 +39,7 @@ const ToggleableList = ({
         {(showAll ? items : items.slice(0, limit)).map((item) => (
           <button
             key={item}
+            type="button"
             className="rounded-lg border border-gray-400 px-3 py-1 text-sm hover:bg-gray-200 dark:border-gray-300 dark:hover:bg-gray-700"
             onClick={() => !isDisabled && handleButtonClick({ item })}
             aria-label={`Search for projects with ${item}`}


### PR DESCRIPTION
## Proposed change

Resolves #2656

This PR adds the missing `type="button"` attribute to button elements that are not intended to submit forms. Without this attribute, buttons default to `type="submit"` which can cause unintended form submissions and unexpected page behavior.

## Changes Made

Added explicit `type="button"` to the following components:
- **ToggleableList.tsx** (line 42): Search filter buttons
- **Search.tsx** (line 89): Clear search button
- **SortBy.tsx** (line 64): Sort order toggle button
- **Release.tsx** (line 77): Repository navigation button

**Note:** ModuleList.tsx already had the correct `type="button"` attribute and didn't require changes.

## Testing

- [x] Ran `make check-frontend` - all linting and formatting checks passed ✅
- [x] Pre-commit hooks executed successfully ✅
- [x] Verified buttons behave as expected (no form submissions)

## Checklist

- [x] I've read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md).
- [x] I've run `make check-test` locally; all checks and tests passed.
