### PR TITLE
refactor: remove redundant exception handling in owasp_sync_board_candidates.py

### DIFF
--- a/backend/apps/owasp/management/commands/owasp_sync_board_candidates.py
+++ b/backend/apps/owasp/management/commands/owasp_sync_board_candidates.py
@@ -158,7 +158,7 @@ class Command(BaseCommand):
                     for item in items
                     if item.get("type") == "dir" and item.get("name", "").isdigit()
                 ]
-            except (json.JSONDecodeError, KeyError, ValueError) as e:
+            except (KeyError, ValueError) as e:
                 self.stderr.write(self.style.ERROR(f"Could not fetch repository structure: {e}"))
                 return
 


### PR DESCRIPTION
## Proposed change
Resolves #3029

This PR fixes a Low/Medium SonarCloud-reported code smell by removing redundant exception handling.
json.JSONDecodeError inherits from ValueError, so catching both was unnecessary.

## Checklist
- [x] **Required:** I read and followed the contributing guidelines
- [x] **Required:** I ran `make check-test` locally OR verified the change is trivial and does not affect functionality
- [x] I used AI for code explanation and guidance, but all code and final decisions are my own
