### PR TITLE
Fix project statistics animation reset on Home page

### DIFF
--- a/frontend/src/components/AnimatedCounter.tsx
+++ b/frontend/src/components/AnimatedCounter.tsx
@@ -9,26 +9,38 @@ interface AnimatedCounterProps {
 
 export default function AnimatedCounter({ end, duration, className }: AnimatedCounterProps) {
   const [count, setCount] = useState(0)
-  const countRef = useRef(count)
-  const startTime = useRef(Date.now())
+  const countRef = useRef(0)
+  const startTime = useRef(0)
 
   useEffect(() => {
+    startTime.current = Date.now()
+    countRef.current = 0
+    setCount(0)
+
+    let frameId: number
+
     const animate = () => {
       const now = Date.now()
-      const progress = Math.min((now - startTime.current) / (duration * 1000), 1)
+      const progress = Math.min(
+        (now - startTime.current) / (duration * 1000),
+        1
+      )
+
       const currentCount = Math.floor(progress * end)
 
       if (currentCount !== countRef.current) {
-        setCount(currentCount)
         countRef.current = currentCount
+        setCount(currentCount)
       }
 
       if (progress < 1) {
-        requestAnimationFrame(animate)
+        frameId = requestAnimationFrame(animate)
       }
     }
 
-    requestAnimationFrame(animate)
+    frameId = requestAnimationFrame(animate)
+
+    return () => cancelAnimationFrame(frameId)
   }, [end, duration])
 
   return <span className={className}>{millify(count)}</span>


### PR DESCRIPTION
## Proposed change

Resolves #2868

This PR fixes the issue where project statistics on the Home page were not animating correctly.

The animation logic has been updated so the counter resets and replays as expected when the component mounts or updates. This ensures a smoother and more consistent animation behavior for users viewing the project statistics.
