### PR TITLE
fix: incorrect Error constructor usage

### DIFF
--- a/frontend/src/app/api/auth/[...nextauth]/route.ts
+++ b/frontend/src/app/api/auth/[...nextauth]/route.ts
@@ -18,7 +18,7 @@ async function checkIfProjectLeader(login: string): Promise<boolean> {
     })
     return data?.isProjectLeader ?? false
   } catch (err) {
-    throw new Error('Failed to fetch project leader status Error', err)
+    throw new Error(`Failed to fetch project leader status Error: ${err}`)
   }
 }
 
@@ -32,7 +32,7 @@ async function checkIfMentor(login: string): Promise<boolean> {
     })
     return data?.isMentor ?? false
   } catch (err) {
-    throw new Error('Failed to fetch mentor status Error', err)
+    throw new Error(`Failed to fetch mentor status Error: ${err}`)
   }
 }
 

--- a/frontend/src/components/ModuleForm.tsx
+++ b/frontend/src/components/ModuleForm.tsx
@@ -286,7 +286,7 @@ export const ProjectSelector = ({ value, defaultName, onProjectChange }: Project
       } catch (err) {
         setRawResults([])
         setShowSuggestions(false)
-        throw new Error('Error fetching suggestions:', err)
+        throw new Error(`Error fetching suggestions: ${err}`)
       }
     }, 300),
     [client]


### PR DESCRIPTION
<!-- Thanks for contributing to OWASP Nest!-->

## Proposed change

<!-- Don't forget to link your PR to an existing issue if any.-->
Resolves #2803

<!-- Describe the big picture of your changes.-->
This PR fixes an issue where the `Error` constructor was being called with two arguments in [frontend/src/components/ModuleForm.tsx](cci:7://file:///Users/ayushkumarsingh/Desktop/Gsoc_repos/Nest/frontend/src/components/ModuleForm.tsx:0:0-0:0) and [frontend/src/app/api/auth/[...nextauth]/route.ts](cci:7://file:///Users/ayushkumarsingh/Desktop/Gsoc_repos/Nest/frontend/src/app/api/auth/%5B...nextauth%5D/route.ts:0:0-0:0). The `Error` constructor only accepts a single message string, so the second argument (the original error) was being ignored.

I have updated the code to use template literals to correctly include the original error message in the new Error object, ensuring that the original error context is preserved.

## Checklist

- [x] I've read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md).
- [ ] I've run `make check-test` locally; all checks and tests passed.