### PR TITLE
fix(board): render error state instead of infinite loader when data i…

### DIFF
--- a/frontend/src/app/board/[year]/candidates/page.tsx
+++ b/frontend/src/app/board/[year]/candidates/page.tsx
@@ -675,11 +675,7 @@ const BoardCandidatesPage = () => {
       </Button>
     )
   }
-
-  if (isLoading) {
-    return <LoadingSpinner />
-  }
-
+  
   if (!graphQLData?.boardOfDirectors) {
     return (
       <ErrorDisplay
@@ -689,7 +685,11 @@ const BoardCandidatesPage = () => {
       />
     )
   }
-
+  
+  if (isLoading) {
+    return <LoadingSpinner />
+  }
+  
   return (
     <div className="container mx-auto px-4 py-8">
       <div className="mb-8">


### PR DESCRIPTION
## Proposed change

Resolves #3052

**Contributor:** Soumya (GitHub: @nios-x)  
**Role:** Student contributor (GSoC aspirant)

This PR fixes an issue on the Board page where the UI enters an infinite loading state when the GraphQL response for a selected year returns `null`.

Previously, the loading state was rendered before validating whether `boardOfDirectors` data existed. As a result, when the query completed successfully but returned `null`, the page remained stuck on the loading spinner.

This change updates the conditional rendering logic to:
- Check for `null` board data before rendering the loading state
- Display a proper 404-style error message when board data is not available
- Ensure the loading spinner is shown only while the query is actively loading

## Checklist

- [x] **Required:** I read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md)
- [x] **Required:** I ran `make check-test` locally and all tests passed
- [ ] I used AI for code, documentation, or tests in this PR