### PR TITLE
Fix ModeToggle Tooltip Misalignment

### DIFF
--- a/frontend/src/components/ModeToggle.tsx
+++ b/frontend/src/components/ModeToggle.tsx
@@ -21,7 +21,11 @@ export default function ModeToggle() {
 
   return (
     <div className="flex items-center">
-      <Tooltip showArrow content={theme === 'dark' ? 'Enable light mode' : 'Enable dark mode'}>
+      <Tooltip
+        showArrow
+        placement="bottom-end"
+        content={theme === 'dark' ? 'Enable light mode' : 'Enable dark mode'}
+      >
         <Button
           onPress={darkModeHandler}
           className="focus-visible:ring-ring relative h-10 w-10 transform rounded-full bg-[#87a1bc] transition-all duration-200 hover:ring-1 hover:ring-[#b0c7de] hover:ring-offset-0 focus-visible:ring-1 focus-visible:outline-hidden active:scale-95 disabled:pointer-events-none disabled:opacity-50 dark:bg-slate-900 dark:text-white dark:hover:bg-slate-900/90 dark:hover:ring-[#46576b]"


### PR DESCRIPTION
## Proposed change
Fixes the misalignment of the tooltip, which is currently pointing to the SignIn button (when not logged in) and Profile Icon (when logged in) rather than the ModeToggle button.

<!-- Don't forget to link your PR to an existing issue if any.-->
Resolves #2711 

<!-- Describe the big picture of your changes.-->
## Files changed:
`frontend/src/components/ModeToggle.tsx`

## Fix: 
Adding `placement="bottom-end"` to the `Tooltip` solves the issue and improves clarity.

## Checklist

- [x] I read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md)
- [x] I ran `make check-test` locally and all tests passed
- [x] I used AI for code, documentation, or tests in this PR
