### PR TITLE
fix(nav): add pointer cursor to 'community' dropdown

### DIFF
--- a/frontend/src/components/NavDropDown.tsx
+++ b/frontend/src/components/NavDropDown.tsx
@@ -40,7 +40,7 @@ export default function NavDropdown({ link, pathname }: NavDropDownProps) {
       )}
     >
       <button
-        className="flex items-center gap-2 whitespace-nowrap"
+        className="flex items-center gap-2 whitespace-nowrap cursor-pointer"
         onClick={() => setIsOpen((prev) => !prev)}
         aria-expanded={isOpen}
         aria-haspopup="true"


### PR DESCRIPTION
<!-- Thanks for contributing to OWASP Nest!-->

## Proposed change

<!-- Don't forget to link your PR to an existing issue if any.-->
Resolves #2818 

<!-- Describe the big picture of your changes.-->
This PR fixes "Community" dropdown by adding `cursor-pointer` class to the dropdown trigger button in `NavDropdown.tsx`.

Previously, hovering over the "Community" dropdown buttons displayed the default arrow cursor, which made it so that the element seemed non-clickable.

## Checklist

- [x] I've read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md).
- [ ] I've run `make check-test` locally; all checks and tests passed.
