### PR TITLE
Improved locked/unlocked map state in ChapterMap

### DIFF
--- a/frontend/__tests__/unit/components/ChapterMap.test.tsx
+++ b/frontend/__tests__/unit/components/ChapterMap.test.tsx
@@ -234,7 +234,7 @@ describe('ChapterMap', () => {
 
       // Unlock map to enable interactions
       const unlockButton = getByText('Unlock map').closest('button')
-      fireEvent.click(unlockButton!)
+      fireEvent.click(unlockButton)
 
       // Clear mocks to ensure we are testing cleanup calls
       jest.clearAllMocks()
@@ -364,7 +364,7 @@ describe('ChapterMap', () => {
       const { getByText, queryByText } = render(<ChapterMap {...defaultProps} />)
 
       const overlay = getByText('Unlock map').closest('button')
-      fireEvent.click(overlay!)
+      fireEvent.click(overlay)
 
       expect(queryByText('Unlock map')).not.toBeInTheDocument()
     })
@@ -373,7 +373,7 @@ describe('ChapterMap', () => {
       const { getByText } = render(<ChapterMap {...defaultProps} />)
 
       const overlay = getByText('Unlock map').closest('button')
-      fireEvent.click(overlay!)
+      fireEvent.click(overlay)
 
       expect(mockMap.dragging.enable).toHaveBeenCalled()
       expect(mockMap.touchZoom.enable).toHaveBeenCalled()
@@ -395,7 +395,7 @@ describe('ChapterMap', () => {
 
       // Unlock first
       const unlockButton = getByText('Unlock map').closest('button')
-      fireEvent.click(unlockButton!)
+      fireEvent.click(unlockButton)
       expect(queryByText('Unlock map')).not.toBeInTheDocument()
 
       // Press Escape

--- a/frontend/src/components/ChapterMap.tsx
+++ b/frontend/src/components/ChapterMap.tsx
@@ -260,16 +260,8 @@ const ChapterMap = ({
       {!isMapActive && (
         <>
           <div
-            role="button"
-            tabIndex={0}
             className="absolute inset-0 z-[2000] rounded-[inherit] bg-black/10"
-            onClick={() => setIsMapActive(false)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                setIsMapActive(false)
-              }
-            }}
-            aria-label="Lock map"
+            aria-hidden="true"
           />
           <div className="pointer-events-none absolute inset-0 z-[2000] flex items-center justify-center">
             <button


### PR DESCRIPTION
## Proposed change
Resolves #3012

### Overview
Improved the ChapterMap user experience by implementing a locked/unlocked state system to prevent accidental map interactions while browsing the page, while still allowing intentional map usage.

### Changes Made

**1. Locked Map State (Default)**
- Map now initializes in a "locked" state to prevent unintentional scrolling/panning
- Disabled interactions on initialization:
  - `dragging: false`
  - `touchZoom: false`
  - `doubleClickZoom: false`
  - `scrollWheelZoom: false`
  - `boxZoom: false`
  - `keyboard: false`
- Zoom control hidden by default
- Minimum zoom level restricted to 2.4 to prevent excessive zoom-out

**2. Centralized Unlock Mechanism**
- Refactored interaction state management using a dedicated `useEffect` hook
- Single source of truth for map interactivity based on `isMapActive` state
- **When Active:**
  - All interaction handlers explicitly enabled
  - Zoom control added to map
- **When Inactive:**
  - All handlers disabled
  - Zoom control removed

**3. Interaction Triggers**
- **Unlock Button Only:** Map unlocks exclusively through the "Unlock map" overlay button (click or keyboard interaction)
- Removed automatic unlock on map click to prevent confusion
- **Auto-lock on mouseout:** Map automatically locks when cursor leaves the map area

**4. Visual Feedback Improvements**
- Markers no longer show pointer cursor when map is locked
- Consistent visual state indicating map is not interactive until explicitly unlocked
- Clear user intent required to activate map interactions

### Benefits
- Prevents frustrating accidental map panning while scrolling the page
- Eliminates confusion from mixed interaction signals (pointer cursor vs locked state)
- Explicit unlock action provides clear user control
- Better mobile/touch experience
- Cleaner, centralized state management for map interactions

### Changes from Maintainer Feedback
- ✅ Removed pointer cursor from markers when map is locked
- ✅ Changed unlock behavior to only activate via the "Unlock map" button
- ✅ Removed automatic unlock on map click to avoid user confusion

## Checklist
- [x] **Required:** I read and followed the [[contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md)](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md)
- [x] **Required:** I ran `make check-test` locally and all tests passed
- [ ] I used AI for code, documentation, or tests in this PR

