### PR TITLE
fix: replace switch statement with if-else in mockDashboardCookies

### DIFF
--- a/frontend/__tests__/e2e/helpers/mockDashboardCookies.ts
+++ b/frontend/__tests__/e2e/helpers/mockDashboardCookies.ts
@@ -14,29 +14,26 @@ export const mockDashboardCookies = async (page, mockDashboardData, isOwaspStaff
   })
   await page.route('**/graphql/', async (route, request) => {
     const postData = request.postDataJSON()
-    switch (postData.operationName) {
-      case 'SyncDjangoSession':
-        await route.fulfill({
-          status: 200,
-          json: {
-            data: {
-              githubAuth: {
-                message: 'test message',
-                ok: true,
-                user: { isOwaspStaff: isOwaspStaff },
-              },
+    if (postData.operationName === 'SyncDjangoSession') {
+      await route.fulfill({
+        status: 200,
+        json: {
+          data: {
+            githubAuth: {
+              message: 'test message',
+              ok: true,
+              user: { isOwaspStaff: isOwaspStaff },
             },
           },
-        })
-        break
-      default:
-        await route.fulfill({
-          status: 200,
-          json: {
-            data: mockDashboardData,
-          },
-        })
-        break
+        },
+      })
+    } else {
+      await route.fulfill({
+        status: 200,
+        json: {
+          data: mockDashboardData,
+        },
+      })
     }
   })
   await page.context().addCookies([


### PR DESCRIPTION
## Proposed change
Replace switch statement to if-else for improved readability in mockDashboardCookies helper
<!-- Don't forget to link your PR to an existing issue if any.-->
Resolves #2904

<!-- Describe the big picture of your changes.-->
A switch statement is used to handle GraphQL operation names in
`frontend/__tests__/e2e/helpers/mockDashboardCookies.ts`, even though only a single specific case (`SyncDjangoSession`) is handled.

For a single condition using `if` statement is simpler and more concise.


## Checklist

- [x] I read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md)
- [x] I ran `make check-test` locally and all tests passed
- [ ] I used AI for code, documentation, or tests in this PR
