### PR TITLE
feat: Add automatic Project Leader badge assignment

### DIFF
--- a/backend/apps/nest/management/commands/nest_update_badges.py
+++ b/backend/apps/nest/management/commands/nest_update_badges.py
@@ -2,12 +2,14 @@
 
 import logging
 
+from django.contrib.contenttypes.models import ContentType
 from django.core.management.base import BaseCommand
 
 from apps.github.models.user import User
 from apps.nest.models.badge import Badge
 from apps.nest.models.user_badge import UserBadge
 from apps.owasp.models.entity_member import EntityMember
+from apps.owasp.models.project import Project
 
 logger = logging.getLogger(__name__)
 
@@ -94,7 +96,9 @@ class Command(BaseCommand):
             self.stdout.write(f"Created badge: {badge.name}")
 
         # Get all active and reviewed project leaders
+        project_content_type = ContentType.objects.get_for_model(Project)
         project_leaders = EntityMember.objects.filter(
+            entity_type=project_content_type,
             role=EntityMember.Role.LEADER,
             is_active=True,
             is_reviewed=True,

--- a/backend/tests/apps/nest/management/commands/nest_update_badges_test.py
+++ b/backend/tests/apps/nest/management/commands/nest_update_badges_test.py
@@ -121,14 +121,19 @@ class TestSyncUserBadgesCommand:
             for s in ("Removed badge from 1 non-staff", "Removed badge from 1 non-employees")
         )
 
+    @patch("apps.nest.management.commands.nest_update_badges.ContentType.objects.get_for_model")
     @patch("apps.nest.management.commands.nest_update_badges.EntityMember.objects.filter")
     @patch("apps.nest.management.commands.nest_update_badges.UserBadge.objects.get_or_create")
     @patch("apps.nest.management.commands.nest_update_badges.UserBadge.objects.filter")
     @patch("apps.nest.management.commands.nest_update_badges.Badge.objects.get_or_create")
     @patch("apps.nest.management.commands.nest_update_badges.User.objects.filter")
     def test_badge_creation(
-        self, mock_user_filter, mock_badge_get_or_create, mock_user_badge_filter, mock_user_badge_get_or_create, mock_entity_member_filter
+        self, mock_user_filter, mock_badge_get_or_create, mock_user_badge_filter, mock_user_badge_get_or_create, mock_entity_member_filter, mock_content_type
     ):
+        # Mock ContentType
+        mock_project_content_type = MagicMock()
+        mock_content_type.return_value = mock_project_content_type
+
         # Set up badge creation mocks
         mock_staff_badge = MagicMock()
         mock_staff_badge.name = OWASP_STAFF_BADGE_NAME
@@ -176,15 +181,20 @@ class TestSyncUserBadgesCommand:
         assert f"Created badge: {mock_staff_badge.name}" in output
         assert f"Created badge: {mock_leader_badge.name}" in output
 
+    @patch("apps.nest.management.commands.nest_update_badges.ContentType.objects.get_for_model")
     @patch("apps.nest.management.commands.nest_update_badges.EntityMember.objects.filter")
     @patch("apps.nest.management.commands.nest_update_badges.UserBadge.objects.get_or_create")
     @patch("apps.nest.management.commands.nest_update_badges.UserBadge.objects.filter")
     @patch("apps.nest.management.commands.nest_update_badges.Badge.objects.get_or_create")
     @patch("apps.nest.management.commands.nest_update_badges.User.objects.filter")
     def test_command_idempotency(
-        self, mock_user_filter, mock_badge_get_or_create, mock_user_badge_filter, mock_user_badge_get_or_create, mock_entity_member_filter
+        self, mock_user_filter, mock_badge_get_or_create, mock_user_badge_filter, mock_user_badge_get_or_create, mock_entity_member_filter, mock_content_type
     ):
         """Test that running the command multiple times has the same effect as running it once."""
+        # Mock ContentType
+        mock_project_content_type = MagicMock()
+        mock_content_type.return_value = mock_project_content_type
+
         # Set up badge mocks
         mock_staff_badge = MagicMock()
         mock_staff_badge.name = OWASP_STAFF_BADGE_NAME
@@ -267,6 +277,7 @@ class TestSyncUserBadgesCommand:
         )
         assert "Removed badge from 0 non-leaders" in out2.getvalue()
 
+    @patch("apps.nest.management.commands.nest_update_badges.ContentType.objects.get_for_model")
     @patch("apps.nest.management.commands.nest_update_badges.EntityMember.objects.filter")
     @patch("apps.nest.management.commands.nest_update_badges.UserBadge.objects.get_or_create")
     @patch("apps.nest.management.commands.nest_update_badges.UserBadge.objects.filter")
@@ -279,7 +290,12 @@ class TestSyncUserBadgesCommand:
         mock_user_badge_filter,
         mock_user_badge_get_or_create,
         mock_entity_member_filter,
+        mock_content_type,
     ):
+        # Mock ContentType
+        mock_project_content_type = MagicMock()
+        mock_content_type.return_value = mock_project_content_type
+
         # Set up badge mocks for both staff and project leader badges
         mock_staff_badge = MagicMock()
         mock_staff_badge.name = OWASP_STAFF_BADGE_NAME


### PR DESCRIPTION
## Summary

This PR extends the existing badge synchronization logic to recognize **OWASP Project Leaders**.  
Previously, the `nest_update_badges` command only handled OWASP Staff badges, so project leaders were not automatically awarded a badge.

With this change, active and reviewed project leaders now receive a **Project Leader** badge automatically, and the badge is removed if the user is no longer a leader. The implementation follows the same pattern as the existing staff badge logic and is safe to run multiple times.

Fixed: #2892 

## Changes Made

- Added `update_project_leader_badge()` to `nest_update_badges.py`
- Uses the `EntityMember` model to identify users with the `LEADER` role
- Filters only active and reviewed members
- Creates the **Project Leader** badge if it does not exist
- Assigns badges to eligible users and removes them from former leaders
- Extended backend tests to cover project leader badge assignment and idempotency
