### PR TITLE
Missing idx_related_urls in Project Index Solved

### DIFF
--- a/backend/apps/owasp/index/registry/project.py
+++ b/backend/apps/owasp/index/registry/project.py
@@ -26,6 +26,7 @@ class ProjectIndex(IndexBase):
         "idx_level",
         "idx_name",
         "idx_organizations",
+        "idx_related_urls",
         "idx_repositories",
         "idx_repositories_count",
         "idx_stars_count",


### PR DESCRIPTION

Resolves #2981 

This change fixes a bug where `idx_related_urls` was missing from the `ProjectIndex` configuration, which could cause schema inconsistencies and potential runtime errors when querying project data via GraphQL.

## Changes

### Backend

#### `backend/apps/owasp/index/registry/project.py`

- Added the `idx_related_urls` field to the `ProjectIndex` fields list.
- This ensures related URLs are properly indexed and available for retrieval.
- Aligns `ProjectIndex` behavior with other entities such as `Chapter`.

```python
fields = (
    # ...
    "idx_organizations",
    "idx_related_urls",  # Added
    "idx_repositories",
    # ...
)
````

## Verification Results

### Manual Verification

* Confirmed that `idx_related_urls` is now present in the `ProjectIndex` `fields` tuple.
* This matches the `ProjectIndexMixin` definition that implements `idx_related_urls`.


