### PR TITLE
fix(board): render error state instead of infinite loader when data  is null

### DIFF
--- a/frontend/src/app/board/[year]/candidates/page.tsx
+++ b/frontend/src/app/board/[year]/candidates/page.tsx
@@ -88,7 +88,11 @@ const BoardCandidatesPage = () => {
   const { year } = useParams<{ year: string }>()
   const [candidates, setCandidates] = useState<CandidateWithSnapshot[]>([])
 
-  const { data: graphQLData, error: graphQLRequestError, loading } = useQuery(GetBoardCandidatesDocument, {
+  const {
+    data: graphQLData,
+    error: graphQLRequestError,
+    loading,
+  } = useQuery(GetBoardCandidatesDocument, {
     variables: { year: Number.parseInt(year) },
   })
 


### PR DESCRIPTION
## Proposed change

Resolves #3052

**Contributor:** Soumya (GitHub: @nios-x)  
**Role:** Student contributor (GSoC aspirant)

This PR fixes an issue on the Board page where the UI enters an infinite loading state when the GraphQL response for a selected year returns `null`.

Previously, the loading state was rendered before validating whether `boardOfDirectors` data existed. As a result, when the query completed successfully but returned `null`, the page remained stuck on the loading spinner.

This change updates the conditional rendering logic to:
- Check for `null` board data before rendering the loading state
- Display a proper 404-style error message when board data is not available
- Ensure the loading spinner is shown only while the query is actively loading

## Checklist

- [x] **Required:** I read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md)
- [x] **Required:** I ran `make check-test` locally and all tests passed
- [ ] I used AI for code, documentation, or tests in this PR



Previous ScreenShots:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b4c7ab09-f7c9-4825-bf63-3f426937d7c5" />


Current ScreenShots 
<img width="1920" height="1080" alt="Screenshot 2025-12-29 195452" src="https://github.com/user-attachments/assets/e0d91930-a43c-4172-b566-7b461a058714" />


