### PR TITLE
fix search-bar loading logic

### DIFF
--- a/frontend/__tests__/unit/components/Search.test.tsx
+++ b/frontend/__tests__/unit/components/Search.test.tsx
@@ -21,7 +21,7 @@ jest.mock('lodash/debounce', () => {
 describe('SearchBar Component', () => {
   const mockOnSearch = jest.fn()
   const defaultProps = {
-    isLoaded: false,
+    isLoaded: true,
     onSearch: mockOnSearch,
     placeholder: 'Search projects...',
   }
@@ -52,8 +52,8 @@ describe('SearchBar Component', () => {
   })
 
   describe('Conditional rendering logic', () => {
-    it('shows skeleton when isLoaded is true', () => {
-      const { container } = render(<SearchBar {...defaultProps} isLoaded={true} />)
+    it('shows skeleton when isLoaded is false', () => {
+      const { container } = render(<SearchBar {...defaultProps} isLoaded={false} />)
       const skeleton = container.querySelector('.h-12.rounded-lg:not(input)')
       const input = screen.queryByPlaceholderText('Search projects...')
       expect(input).not.toBeInTheDocument()
@@ -61,8 +61,8 @@ describe('SearchBar Component', () => {
       expect(skeleton).toHaveClass('h-12 rounded-lg')
     })
 
-    it('shows input when isLoaded is false', () => {
-      const { container } = render(<SearchBar {...defaultProps} isLoaded={false} />)
+    it('shows input when isLoaded is true', () => {
+      const { container } = render(<SearchBar {...defaultProps} isLoaded={true} />)
       const skeleton = container.querySelector('.h-12.rounded-lg:not(input)')
       const input = screen.getByPlaceholderText('Search projects...')
       expect(skeleton).not.toBeInTheDocument()
@@ -70,7 +70,7 @@ describe('SearchBar Component', () => {
     })
 
     it('does not show clear button when searchQuery is empty', () => {
-      const { container } = render(<SearchBar {...defaultProps} isLoaded={false} />)
+      const { container } = render(<SearchBar {...defaultProps} isLoaded={true} />)
       const input = screen.getByPlaceholderText('Search projects...')
       expect(input).toHaveValue('')
       const clearButton = container.querySelector('button.absolute.rounded-md[class*="right-2"]')
@@ -78,7 +78,7 @@ describe('SearchBar Component', () => {
     })
 
     it('shows clear button when searchQuery is not empty', () => {
-      const { container } = render(<SearchBar {...defaultProps} isLoaded={false} />)
+      const { container } = render(<SearchBar {...defaultProps} isLoaded={true} />)
       const input = screen.getByPlaceholderText('Search projects...')
       fireEvent.change(input, { target: { value: 'test' } })
       const clearButton = container.querySelector('button.absolute.rounded-md[class*="right-2"]')
@@ -89,7 +89,7 @@ describe('SearchBar Component', () => {
   describe('Prop-based behavior – different props affect output', () => {
     it('uses initialValue prop as default search query', async () => {
       const initialValue = 'default search'
-      render(<SearchBar {...defaultProps} isLoaded={false} initialValue={initialValue} />)
+      render(<SearchBar {...defaultProps} isLoaded={true} initialValue={initialValue} />)
       const input = screen.getByPlaceholderText('Search projects...')
 
       expect(input).toHaveValue(initialValue)
@@ -111,24 +111,24 @@ describe('SearchBar Component', () => {
 
   describe('Auto-focus functionality', () => {
     it('should auto-focus on initial render', () => {
-      render(<SearchBar {...defaultProps} isLoaded={false} />)
+      render(<SearchBar {...defaultProps} isLoaded={true} />)
       const input = screen.getByPlaceholderText('Search projects...')
       expect(input).toHaveFocus()
     })
 
     it('should not lose focus on re-renders', () => {
-      const { rerender } = render(<SearchBar {...defaultProps} isLoaded={false} />)
+      const { rerender } = render(<SearchBar {...defaultProps} isLoaded={true} />)
       const input = screen.getByPlaceholderText('Search projects...')
       expect(input).toHaveFocus()
 
-      rerender(<SearchBar {...defaultProps} isLoaded={false} placeholder="New placeholder" />)
+      rerender(<SearchBar {...defaultProps} isLoaded={true} placeholder="New placeholder" />)
       expect(input).toHaveFocus()
     })
   })
 
   describe('Event handling – simulate user actions and verify callbacks', () => {
     it('calls onSearch with debounced input value', async () => {
-      render(<SearchBar {...defaultProps} isLoaded={false} />)
+      render(<SearchBar {...defaultProps} isLoaded={true} />)
       const input = screen.getByPlaceholderText('Search projects...')
 
       fireEvent.change(input, { target: { value: 'test' } })
@@ -141,7 +141,7 @@ describe('SearchBar Component', () => {
     })
 
     it('clears input when clear button is clicked', async () => {
-      const { container } = render(<SearchBar {...defaultProps} isLoaded={false} />)
+      const { container } = render(<SearchBar {...defaultProps} isLoaded={true} />)
       const input = screen.getByPlaceholderText('Search projects...')
       fireEvent.change(input, { target: { value: 'test' } })
       expect(input).toHaveValue('test')
@@ -151,7 +151,7 @@ describe('SearchBar Component', () => {
     })
 
     it('calls onSearch when input value changes', async () => {
-      render(<SearchBar {...defaultProps} isLoaded={false} />)
+      render(<SearchBar {...defaultProps} isLoaded={true} />)
       const input = screen.getByPlaceholderText('Search projects...')
       fireEvent.change(input, { target: { value: 'test' } })
 
@@ -176,7 +176,7 @@ describe('SearchBar Component', () => {
     })
 
     it('sends GTM event when search query is not empty', async () => {
-      render(<SearchBar {...defaultProps} isLoaded={false} />)
+      render(<SearchBar {...defaultProps} isLoaded={true} />)
       const input = screen.getByPlaceholderText('Search projects...')
 
       fireEvent.change(input, { target: { value: 'test' } })
@@ -193,7 +193,7 @@ describe('SearchBar Component', () => {
 
   describe('State changes / internal logic', () => {
     it('updates searchQuery state when input value changes', async () => {
-      render(<SearchBar {...defaultProps} isLoaded={false} />)
+      render(<SearchBar {...defaultProps} isLoaded={true} />)
       const input = screen.getByPlaceholderText('Search projects...')
 
       fireEvent.change(input, { target: { value: 'new query' } })
@@ -220,7 +220,7 @@ describe('SearchBar Component', () => {
     })
 
     it('maintains internal state correctly during rapid input changes', () => {
-      render(<SearchBar {...defaultProps} isLoaded={false} />)
+      render(<SearchBar {...defaultProps} isLoaded={true} />)
       const input = screen.getByPlaceholderText('Search projects...')
 
       fireEvent.change(input, { target: { value: 'a' } })
@@ -233,14 +233,14 @@ describe('SearchBar Component', () => {
 
   describe('Default values and fallbacks', () => {
     it('uses default empty string when no initialValue provided', () => {
-      render(<SearchBar {...defaultProps} isLoaded={false} />)
+      render(<SearchBar {...defaultProps} isLoaded={true} />)
       const input = screen.getByPlaceholderText('Search projects...')
       expect(input).toHaveValue('')
     })
 
     it('handles undefined props gracefully', () => {
       const minimalProps = {
-        isLoaded: false,
+        isLoaded: true,
         onSearch: mockOnSearch,
         placeholder: 'Search projects...',
       }
@@ -253,7 +253,7 @@ describe('SearchBar Component', () => {
 
   describe('Text and content rendering', () => {
     it('renders the correct placeholder text', () => {
-      render(<SearchBar {...defaultProps} isLoaded={false} />)
+      render(<SearchBar {...defaultProps} isLoaded={true} />)
       const input = screen.getByPlaceholderText('Search projects...')
       expect(input).toBeInTheDocument()
       expect(input).toHaveAttribute('placeholder', 'Search projects...')
@@ -264,7 +264,7 @@ describe('SearchBar Component', () => {
     })
 
     it('displays typed text correctly in input', () => {
-      render(<SearchBar {...defaultProps} isLoaded={false} />)
+      render(<SearchBar {...defaultProps} isLoaded={true} />)
       const input = screen.getByPlaceholderText('Search projects...')
 
       const testValue = 'search term'
@@ -275,7 +275,7 @@ describe('SearchBar Component', () => {
 
   describe('Handles edge cases and invalid inputs', () => {
     it('handles empty input gracefully', () => {
-      render(<SearchBar {...defaultProps} isLoaded={false} />)
+      render(<SearchBar {...defaultProps} isLoaded={true} />)
       const input = screen.getByPlaceholderText('Search projects...')
 
       fireEvent.change(input, { target: { value: '' } })
@@ -286,7 +286,7 @@ describe('SearchBar Component', () => {
     })
 
     it('handles special characters in input', () => {
-      render(<SearchBar {...defaultProps} isLoaded={false} />)
+      render(<SearchBar {...defaultProps} isLoaded={true} />)
       const input = screen.getByPlaceholderText('Search projects...')
 
       const specialChars = '!@#$%^&*()_+-=[]{}|;:,.<>?'
@@ -296,7 +296,7 @@ describe('SearchBar Component', () => {
     })
 
     it('handles very long input strings', () => {
-      render(<SearchBar {...defaultProps} isLoaded={false} />)
+      render(<SearchBar {...defaultProps} isLoaded={true} />)
       const input = screen.getByPlaceholderText('Search projects...')
 
       const longString = 'balance'.repeat(140)
@@ -306,7 +306,7 @@ describe('SearchBar Component', () => {
     })
 
     it('cancels pending debounced search when clear button is clicked', async () => {
-      const { container } = render(<SearchBar {...defaultProps} isLoaded={false} />)
+      const { container } = render(<SearchBar {...defaultProps} isLoaded={true} />)
       const input = screen.getByPlaceholderText('Search projects...')
 
       fireEvent.change(input, { target: { value: 'edge case' } })
@@ -328,7 +328,7 @@ describe('SearchBar Component', () => {
 
   describe('Accessibility roles and labels', () => {
     it('has the correct accessibility labels', () => {
-      const { container } = render(<SearchBar {...defaultProps} isLoaded={false} />)
+      const { container } = render(<SearchBar {...defaultProps} isLoaded={true} />)
       const input = screen.getByPlaceholderText('Search projects...')
       expect(input).toBeInTheDocument()
       expect(input).toHaveAttribute('type', 'text')
@@ -340,7 +340,7 @@ describe('SearchBar Component', () => {
     })
 
     it('provides proper ARIA attributes for screen readers', () => {
-      render(<SearchBar {...defaultProps} isLoaded={false} />)
+      render(<SearchBar {...defaultProps} isLoaded={true} />)
       const input = screen.getByPlaceholderText('Search projects...')
       expect(input).toHaveAttribute('type', 'text')
       expect(input).toHaveAttribute('placeholder', 'Search projects...')
@@ -349,7 +349,7 @@ describe('SearchBar Component', () => {
 
   describe('DOM structure / classNames / styles', () => {
     it('has the correct class names and styles for input', () => {
-      render(<SearchBar {...defaultProps} isLoaded={false} />)
+      render(<SearchBar {...defaultProps} isLoaded={true} />)
       const input = screen.getByPlaceholderText('Search projects...')
       expect(input).toHaveClass(
         'h-12 w-full rounded-lg border-1 border-gray-300 bg-white pr-10 pl-10 text-lg text-black focus:ring-1 focus:ring-blue-500 focus:outline-hidden dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:focus:ring-blue-300'
@@ -357,13 +357,13 @@ describe('SearchBar Component', () => {
     })
 
     it('has the correct class names for skeleton', () => {
-      const { container } = render(<SearchBar {...defaultProps} isLoaded={true} />)
+      const { container } = render(<SearchBar {...defaultProps} isLoaded={false} />)
       const skeleton = container.querySelector('.h-12.rounded-lg:not(input)')
       expect(skeleton).toHaveClass('h-12 rounded-lg')
     })
 
     it('has the correct class names for clear button', () => {
-      const { container } = render(<SearchBar {...defaultProps} isLoaded={false} />)
+      const { container } = render(<SearchBar {...defaultProps} isLoaded={true} />)
       const input = screen.getByPlaceholderText('Search projects...')
       fireEvent.change(input, { target: { value: 'test' } })
       const clearButton = container.querySelector('button.absolute.rounded-md[class*="right-2"]')
@@ -373,13 +373,13 @@ describe('SearchBar Component', () => {
     })
 
     it('has the correct class names for search icon', () => {
-      render(<SearchBar {...defaultProps} isLoaded={false} />)
+      render(<SearchBar {...defaultProps} isLoaded={true} />)
       const searchIcon = screen.getByTestId('search-icon')
       expect(searchIcon).toBeInTheDocument()
     })
 
     it('maintains proper DOM structure with all elements', () => {
-      render(<SearchBar {...defaultProps} isLoaded={false} />)
+      render(<SearchBar {...defaultProps} isLoaded={true} />)
       const input = screen.getByPlaceholderText('Search projects...')
       const searchIcon = document.querySelector(
         String.raw`svg.pointer-events-none.absolute.left-3.top-1\/2.h-4.w-4.-translate-y-1\/2.text-gray-400`

--- a/frontend/src/components/Search.tsx
+++ b/frontend/src/components/Search.tsx
@@ -27,7 +27,7 @@ const SearchBar: React.FC<SearchProps> = ({
   }, [initialValue])
 
   useEffect(() => {
-    if (!isLoaded && inputRef.current) {
+    if (isLoaded && inputRef.current) {
       inputRef.current.focus()
     }
   }, [pathname, isLoaded])
@@ -69,7 +69,7 @@ const SearchBar: React.FC<SearchProps> = ({
   return (
     <div className="w-full max-w-md p-4">
       <div className="relative">
-        {!isLoaded ? (
+        {isLoaded ? (
           <>
             <FaSearch
               data-testid="search-icon"

--- a/frontend/src/components/SearchPageLayout.tsx
+++ b/frontend/src/components/SearchPageLayout.tsx
@@ -43,7 +43,7 @@ const SearchPageLayout = ({
     <div className="text-text flex min-h-screen w-full flex-col items-center justify-normal p-5">
       <div className="flex w-full items-center justify-center">
         <SearchBar
-          isLoaded={isFirstLoad}
+          isLoaded={!isFirstLoad}
           onSearch={onSearch}
           placeholder={searchPlaceholder}
           initialValue={searchQuery}


### PR DESCRIPTION

## Proposed change

<!-- Don't forget to link your PR to an existing issue.-->
Resolves #3051

<!-- Describe the big picture of your changes.-->
This PR fixes the inverted loading logic in the SearchBar component to ensure consistency across the codebase (specifically with MultiSearchBar) and follows standard project conventions where isLoaded=true indicates the data/component is ready.
Refactored the unit tests to match the new logic, ensuring all tests correctly verify the skeleton and input states.

## Checklist

- [x] **Required:** I read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md)
- [x] **Required:** I ran `make check-test` locally and all tests passed
- [ ] I used AI for code, documentation, or tests in this PR
