### PR TITLE
Refactor get_leaders regex to reduce cognitive complexity

### DIFF
--- a/frontend/src/utils/breadcrumb.ts
+++ b/frontend/src/utils/breadcrumb.ts
@@ -4,12 +4,12 @@ export function formatBreadcrumbTitle(text: string): string {
   const DATE_TOKEN = '__DATE_HYPHEN__'
   const datePattern = /\d{4}-\d{1,2}(?:-\d{1,2})?/g
 
-  const protectedText = text.replace(datePattern, (match) => match.replaceAll('-', DATE_TOKEN))
+  const protectedText = text.replace(datePattern, (match) => match.replace(/-/g, DATE_TOKEN))
 
   return protectedText
     .split('-')
     .map((segment) => {
-      const restored = segment.replaceAll(DATE_TOKEN, '-')
+      const restored = segment.replace(new RegExp(DATE_TOKEN, 'g'), '-')
       return restored ? restored[0].toUpperCase() + restored.slice(1) : ''
     })
     .join(' ')


### PR DESCRIPTION
## Proposed change

Resolves #3120 

This PR refactors the `get_leaders` method in `common.py` to resolve a SonarCloud cognitive complexity warning (score 22). 

**Technical Refactor:**
The original regex was overly complex due to nested groups and attempts to handle conditional formatting within the pattern itself. I have simplified the logic by:
1. Using a flatter regex pattern: `r"[-*]\s*(?:\[([^\]]+)\]|([\w\s]+))"`.
2. Handling the removal of parenthetical roles (e.g., "(Project Lead)") via Python's `.split()` method instead of regex lookarounds. 
3. Removing the unused `itertools` import.

**Note on Linter Formatting:**
While running `make check-test`, the project's `ruff` formatter automatically updated the regex on line 178 to use `[\s\S]`. I previously addressed this line in PR #3026 ,  but since the local project tools now insist on this formatting for compliance with the current quality hooks, I have included it here to ensure the CI/CD pipeline passes.

## Checklist

- [x] **Required:** I read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md)
- [x] **Required:** I ran `make check-test` locally and all tests passed
- [ ] I used AI for code, documentation, or tests in this PR