### PR TITLE
ci: Add timeout to multiple CI jobs for improved reliability

### DIFF
--- a/.github/workflows/run-ci-cd.yaml
+++ b/.github/workflows/run-ci-cd.yaml
@@ -151,6 +151,7 @@ jobs:
       - scan-code
       - scan-ci-dependencies
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Check out repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
@@ -182,6 +183,7 @@ jobs:
       - scan-code
       - scan-ci-dependencies
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Check out repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
@@ -213,6 +215,7 @@ jobs:
       - scan-code
       - scan-ci-dependencies
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Check out repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
@@ -265,6 +268,7 @@ jobs:
       - run-frontend-unit-tests
       - set-release-version
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Check out repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
@@ -591,6 +595,7 @@ jobs:
       - run-frontend-unit-tests
       - set-release-version
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Check out repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8


### PR DESCRIPTION
## Proposed change

Resolves #2843 

This PR updates `.github/workflows/run-ci-cd.yaml` to enforce a **10-minute timeout** on the following resource-intensive jobs:
- `run-backend-tests`
- `run-frontend-unit-tests`
- `run-frontend-e2e-tests`
- `build-staging-images`

**Rationale:**
Currently, these jobs rely on the GitHub default timeout of 6 hours. If a process hangs (e.g., a "zombie" headless browser or a stalled Docker build), it consumes excessive GitHub Action runner minutes. This change ensures these jobs fail fast if they get stuck.

**Ref:** Timeout value confirmed by @arkid15r in the issue comments.

## Checklist

- [x] I read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md)
- [x] I ran `make check-test` locally and all tests passed
- [ ] I used AI for code, documentation, or tests in this PR