### PR TITLE
Renamed import to node:os

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,4 +1,4 @@
-import os from 'os'
+import os from 'node:os'
 import { defineConfig, devices } from '@playwright/test'
 
 export default defineConfig({


### PR DESCRIPTION
## Proposed change

<!-- Don't forget to link your PR to an existing issue.-->
Resolves #3014 

<!-- Describe the big picture of your changes.-->
renamed import from 'os' to 'node:os' as it is a .ts file i won't cause any issue

## Checklist

- [X] **Required:** I read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md)
- [X] **Required:** I ran `make check-test` locally and all tests passed
- [ ] I used AI for code, documentation, or tests in this PR
