### PR TITLE
Refactor regex to use concise wildcard

### DIFF
--- a/backend/apps/owasp/models/common.py
+++ b/backend/apps/owasp/models/common.py
@@ -236,7 +236,7 @@ class RepositoryBasedEntityModel(models.Model):
         """Get entity metadata."""
         try:
             yaml_content = re.search(
-                r"^---\s*([\s\S]*?)\s*---",
+                r"^---\s*(.*?)\s*---",
                 get_repository_file_content(self.index_md_url),
                 re.DOTALL,
             )


### PR DESCRIPTION
## Proposed change

Resolves #3013

This PR updates a regular expression in  
`backend/apps/owasp/models/common.py` to make it easier to read and maintain.

The existing pattern used `[\s\S]` to match any character. This has been replaced with the equivalent wildcard `.` , which is clearer and follows common regex best practices.

## Why this change?

- Fixes a low-severity code smell reported by SonarCloud
- Improves readability while keeping the behaviour unchanged
- Keeps the change small and focused on a single line

## Checklist

- [x] **Required:** I read and followed the contributing guidelines
- [ ] **Required:** I ran `make check-test` locally and all tests passed
- [ ] I used AI for code, documentation, or tests in this PR