### PR TITLE
Fix Array constructor usage to satisfy Sonar rules

### DIFF
--- a/frontend/__tests__/unit/components/ItemCardList.test.tsx
+++ b/frontend/__tests__/unit/components/ItemCardList.test.tsx
@@ -653,7 +653,7 @@ describe('ItemCardList Component', () => {
     })
 
     it('handles large datasets', () => {
-      const largeDataset =Array.from({ length: 100 })
+      const largeDataset = Array.from({ length: 100 })
         .fill(null)
         .map((_, index) => ({
           ...mockIssue,

--- a/frontend/__tests__/unit/components/TopContributorsList.test.tsx
+++ b/frontend/__tests__/unit/components/TopContributorsList.test.tsx
@@ -291,7 +291,7 @@ describe('TopContributorsList Component', () => {
     })
 
     it('respects custom maxInitialDisplay prop', () => {
-      const manyContributors =Array.from({ length: 10 }) 
+      const manyContributors = Array.from({ length: 10 })
         .fill(null)
         .map((_, index) => ({
           ...mockContributors[0],

--- a/frontend/src/components/skeletons/ApiKeySkelton.tsx
+++ b/frontend/src/components/skeletons/ApiKeySkelton.tsx
@@ -51,8 +51,7 @@ export function ApiKeysSkeleton() {
               </thead>
               <tbody>
                 {/* # NOSONAR As safe to use index as key - static skeleton items with fixed length */}
-               {Array.from({ length: totalRows }).map((_, i) => (
-
+                {Array.from({ length: totalRows }).map((_, i) => (
                   <tr key={i} className="border-b-1 border-b-gray-200 dark:border-b-gray-700">
                     <td className="py-3">
                       <div className="h-4 w-24 animate-pulse rounded bg-gray-200 dark:bg-gray-700"></div>

--- a/frontend/src/components/skeletons/Card.tsx
+++ b/frontend/src/components/skeletons/Card.tsx
@@ -58,8 +58,7 @@ const CardSkeleton: React.FC<CardSkeletonProps> = ({
               {showContributors && (
                 <div className="mt-3 flex w-full flex-wrap items-center gap-2">
                   {/* # NOSONAR As safe to use index as key - static skeleton items with fixed length */}
-                 {Array.from({ length: NUM_CONTRIBUTORS }).map((_, i) => (
-
+                  {Array.from({ length: NUM_CONTRIBUTORS }).map((_, i) => (
                     <Skeleton key={i} className="border-background h-8 w-8 rounded-full border-2" />
                   ))}
                 </div>


### PR DESCRIPTION
## Proposed change

Resolves #3031

This PR updates all occurrences of `Array()` to use
`Array.from({ length: ... })`, as recommended by Sonar.

### Summary of changes
- Replaced all `Array()` usages with `Array.from({ length })`
- Updated all 13 instances across 4 files
- No behavioral or logic changes
- Improves static analysis compliance and consistency

### Notes
- Changes are limited to test and UI utility code only
- No impact on application logic or runtime behavior
- Follows the approach suggested by maintainers in the issue discussion

## Checklist

- [x] I read and followed the contributing guidelines
- [x] I ran `make check-test` locally and all tests passed  
- [x] I used AI for code, documentation, or tests in this PR

