### PR TITLE
fix: remove duplicate docstring from release mixin property

### DIFF
--- a/backend/apps/github/models/mixins/release.py
+++ b/backend/apps/github/models/mixins/release.py
@@ -18,7 +18,6 @@ class ReleaseIndexMixin:
     @property
     def idx_author(self) -> list[dict[str, str]]:
         """Return author for indexing."""
-        """Get top contributors."""
         return (
             [
                 {


### PR DESCRIPTION
## Description
This PR fixes a duplicate docstring issue in the release mixin file.

## Changes
- Removed duplicate/incorrect docstring from [idx_author](cci:1://file:///d:/OWASP-Nest/backend/apps/github/models/mixins/release.py:17:4-30:9) property in [backend/apps/github/models/mixins/release.py](cci:7://file:///d:/OWASP-Nest/backend/apps/github/models/mixins/release.py:0:0-0:0)
- The property had two docstrings: one correct ("Return author for indexing.") and one incorrect ("Get top contributors.")

## Related Issue
Closes #2648