### PR TITLE
Fix: inconsistent badge sizes on project health metrics page

### DIFF
--- a/frontend/src/app/projects/dashboard/metrics/[projectKey]/page.tsx
+++ b/frontend/src/app/projects/dashboard/metrics/[projectKey]/page.tsx
@@ -80,6 +80,7 @@ const ProjectHealthMetricsDetails: FC = () => {
                 }
                 icon={faDollar}
                 compliant={metricsLatest.isFundingRequirementsCompliant}
+                size="sm"
               />
               <GeneralCompliantComponent
                 title={
@@ -89,6 +90,7 @@ const ProjectHealthMetricsDetails: FC = () => {
                 }
                 icon={faHandshake}
                 compliant={metricsLatest.isLeaderRequirementsCompliant}
+                size="sm"
               />
             </div>
           </div>

--- a/frontend/src/components/Badges.tsx
+++ b/frontend/src/components/Badges.tsx
@@ -2,13 +2,14 @@ import { Tooltip } from '@heroui/tooltip'
 import FontAwesomeIconWrapper from 'wrappers/FontAwesomeIconWrapper'
 import { BADGE_CLASS_MAP } from 'utils/data'
 
+const BADGE_SIZE = 16
+const DEFAULT_ICON = BADGE_CLASS_MAP['medal']
+
 type BadgeProps = {
   name: string
   cssClass: string | undefined
   showTooltip?: boolean
 }
-
-const DEFAULT_ICON = BADGE_CLASS_MAP['medal']
 
 const normalizeCssClass = (cssClass: string | undefined) => {
   if (!cssClass || cssClass.trim() === '') {
@@ -30,7 +31,17 @@ const Badges = ({ name, cssClass, showTooltip = true }: BadgeProps) => {
   return (
     <div className="inline-flex items-center">
       <Tooltip content={name} isDisabled={!showTooltip}>
-        <FontAwesomeIconWrapper icon={icon} className="h-4 w-4" data-testid="badge-icon" />
+        <div
+          className="flex items-center justify-center"
+          style={{ width: BADGE_SIZE, height: BADGE_SIZE }}
+        >
+          <FontAwesomeIconWrapper
+            icon={icon}
+            data-testid="badge-icon"
+            style={{ width: BADGE_SIZE, height: BADGE_SIZE }}
+            fixedWidth
+          />
+        </div>
       </Tooltip>
     </div>
   )

--- a/frontend/src/components/GeneralCompliantComponent.tsx
+++ b/frontend/src/components/GeneralCompliantComponent.tsx
@@ -7,30 +7,42 @@ import { Tooltip } from '@heroui/tooltip'
 import clsx from 'clsx'
 import { FC } from 'react'
 
+const BADGE_SIZE = 16
+
 const GeneralCompliantComponent: FC<{
   readonly compliant: boolean
   readonly icon: IconProp
   readonly title: string
-}> = ({ icon, compliant, title }) => {
+  readonly size?: 'sm' | 'md'
+}> = ({ icon, compliant, title, size = 'md' }) => {
+  const isSmall = size === 'sm'
+
   return (
     <Tooltip content={title} placement="top">
-      <div className="group pointer-events-auto relative inline-block transition-all duration-300 ease-in-out hover:scale-105">
+      <div
+        className={clsx(
+          'group pointer-events-auto relative inline-flex items-center justify-center',
+          !isSmall && 'transition-all duration-300 ease-in-out hover:scale-105'
+        )}
+        style={isSmall ? { width: BADGE_SIZE, height: BADGE_SIZE } : undefined}
+      >
         <FontAwesomeIcon
           icon={faCertificate}
-          className={clsx(
-            'h-14 w-14 drop-shadow-md filter transition-all group-hover:drop-shadow-lg',
-            {
-              'text-green-400/80': compliant,
-              'text-red-400/80': !compliant,
-            }
-          )}
+          className={clsx('drop-shadow-md filter transition-all group-hover:drop-shadow-lg', {
+            'h-14 w-14': !isSmall,
+            'text-green-400/80': compliant,
+            'text-red-400/80': !compliant,
+          })}
+          style={isSmall ? { width: BADGE_SIZE, height: BADGE_SIZE } : undefined}
         />
         <FontAwesomeIcon
           icon={icon}
-          className={clsx('absolute top-1/2 left-1/2 h-7 w-7 -translate-x-1/2 -translate-y-1/2', {
+          className={clsx('absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2', {
+            'h-7 w-7': !isSmall,
             'text-green-900/90': compliant,
             'text-red-900/90': !compliant,
           })}
+          style={isSmall ? { width: BADGE_SIZE * 0.5, height: BADGE_SIZE * 0.5 } : undefined}
         />
       </div>
     </Tooltip>


### PR DESCRIPTION
<!-- Thanks for contributing to OWASP Nest!-->

## Proposed change
Fix badge sizes in the project health dashboard details page.

This PR standardizes their dimensions to improve visual consistency and alignment.
<!-- Don't forget to link your PR to an existing issue if any.-->
Resolves (#2797)

<!-- Describe the big picture of your changes.-->

The health score badge and compliance badges on
/projects/dashboard/metrics/[projectKey] were rendered at inconsistent sizes.

This PR standardizes their dimensions to improve visual consistency and alignment.
Made the badge sizes consistent. The health score circle remains the same.

## Checklist

- [x] I've read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md).
- [x] I've run `make check-test` locally; all checks and tests passed.
