### PR TITLE
Prevent icons from shrinking next to TruncatedText

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -195,7 +195,7 @@ export default function Home() {
                     </div>
                     {event.suggestedLocation && (
                       <div className="flex flex-1 items-center overflow-hidden">
-                        <FaMapMarkerAlt className="mr-1 h-4 w-4" />
+                        <FaMapMarkerAlt className="mr-1 h-4 w-4 shrink-0" />
                         <TruncatedText text={event.suggestedLocation} />
                       </div>
                     )}
@@ -242,7 +242,7 @@ export default function Home() {
                     </div>
                     {chapter.suggestedLocation && (
                       <div className="flex flex-1 items-center overflow-hidden">
-                        <FaMapMarkerAlt className="mr-2 h-4 w-4" />
+                        <FaMapMarkerAlt className="mr-2 h-4 w-4 shrink-0" />
                         <TruncatedText text={chapter.suggestedLocation} />
                       </div>
                     )}
@@ -282,7 +282,10 @@ export default function Home() {
                       <span>{formatDate(project.createdAt)}</span>
                     </div>
                     <div className="mr-4 flex flex-1 items-center overflow-hidden">
-                      <IconWrapper icon={getProjectIcon(project.type)} className="mr-2 h-4 w-4" />
+                      <IconWrapper
+                        icon={getProjectIcon(project.type)}
+                        className="mr-2 h-4 w-4 shrink-0"
+                      />
                       <TruncatedText text={upperFirst(project.type)} />
                     </div>
                   </div>
@@ -359,7 +362,7 @@ export default function Home() {
                     <span>{formatDate(post.publishedAt)}</span>
                   </div>
                   <div className="flex flex-1 items-center overflow-hidden">
-                    <FaUser className="mr-2 h-4 w-4" />
+                    <FaUser className="mr-2 h-4 w-4 shrink-0" />
                     <LeadersList leaders={post.authorName} />
                   </div>
                 </div>

--- a/frontend/src/components/Milestones.tsx
+++ b/frontend/src/components/Milestones.tsx
@@ -53,7 +53,7 @@ const Milestones: React.FC<ProjectMilestonesProps> = ({
           </div>
           {item?.repositoryName && (
             <div className="flex flex-1 items-center overflow-hidden">
-              <FaFolderOpen className="mr-2 h-5 w-4" />
+              <FaFolderOpen className="mr-2 h-5 w-4 shrink-0" />
               <button
                 type="button"
                 className="cursor-pointer overflow-hidden text-ellipsis whitespace-nowrap text-gray-600 hover:underline dark:text-gray-400"

--- a/frontend/src/components/RecentIssues.tsx
+++ b/frontend/src/components/RecentIssues.tsx
@@ -33,7 +33,7 @@ const RecentIssues: React.FC<RecentIssuesProps> = ({ data, showAvatar = true }) 
           </div>
           {item?.repositoryName && (
             <div className="flex flex-1 items-center overflow-hidden">
-              <FaFolderOpen className="mr-2 h-5 w-4" />
+              <FaFolderOpen className="mr-2 h-5 w-4 shrink-0" />
               <button
                 type="button"
                 className="cursor-pointer overflow-hidden text-ellipsis whitespace-nowrap text-gray-600 hover:underline dark:text-gray-400"

--- a/frontend/src/components/RecentPullRequests.tsx
+++ b/frontend/src/components/RecentPullRequests.tsx
@@ -34,7 +34,7 @@ const RecentPullRequests: React.FC<RecentPullRequestsProps> = ({ data, showAvata
 
           {item?.repositoryName && (
             <div className="mr-4 flex flex-1 items-center overflow-hidden">
-              <FaFolderOpen className="mr-2 h-5 w-4" />
+              <FaFolderOpen className="mr-2 h-5 w-4 shrink-0" />
               <button
                 type="button"
                 className="cursor-pointer overflow-hidden text-ellipsis whitespace-nowrap text-gray-600 hover:underline dark:text-gray-400"

--- a/frontend/src/components/Release.tsx
+++ b/frontend/src/components/Release.tsx
@@ -71,7 +71,7 @@ const Release: React.FC<ReleaseProps> = ({
             <span>{formatDate(release.publishedAt)}</span>
           </div>
           <div className="flex flex-1 items-center overflow-hidden">
-            <FaFolderOpen className="mr-2 h-5 w-4" aria-hidden="true" />
+            <FaFolderOpen className="mr-2 h-5 w-4 shrink-0" aria-hidden="true" />
             <button
               type="button"
               className="cursor-pointer overflow-hidden text-ellipsis whitespace-nowrap text-gray-600 hover:underline dark:text-gray-400"


### PR DESCRIPTION
## Proposed change
Resolves #2993 
This PR fixes an issue where icons rendered next to the TruncatedText component appeared smaller when the text was truncated, by adding `shrink-0` to all instances of icons rendered alongside `TruncatedText`

**Example Screenshot**
Before Fix:
<img width="256" height="110" alt="image" src="https://github.com/user-attachments/assets/600f3032-4497-433c-aa7f-c6569d435b72" />
After Fix:
<img width="256" height="110" alt="image" src="https://github.com/user-attachments/assets/2acc1a2e-bdef-475e-bc94-edc433fdca1b" />


## Checklist
- [x] **Required:** I read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md)
- [x] **Required:** I ran `make check-test` locally and all tests passed
- [ ] I used AI for code, documentation, or tests in this PR
