### PR TITLE
Fixed project grahpql node attribute error

### DIFF
--- a/backend/apps/owasp/models/mixins/project.py
+++ b/backend/apps/owasp/models/mixins/project.py
@@ -125,3 +125,8 @@ class ProjectIndexMixin(RepositoryBasedEntityModelMixin):
     def idx_updated_at(self) -> str | float:
         """Return updated at for indexing."""
         return self.updated_at.timestamp() if self.updated_at else ""
+
+    @property
+    def idx_related_urls(self) -> list:
+        """Return related URLs for indexing."""
+        return self.related_urls


### PR DESCRIPTION
Resolves #2964 
 
Summary of Fix:

- Issue: `AttributeError: 'Project' object has no attribute 'idx_related_urls'`

- Cause: The Project model (via ProjectIndexMixin) lacked the idx_related_urls property that the GraphQL API (common.py) was trying to access.

- Resolution: Added idx_related_urls to backend/apps/owasp/models/mixins/project.py.