### PR TITLE
fix: add missing type attributes to button elements

### DIFF
--- a/frontend/src/components/Release.tsx
+++ b/frontend/src/components/Release.tsx
@@ -74,6 +74,7 @@ const Release: React.FC<ReleaseProps> = ({
           <div className="flex flex-1 items-center overflow-hidden">
             <FontAwesomeIcon icon={faFolderOpen} className="mr-2 h-5 w-4" />
             <button
+            type="button"
               className="cursor-pointer overflow-hidden text-ellipsis whitespace-nowrap text-gray-600 hover:underline dark:text-gray-400"
               disabled={!release.organizationName || !release.repositoryName}
               onClick={() => {

--- a/frontend/src/components/Search.tsx
+++ b/frontend/src/components/Search.tsx
@@ -86,6 +86,7 @@ const SearchBar: React.FC<SearchProps> = ({
             />
             {searchQuery && (
               <button
+              type="button"
                 className="absolute top-1/2 right-2 -translate-y-1/2 rounded-full p-1 hover:bg-gray-100 focus:ring-2 focus:ring-gray-300 focus:outline-hidden"
                 onClick={handleClearSearch}
                 aria-label="Clear search"

--- a/frontend/src/components/SortBy.tsx
+++ b/frontend/src/components/SortBy.tsx
@@ -61,6 +61,7 @@ const SortBy = ({
           closeDelay={100}
         >
           <button
+          type="button"
             onClick={() => onOrderChange(selectedOrder === 'asc' ? 'desc' : 'asc')}
             className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-gray-300 bg-gray-100 p-0 shadow-sm transition-all duration-200 hover:bg-gray-200 hover:shadow-md focus:ring-2 focus:ring-gray-300 focus:ring-offset-1 focus:outline-none dark:border-gray-600 dark:bg-[#323232] dark:hover:bg-[#404040] dark:focus:ring-gray-500"
             aria-label={

--- a/frontend/src/components/ToggleableList.tsx
+++ b/frontend/src/components/ToggleableList.tsx
@@ -38,6 +38,7 @@ const ToggleableList = ({
       <div className="flex flex-wrap gap-2">
         {(showAll ? items : items.slice(0, limit)).map((item) => (
           <button
+          type="button"
             key={item}
             className="rounded-lg border border-gray-400 px-3 py-1 text-sm hover:bg-gray-200 dark:border-gray-300 dark:hover:bg-gray-700"
             onClick={() => !isDisabled && handleButtonClick({ item })}


### PR DESCRIPTION
**Summary**

Added missing type attributes to <button> elements across the frontend to prevent unintended form submissions and ensure consistent behavior.

**Why this change?**

Buttons without an explicit type default to submit, which can cause forms to submit unexpectedly. Adding type="button" or type="submit" makes the behavior clear and predictable.

**What was done?**

Added type to all buttons missing it

Ensured submit buttons use type="submit"

Verified no UI or functionality breaks

