### PR TITLE
fix(module-list): replace non-interactive button with div 

### DIFF
--- a/frontend/src/components/ModuleList.tsx
+++ b/frontend/src/components/ModuleList.tsx
@@ -20,15 +20,13 @@ const ModuleList: React.FC<ModuleListProps> = ({ modules }) => {
         {displayedModules.map((module, index) => {
           const displayText = module.length > 50 ? `${module.slice(0, 50)}...` : module
           return (
-            <button
+            <div
               key={`${module}-${index}`}
-              className="rounded-lg border border-gray-400 px-3 py-1 text-sm transition-all duration-200 ease-in-out hover:scale-105 hover:bg-gray-200 dark:border-gray-300 dark:hover:bg-gray-700"
+              className="rounded-lg border border-gray-400 px-3 py-1 text-sm transition-all duration-200 ease-in-out dark:border-gray-300"
               title={module.length > 50 ? module : undefined}
-              type="button"
-              aria-label={`Module: ${module}`}
             >
               {displayText}
-            </button>
+            </div>
           )
         })}
 


### PR DESCRIPTION
<!-- Thanks for contributing to OWASP Nest! -->

## Proposed change

Resolves #2701

Replace a non-interactive `<button>` element in `frontend/src/components/ModuleList.tsx` with a non-interactive `<div>` and remove hover styles that implied clickability.

What:
- Replace the `<button>` (which had no handlers) with a `<div>` to correct semantics.
- Remove hover/scale/bg styles that created a misleading clickable affordance.
- Preserve visual layout (border, padding, text) and tooltip via `title` when the module name is truncated.

Why:
- Buttons must represent actionable controls. Using a `<button>` with no action is misleading to sighted users, keyboard users and assistive tech (screen readers).
- This change fixes an accessibility/semantics issue without changing behavior.

Files changed:
- `frontend/src/components/ModuleList.tsx`

## Checklist

- [ ] I've read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md).
- [ ] I've run `make check-test` locally; all checks and tests passed.