### PR TITLE
[Bug]:File path overflows card border on iPhone 12 Pro

### DIFF
--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -97,19 +97,10 @@ const Card = ({
         </Link>
       )}
 
-<Markdown
-  content={summary}
-  className="
-    mt-2 w-full
-    break-words
-    [overflow-wrap:anywhere]
-    [&_code]:break-all
-    [&_a]:break-all
-    text-gray-600
-    dark:text-gray-300
-  "
-/>
-
+      <Markdown
+        content={summary}
+        className="mt-2 w-full [overflow-wrap:anywhere] break-words text-gray-600 dark:text-gray-300 [&_a]:break-all [&_code]:break-all"
+      />
 
       <div className="mt-4 w-full">
         {/* Social icons section */}


### PR DESCRIPTION
## Proposed change

Resolves #2989

This PR fixes a mobile responsiveness issue where long inline code snippets
and URLs in issue summaries caused cards to overflow horizontally on small
screens.

The fix enables safe word wrapping for Markdown-rendered content, including
inline code and links, allowing cards to expand vertically on mobile devices
without affecting the desktop layout.

screenshots before change ->
<img width="927" height="971" alt="image" src="https://github.com/user-attachments/assets/83cd1986-ce27-48e9-a7eb-26f12efb4458" />
screenshots after change ->
<img width="730" height="833" alt="Screenshot 2025-12-29 223623" src="https://github.com/user-attachments/assets/38e8f05a-5c07-4887-ad33-861e38feeeeb" />



## Checklist

- [x] **Required:** I read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md)
- [x] **Required:** I ran `make check-test` locally and all tests passed
- [ ] I used AI for code, documentation, or tests in this PR
