### PR TITLE
fix: add aria-label to ShowMoreButton for accessibility

### DIFF
--- a/frontend/src/components/ShowMoreButton.tsx
+++ b/frontend/src/components/ShowMoreButton.tsx
@@ -18,6 +18,7 @@ const ShowMoreButton = ({ onToggle }: { onToggle: () => void }) => {
         disableAnimation
         onPress={handleToggle}
         className="flex items-center bg-transparent px-0 text-blue-400"
+        aria-label={isExpanded ? 'Show fewer items' : 'Show more items'}
       >
         {isExpanded ? (
           <>


### PR DESCRIPTION
## Proposed change

Resolves #2748

Adds a dynamic `aria-label` attribute to the ShowMoreButton component to improve accessibility for screen reader users.

## Changes Made

Added `aria-label` to the Button element in `ShowMoreButton.tsx` that changes based on the button's expanded state:
- When collapsed: `aria-label="Show more items"`
- When expanded: `aria-label="Show fewer items"`

## Why This Matters

- ✅ Improves accessibility for screen reader users
- ✅ Follows WCAG guidelines
- ✅ Maintains consistency with other buttons in the codebase (e.g., Pagination.tsx)
- ✅ Better semantic HTML

## Testing

- [x] Ran `make check-frontend` - all linting and formatting checks passed ✅
- [x] Pre-commit hooks executed successfully ✅
- [x] Button state correctly updates aria-label

## Checklist

- [x] I've read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md).
- [x] I've run `make check-test` locally; all checks and tests passed.
