### PR TITLE
Conditionally render location icon in New Chapters card

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -240,10 +240,12 @@ export default function Home() {
                       <FaCalendar className="mr-2 h-4 w-4" />
                       <span>{formatDate(chapter.createdAt)}</span>
                     </div>
-                    <div className="flex flex-1 items-center overflow-hidden">
-                      <FaMapMarkerAlt className="mr-2 h-4 w-4" />
-                      <TruncatedText text={chapter.suggestedLocation} />
-                    </div>
+                    {chapter.suggestedLocation && (
+                      <div className="flex flex-1 items-center overflow-hidden">
+                        <FaMapMarkerAlt className="mr-2 h-4 w-4" />
+                        <TruncatedText text={chapter.suggestedLocation} />
+                      </div>
+                    )}
                   </div>
 
                   {chapter.leaders.length > 0 && (


### PR DESCRIPTION
Resolves #2967 

Conditionally render the location icon in the New Chapters card at Home to prevent it from showing when no location is present.

Screenshot:
<img width="521" height="123" alt="image" src="https://github.com/user-attachments/assets/1ef40bd2-a720-435c-84ab-2011810c8dcb" />
(Verified by intentionally setting the location to null on the frontend locally)

## Checklist
- [x] **Required:** I read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md)
- [x] **Required:** I ran `make check-test` locally and all tests passed
- [ ] I used AI for code, documentation, or tests in this PR
