### PR TITLE
docs: Add documentation for GET /api/v0/projects/ endpoint

### DIFF
--- a/docs/api/projects.md
+++ b/docs/api/projects.md
@@ -15,64 +15,60 @@ In non-local environments (staging and production), this endpoint is protected b
 - The API uses a custom `ApiKey` authentication class that extends `APIKeyHeader`.
 - Clients must send a valid API key in the HTTP header:
 
-    X-API-Key: YOUR_API_KEY_VALUE
+  X-API-Key: YOUR_API_KEY_VALUE
 
 - If the `X-API-Key` header is missing or invalid, the API returns `401 Unauthorized` with a message indicating a missing or invalid API key.
 - Authenticated requests are subject to an auth-based rate limit of **10 requests per second**.
 
 In local development (`IS_LOCAL_ENVIRONMENT`):
 
-- `auth` is disabled and this endpoint is **publicly accessible without authentication**.
-- Throttling is disabled.
+- auth is disabled and this endpoint is publicly accessible without authentication.
+- throttling is disabled.
 
 ---
 
 ## Request
 
-**Method:** `GET`  
-**Path:** `/api/v0/projects/`  
+Method: GET  
+Path: /api/v0/projects/
 
 ### Query parameters
 
-- `level` (string, query, optional)  
+- level (string, query, optional)  
   Level of the project. Must be one of:
-  - `other`
-  - `incubator`
-  - `lab`
-  - `production`
-  - `flagship`
+  - other
+  - incubator
+  - lab
+  - production
+  - flagship
 
-- `ordering` (string, query, optional)  
+- ordering (string, query, optional)  
   Ordering field. Must be one of:
-  - `created_at`
-  - `-created_at`
-  - `updated_at`
-  - `-updated_at`  
+  - created_at
+  - -created_at
+  - updated_at
+  - -updated_at
 
-  If `ordering` is not provided, the API applies a default ordering in code.
+  If ordering is not provided, the API applies a default ordering in code.
 
-- `page` (integer, query, optional, default: `1`)  
-  Page number (must be **>= 1**). If `page` is less than 1 (for example `page=0`), the API returns **422 Unprocessable Content**.
+- page (integer, query, optional, default: 1)  
+  Page number (must be >= 1). If page is less than 1 (for example page=0), the API returns 422 Unprocessable Content.
 
-- `page_size` (integer, query, optional, default: `100`)  
+- page_size (integer, query, optional, default: 100)  
   Number of items per page.
 
 ### Example request (from OpenAPI “Try it out”, local dev)
 
-```
-curl -X 'GET' \
-  'http://localhost:8000/api/v0/projects/?level=flagship&ordering=created_at&page=1&page_size=100' \
-  -H 'accept: application/json'
-```
+  curl -X 'GET' \
+    'http://localhost:8000/api/v0/projects/?level=flagship&ordering=created_at&page=1&page_size=100' \
+    -H 'accept: application/json'
 
 In a non-local environment, you would also include the API key header:
 
-```
-curl -X 'GET' \
-  'https://<nest-base-url>/api/v0/projects/?level=flagship&ordering=created_at&page=1&page_size=100' \
-  -H 'accept: application/json' \
-  -H 'X-API-Key: YOUR_API_KEY_VALUE'
-```
+  curl -X 'GET' \
+    'https://<nest-base-url>/api/v0/projects/?level=flagship&ordering=created_at&page=1&page_size=100' \
+    -H 'accept: application/json' \
+    -H 'X-API-Key: YOUR_API_KEY_VALUE'
 
 ---
 
@@ -80,126 +76,130 @@ curl -X 'GET' \
 
 ### 200 OK – Paginated project list
 
-Media type: `application/json`
+Media type: application/json
 
-#### Example structure (from OpenAPI schema)
+#### Example response (truncated for brevity)
 
-> Note: The OpenAPI “Example Value” is illustrative. In live responses, `current_page` is 1-based and reflects the `page` parameter (e.g., `page=1` → `current_page: 1`).
+Note: The items array below is intentionally truncated to keep the example readable.
 
-```
-{
-  "current_page": 0,
-  "has_next": true,
-  "has_previous": true,
-  "items": [
-    {
-      "created_at": "2025-12-07T23:11:41.450Z",
-      "key": "string",
-      "level": "other",
-      "name": "string",
-      "updated_at": "2025-12-07T23:11:41.450Z"
-    }
-  ],
-  "total_count": 0,
-  "total_pages": 0
-}
-```
-
-#### Example when no projects exist (local dev “Try it out”)
-
-```
-{
-  "current_page": 1,
-  "has_next": false,
-  "has_previous": false,
-  "items": [],
-  "total_count": 0,
-  "total_pages": 1
-}
-```
+  {
+    "current_page": 1,
+    "has_next": true,
+    "has_previous": false,
+    "total_count": 252,
+    "total_pages": 3,
+    "items": [
+      {
+        "created_at": "2019-09-12T20:15:45Z",
+        "key": "cheat-sheets",
+        "level": "flagship",
+        "name": "OWASP Cheat Sheet Series",
+        "updated_at": "2025-12-15T15:12:05Z"
+      },
+      {
+        "created_at": "2019-09-12T20:24:13Z",
+        "key": "mobile-app-security",
+        "level": "flagship",
+        "name": "OWASP Mobile Application Security",
+        "updated_at": "2025-09-18T06:50:45Z"
+      }
+    ]
+  }
 
 Field overview (based on the schema):
 
-- `current_page`
-- `has_next`
-- `has_previous`
-- `items[]` (array of project objects when present):
-  - `created_at`
-  - `key`
-  - `level`
-  - `name`
-  - `updated_at`
-- `total_count`
-- `total_pages`
-
-> Note: In a fresh local development environment (no data synced), `items` may be empty as shown in the “no projects exist” example above.
+- current_page
+- has_next
+- has_previous
+- items[] (array of project objects when present):
+  - created_at
+  - key
+  - level
+  - name
+  - updated_at
+- total_count
+- total_pages
 
 ---
+
+## Notes
+
+### Pre-sync local development behavior (no projects exist)
+
+In a fresh local development environment (before syncing data), the API may return an empty items array.
+
+Example response (pre-sync):
+
+  {
+    "current_page": 1,
+    "has_next": false,
+    "has_previous": false,
+    "items": [],
+    "total_count": 0,
+    "total_pages": 1
+  }
+
+---
+
 ### 404 Not Found — Page out of range
 
 Happens when page is greater than total_pages
 
-```
-{
-    "detail": "Not Found: Page 2 not found. Valid pages are 1 to 1."
-}
-```
+  {
+    "detail": "Not Found: Page 3000 not found. Valid pages are 1 to 3."
+  }
 
 ---
 
 ### 422 Unprocessable Content – Invalid query parameters
 
-Returned when query parameters do not match the expected values. For example, sending `level=1` or `ordering=1` results in a response similar to:
+Returned when query parameters do not match the expected values. For example, sending level=1 or ordering=1 results in a response similar to:
 
-```
-{
-  "detail": [
-    {
-      "type": "enum",
-      "loc": [
-        "query",
-        "level"
-      ],
-      "msg": "Input should be 'other', 'incubator', 'lab', 'production' or 'flagship'",
-      "ctx": {
-        "expected": "'other', 'incubator', 'lab', 'production' or 'flagship'"
+  {
+    "detail": [
+      {
+        "type": "enum",
+        "loc": [
+          "query",
+          "level"
+        ],
+        "msg": "Input should be 'other', 'incubator', 'lab', 'production' or 'flagship'",
+        "ctx": {
+          "expected": "'other', 'incubator', 'lab', 'production' or 'flagship'"
+        }
+      },
+      {
+        "type": "literal_error",
+        "loc": [
+          "query",
+          "ordering"
+        ],
+        "msg": "Input should be 'created_at', '-created_at', 'updated_at' or '-updated_at'",
+        "ctx": {
+          "expected": "'created_at', '-created_at', 'updated_at' or '-updated_at'"
+        }
       }
-    },
-    {
-      "type": "literal_error",
-      "loc": [
-        "query",
-        "ordering"
-      ],
-      "msg": "Input should be 'created_at', '-created_at', 'updated_at' or '-updated_at'",
-      "ctx": {
-        "expected": "'created_at', '-created_at', 'updated_at' or '-updated_at'"
+    ]
+  }
+
+To fix, update level and ordering to one of the valid values listed above.
+
+#### Example – Invalid page (e.g., page=0)
+
+  {
+    "detail": [
+      {
+        "type": "greater_than_equal",
+        "loc": [
+          "query",
+          "page"
+        ],
+        "msg": "Input should be greater than or equal to 1",
+        "ctx": {
+          "ge": 1
+        }
       }
-    }
-  ]
-}
-```
+    ]
+  }
 
-To fix, update `level` and `ordering` to one of the valid values listed above.
-
-#### Example – Invalid `page` (e.g., `page=0`)
-
-```
-{
-  "detail": [
-    {
-      "type": "greater_than_equal",
-      "loc": [
-        "query",
-        "page"
-      ],
-      "msg": "Input should be greater than or equal to 1",
-      "ctx": {
-        "ge": 1
-      }
-    }
-  ]
-}
-```
-
-To fix ensure `page` is **>= 1**.
+To fix ensure page is >= 1.


### PR DESCRIPTION
## Proposed change

<!-- Don't forget to link your PR to an existing issue.-->
Resolves #3062
Refs #3062

<!-- Describe the big picture of your changes.-->
Adds initial documentation for the Projects list endpoint: `GET /api/v0/projects/`

This doc covers:
- Endpoint purpose and how it’s used to discover project keys/IDs for follow-up calls.
- Authentication behavior differences between local development and non-local environments (API key via `X-API-Key`, plus notes on rate limiting/throttling behavior as documented).
- Supported query parameters (`level`, `ordering`, `page`, `page_size`) and expected validation behavior.
- Example requests for local dev and non-local usage.
- Response envelope and field overview, including a realistic 200 OK example (truncated for readability).
- Notes for pre-sync local behavior where `items` can be empty.
- Error examples for page out of range (404) and invalid query params (422), based on observed local behavior.

## Checklist

- [x] **Required:** I read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md)
- [x] **Required:** I ran `make check-test` locally and all tests passed
- [x] I used AI for code, documentation, or tests in this PR
