### PR TITLE
Fixed inconsistent UI of clear search icon across all search bars

### DIFF
--- a/frontend/__tests__/unit/components/Search.test.tsx
+++ b/frontend/__tests__/unit/components/Search.test.tsx
@@ -73,7 +73,7 @@ describe('SearchBar Component', () => {
       const { container } = render(<SearchBar {...defaultProps} isLoaded={false} />)
       const input = screen.getByPlaceholderText('Search projects...')
       expect(input).toHaveValue('')
-      const clearButton = container.querySelector('button.absolute.rounded-full[class*="right-2"]')
+      const clearButton = container.querySelector('button.absolute.rounded-md[class*="right-2"]')
       expect(clearButton).not.toBeInTheDocument()
     })
 
@@ -81,7 +81,7 @@ describe('SearchBar Component', () => {
       const { container } = render(<SearchBar {...defaultProps} isLoaded={false} />)
       const input = screen.getByPlaceholderText('Search projects...')
       fireEvent.change(input, { target: { value: 'test' } })
-      const clearButton = container.querySelector('button.absolute.rounded-full[class*="right-2"]')
+      const clearButton = container.querySelector('button.absolute.rounded-md[class*="right-2"]')
       expect(clearButton).toBeInTheDocument()
     })
   })
@@ -145,7 +145,7 @@ describe('SearchBar Component', () => {
       const input = screen.getByPlaceholderText('Search projects...')
       fireEvent.change(input, { target: { value: 'test' } })
       expect(input).toHaveValue('test')
-      const clearButton = container.querySelector('button.absolute.rounded-full[class*="right-2"]')
+      const clearButton = container.querySelector('button.absolute.rounded-md[class*="right-2"]')
       fireEvent.click(clearButton)
       expect(input).toHaveValue('')
     })
@@ -312,7 +312,7 @@ describe('SearchBar Component', () => {
       fireEvent.change(input, { target: { value: 'edge case' } })
       expect(mockOnSearch).not.toHaveBeenCalled()
 
-      const clearButton = container.querySelector('button.absolute.rounded-full[class*="right-2"]')
+      const clearButton = container.querySelector('button.absolute.rounded-md[class*="right-2"]')
       fireEvent.click(clearButton)
 
       jest.advanceTimersByTime(750)
@@ -332,10 +332,10 @@ describe('SearchBar Component', () => {
       const input = screen.getByPlaceholderText('Search projects...')
       expect(input).toBeInTheDocument()
       expect(input).toHaveAttribute('type', 'text')
-      let clearButton = container.querySelector('button.absolute.rounded-full[class*="right-2"]')
+      let clearButton = container.querySelector('button.absolute.rounded-md[class*="right-2"]')
       expect(clearButton).not.toBeInTheDocument()
       fireEvent.change(input, { target: { value: 'test' } })
-      clearButton = container.querySelector('button.absolute.rounded-full[class*="right-2"]')
+      clearButton = container.querySelector('button.absolute.rounded-md[class*="right-2"]')
       expect(clearButton).toBeInTheDocument()
     })
 
@@ -366,9 +366,9 @@ describe('SearchBar Component', () => {
       const { container } = render(<SearchBar {...defaultProps} isLoaded={false} />)
       const input = screen.getByPlaceholderText('Search projects...')
       fireEvent.change(input, { target: { value: 'test' } })
-      const clearButton = container.querySelector('button.absolute.rounded-full[class*="right-2"]')
+      const clearButton = container.querySelector('button.absolute.rounded-md[class*="right-2"]')
       expect(clearButton).toHaveClass(
-        'absolute top-1/2 right-2 h-8 w-8 -translate-y-1/2 rounded-full p-1 text-gray-400 hover:bg-gray-400 hover:text-gray-200 focus:ring-2 focus:ring-gray-300 focus:outline-hidden dark:hover:bg-gray-600'
+        'absolute top-1/2 right-2 h-8 w-8 -translate-y-1/2 rounded-md p-1 text-gray-400 hover:bg-gray-400 hover:text-gray-200 focus:ring-2 focus:ring-gray-300 focus:outline-hidden dark:hover:bg-gray-600'
       )
     })
 

--- a/frontend/src/components/MultiSearch.tsx
+++ b/frontend/src/components/MultiSearch.tsx
@@ -243,7 +243,7 @@ const MultiSearchBar: React.FC<MultiSearchBarProps> = ({
             {searchQuery && (
               <button
                 type="button"
-                className="absolute top-1/2 right-2 h-8 w-8 -translate-y-1/2 rounded-full p-1 text-gray-400 hover:bg-gray-400 hover:text-gray-200 focus:ring-2 focus:ring-gray-300 focus:outline-hidden dark:hover:bg-gray-600"
+                className="absolute top-1/2 right-2 h-8 w-8 -translate-y-1/2 rounded-md p-1 text-gray-400 hover:bg-gray-400 hover:text-gray-200 focus:ring-2 focus:ring-gray-300 focus:outline-hidden dark:hover:bg-gray-600"
                 onClick={handleClearSearch}
                 aria-label="Clear search"
               >

--- a/frontend/src/components/Search.tsx
+++ b/frontend/src/components/Search.tsx
@@ -87,7 +87,7 @@ const SearchBar: React.FC<SearchProps> = ({
             {searchQuery && (
               <button
                 type="button"
-                className="absolute top-1/2 right-2 h-8 w-8 -translate-y-1/2 rounded-full p-1 text-gray-400 hover:bg-gray-400 hover:text-gray-200 focus:ring-2 focus:ring-gray-300 focus:outline-hidden dark:hover:bg-gray-600"
+                className="absolute top-1/2 right-2 h-8 w-8 -translate-y-1/2 rounded-md p-1 text-gray-400 hover:bg-gray-400 hover:text-gray-200 focus:ring-2 focus:ring-gray-300 focus:outline-hidden dark:hover:bg-gray-600"
                 onClick={handleClearSearch}
                 aria-label="Clear search"
               >


### PR DESCRIPTION
## Proposed change

<!-- Don't forget to link your PR to an existing issue if any.-->
Resolves #2849 

<!-- Describe the big picture of your changes.-->
This PR fixed inconsistencies in UI of clear search icon across all the search bars which support both themes.

changes made:
- fixed for search bar for projects and contributions page
- fixed for home page

for home page:

dark mode:
<img width="706" height="141" alt="screenshot-2025-12-11_16-31-33" src="https://github.com/user-attachments/assets/fda335f5-c3eb-4a49-8fa6-7d4024a3e643" />

light mode:
<img width="678" height="151" alt="screenshot-2025-12-11_16-31-50" src="https://github.com/user-attachments/assets/7707ac3f-ab61-495b-a768-a7271a2d29f7" />

for projects and contributions page:

dark mode:
<img width="768" height="148" alt="screenshot-2025-12-11_16-36-45" src="https://github.com/user-attachments/assets/0ea1a36e-0fae-46c4-bfda-2cd033a775cc" />

light mode:
<img width="781" height="144" alt="screenshot-2025-12-11_16-36-25" src="https://github.com/user-attachments/assets/86ea9d01-d05b-41ad-97f8-68f305a2f86d" />



## Checklist

- [X] I read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md)
- [X] I ran `make check-test` locally and all tests passed
- [  ] I used AI for code, documentation, or tests in this PR
