### PR TITLE
Replacing redundant useState loading state with useQuery 

### DIFF
--- a/frontend/src/app/chapters/[chapterKey]/page.tsx
+++ b/frontend/src/app/chapters/[chapterKey]/page.tsx
@@ -2,7 +2,7 @@
 import { useQuery } from '@apollo/client/react'
 import Link from 'next/link'
 import { useParams } from 'next/navigation'
-import { useState, useEffect } from 'react'
+import { useEffect } from 'react'
 import { handleAppError, ErrorDisplay } from 'app/global-error'
 import { GetChapterDataDocument } from 'types/__generated__/chapterQueries.generated'
 import type { Chapter } from 'types/chapter'
@@ -13,31 +13,21 @@ import LoadingSpinner from 'components/LoadingSpinner'
 
 export default function ChapterDetailsPage() {
   const { chapterKey } = useParams<{ chapterKey: string }>()
-  const [chapter, setChapter] = useState<Chapter>({} as Chapter)
-  const [topContributors, setTopContributors] = useState<Contributor[]>([])
-  const [isLoading, setIsLoading] = useState<boolean>(true)
-
-  const { data, error: graphQLRequestError } = useQuery(GetChapterDataDocument, {
+  const { data, loading, error: graphQLRequestError } = useQuery(GetChapterDataDocument, {
     variables: { key: chapterKey },
   })
 
   useEffect(() => {
-    if (data) {
-      setChapter(data.chapter)
-      setTopContributors(data.topContributors)
-      setIsLoading(false)
-    }
     if (graphQLRequestError) {
       handleAppError(graphQLRequestError)
-      setIsLoading(false)
     }
-  }, [data, graphQLRequestError, chapterKey])
+  }, [graphQLRequestError, chapterKey])
 
-  if (isLoading) {
+  if (loading) {
     return <LoadingSpinner />
   }
 
-  if (!chapter && !isLoading)
+  if (!data?.chapter && !loading)
     return (
       <ErrorDisplay
         statusCode={404}
@@ -46,6 +36,7 @@ export default function ChapterDetailsPage() {
       />
     )
 
+  const chapter = data.chapter
   const details = [
     { label: 'Last Updated', value: formatDate(chapter.updatedAt) },
     { label: 'Location', value: chapter.suggestedLocation },
@@ -69,7 +60,7 @@ export default function ChapterDetailsPage() {
       socialLinks={chapter.relatedUrls}
       summary={chapter.summary}
       title={chapter.name}
-      topContributors={topContributors}
+      topContributors={data.topContributors}
       type="chapter"
     />
   )

--- a/frontend/src/app/committees/[committeeKey]/page.tsx
+++ b/frontend/src/app/committees/[committeeKey]/page.tsx
@@ -2,7 +2,7 @@
 import { useQuery } from '@apollo/client/react'
 import Link from 'next/link'
 import { useParams } from 'next/navigation'
-import { useState, useEffect } from 'react'
+import { useEffect } from 'react'
 import { FaExclamationCircle } from 'react-icons/fa'
 import { FaCode, FaCodeFork, FaStar } from 'react-icons/fa6'
 import { HiUserGroup } from 'react-icons/hi'
@@ -16,31 +16,21 @@ import LoadingSpinner from 'components/LoadingSpinner'
 
 export default function CommitteeDetailsPage() {
   const { committeeKey } = useParams<{ committeeKey: string }>()
-  const [committee, setCommittee] = useState<Committee | null>(null)
-  const [topContributors, setTopContributors] = useState<Contributor[]>([])
-  const [isLoading, setIsLoading] = useState<boolean>(true)
-
-  const { data, error: graphQLRequestError } = useQuery(GetCommitteeDataDocument, {
+  const { data, loading, error: graphQLRequestError } = useQuery(GetCommitteeDataDocument, {
     variables: { key: committeeKey },
   })
 
   useEffect(() => {
-    if (data?.committee) {
-      setCommittee(data.committee)
-      setTopContributors(data.topContributors)
-      setIsLoading(false)
-    }
     if (graphQLRequestError) {
       handleAppError(graphQLRequestError)
-      setIsLoading(false)
     }
-  }, [data, graphQLRequestError, committeeKey])
+  }, [graphQLRequestError, committeeKey])
 
-  if (isLoading) {
+  if (loading) {
     return <LoadingSpinner />
   }
 
-  if (!committee && !isLoading)
+  if (!data?.committee && !loading)
     return (
       <ErrorDisplay
         statusCode={404}
@@ -49,6 +39,7 @@ export default function CommitteeDetailsPage() {
       />
     )
 
+  const committee = data.committee
   const details = [
     { label: 'Last Updated', value: formatDate(committee.updatedAt) },
     { label: 'Leaders', value: committee.leaders.join(', ') },
@@ -82,7 +73,7 @@ export default function CommitteeDetailsPage() {
       stats={committeeStats}
       summary={committee.summary}
       title={committee.name}
-      topContributors={topContributors}
+      topContributors={data.topContributors}
       type="committee"
     />
   )

--- a/frontend/src/app/community/snapshots/page.tsx
+++ b/frontend/src/app/community/snapshots/page.tsx
@@ -2,7 +2,7 @@
 import { useQuery } from '@apollo/client/react'
 import { addToast } from '@heroui/toast'
 import { useRouter } from 'next/navigation'
-import React, { useState, useEffect } from 'react'
+import React, { useEffect } from 'react'
 import { FaRightToBracket } from 'react-icons/fa6'
 import { GetCommunitySnapshotsDocument } from 'types/__generated__/snapshotQueries.generated'
 import type { Snapshot } from 'types/snapshot'
@@ -10,16 +10,9 @@ import SnapshotSkeleton from 'components/skeletons/SnapshotSkeleton'
 import SnapshotCard from 'components/SnapshotCard'
 
 const SnapshotsPage: React.FC = () => {
-  const [snapshots, setSnapshots] = useState<Snapshot[] | null>(null)
-  const [isLoading, setIsLoading] = useState<boolean>(true)
-
-  const { data: graphQLData, error: graphQLRequestError } = useQuery(GetCommunitySnapshotsDocument)
+  const { data, loading, error: graphQLRequestError } = useQuery(GetCommunitySnapshotsDocument)
 
   useEffect(() => {
-    if (graphQLData) {
-      setSnapshots(graphQLData.snapshots)
-      setIsLoading(false)
-    }
     if (graphQLRequestError) {
       addToast({
         description: 'Unable to complete the requested operation.',
@@ -29,9 +22,8 @@ const SnapshotsPage: React.FC = () => {
         color: 'danger',
         variant: 'solid',
       })
-      setIsLoading(false)
     }
-  }, [graphQLData, graphQLRequestError])
+  }, [graphQLRequestError])
 
   const router = useRouter()
 
@@ -60,7 +52,7 @@ const SnapshotsPage: React.FC = () => {
   return (
     <div className="min-h-screen p-8 text-gray-600 dark:bg-[#212529] dark:text-gray-300">
       <div className="text-text flex min-h-screen w-full flex-col items-center justify-normal p-5">
-        {isLoading ? (
+        {loading ? (
           <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
             {Array.from({ length: 12 }, (_, index) => (
               <SnapshotSkeleton key={`snapshot-skeleton-${index}`} />
@@ -68,8 +60,8 @@ const SnapshotsPage: React.FC = () => {
           </div>
         ) : (
           <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-            {snapshots?.length ? (
-              snapshots.map((snapshot: Snapshot) => (
+            {data?.snapshots?.length ? (
+              data.snapshots.map((snapshot: Snapshot) => (
                 <div key={snapshot.key}>{renderSnapshotCard(snapshot)}</div>
               ))
             ) : (

--- a/frontend/src/app/organizations/[organizationKey]/page.tsx
+++ b/frontend/src/app/organizations/[organizationKey]/page.tsx
@@ -2,7 +2,7 @@
 import { useQuery } from '@apollo/client/react'
 import Link from 'next/link'
 import { useParams } from 'next/navigation'
-import { useState, useEffect } from 'react'
+import { useEffect } from 'react'
 import { FaExclamationCircle } from 'react-icons/fa'
 import { FaCodeFork, FaFolderOpen, FaStar } from 'react-icons/fa6'
 import { HiUserGroup } from 'react-icons/hi'
@@ -13,36 +13,17 @@ import DetailsCard from 'components/CardDetailsPage'
 import OrganizationDetailsPageSkeleton from 'components/skeletons/OrganizationDetailsPageSkeleton'
 const OrganizationDetailsPage = () => {
   const { organizationKey } = useParams<{ organizationKey: string }>()
-  const [organization, setOrganization] = useState(null)
-  const [issues, setIssues] = useState(null)
-  const [milestones, setMilestones] = useState(null)
-  const [pullRequests, setPullRequests] = useState(null)
-  const [releases, setReleases] = useState(null)
-  const [repositories, setRepositories] = useState(null)
-  const [topContributors, setTopContributors] = useState(null)
-  const [isLoading, setIsLoading] = useState<boolean>(true)
-  const { data: graphQLData, error: graphQLRequestError } = useQuery(GetOrganizationDataDocument, {
+  const { data, loading, error: graphQLRequestError } = useQuery(GetOrganizationDataDocument, {
     variables: { login: organizationKey },
   })
 
   useEffect(() => {
-    if (graphQLData) {
-      setMilestones(graphQLData.recentMilestones)
-      setOrganization(graphQLData.organization)
-      setIssues(graphQLData.recentIssues)
-      setPullRequests(graphQLData.recentPullRequests)
-      setReleases(graphQLData.recentReleases)
-      setRepositories(graphQLData.repositories)
-      setTopContributors(graphQLData.topContributors)
-      setIsLoading(false)
-    }
     if (graphQLRequestError) {
       handleAppError(graphQLRequestError)
-      setIsLoading(false)
     }
-  }, [graphQLData, graphQLRequestError, organizationKey])
+  }, [graphQLRequestError, organizationKey])
 
-  if (isLoading) {
+  if (loading) {
     return (
       <div data-testid="org-loading-skeleton">
         <OrganizationDetailsPageSkeleton />
@@ -50,7 +31,7 @@ const OrganizationDetailsPage = () => {
     )
   }
 
-  if (!isLoading && !graphQLData?.organization) {
+  if (!loading && !data?.organization) {
     return (
       <ErrorDisplay
         message="Sorry, the organization you're looking for doesn't exist"
@@ -60,6 +41,7 @@ const OrganizationDetailsPage = () => {
     )
   }
 
+  const organization = data.organization
   const organizationDetails = [
     {
       label: 'GitHub Profile',
@@ -115,15 +97,15 @@ const OrganizationDetailsPage = () => {
   return (
     <DetailsCard
       details={organizationDetails}
-      recentIssues={issues}
-      recentReleases={releases}
-      recentMilestones={milestones}
-      pullRequests={pullRequests}
-      repositories={repositories}
+      recentIssues={data.recentIssues}
+      recentReleases={data.recentReleases}
+      recentMilestones={data.recentMilestones}
+      pullRequests={data.recentPullRequests}
+      repositories={data.repositories}
       stats={organizationStats}
       summary={organization.description}
       title={organization.name}
-      topContributors={topContributors}
+      topContributors={data.topContributors}
       type="organization"
     />
   )

--- a/frontend/src/app/organizations/[organizationKey]/repositories/[repositoryKey]/page.tsx
+++ b/frontend/src/app/organizations/[organizationKey]/repositories/[repositoryKey]/page.tsx
@@ -2,7 +2,7 @@
 import { useQuery } from '@apollo/client/react'
 import Link from 'next/link'
 import { useParams } from 'next/navigation'
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 import { FaExclamationCircle } from 'react-icons/fa'
 import { FaCodeCommit, FaCodeFork, FaStar } from 'react-icons/fa6'
 import { HiUserGroup } from 'react-icons/hi'
@@ -18,31 +18,20 @@ const RepositoryDetailsPage = () => {
     repositoryKey: string
     organizationKey: string
   }>()
-  const [repository, setRepository] = useState(null)
-  const [topContributors, setTopContributors] = useState<Contributor[]>([])
-  const [recentPullRequests, setRecentPullRequests] = useState(null)
-  const [isLoading, setIsLoading] = useState<boolean>(true)
-  const { data, error: graphQLRequestError } = useQuery(GetRepositoryDataDocument, {
+  const { data, loading, error: graphQLRequestError } = useQuery(GetRepositoryDataDocument, {
     variables: { repositoryKey: repositoryKey, organizationKey: organizationKey },
   })
   useEffect(() => {
-    if (data) {
-      setRepository(data.repository)
-      setTopContributors(data.topContributors)
-      setRecentPullRequests(data.recentPullRequests)
-      setIsLoading(false)
-    }
     if (graphQLRequestError) {
       handleAppError(graphQLRequestError)
-      setIsLoading(false)
     }
-  }, [data, graphQLRequestError, repositoryKey])
+  }, [graphQLRequestError, repositoryKey])
 
-  if (isLoading) {
+  if (loading) {
     return <LoadingSpinner />
   }
 
-  if (!isLoading && !repository) {
+  if (!loading && !data?.repository) {
     return (
       <ErrorDisplay
         message="Sorry, the Repository you're looking for doesn't exist"
@@ -52,6 +41,7 @@ const RepositoryDetailsPage = () => {
     )
   }
 
+  const repository = data.repository
   const repositoryDetails = [
     {
       label: 'Last Updated',
@@ -109,14 +99,14 @@ const RepositoryDetailsPage = () => {
       isArchived={repository.isArchived}
       languages={repository.languages}
       projectName={repository.project?.name}
-      pullRequests={recentPullRequests}
+      pullRequests={data.recentPullRequests}
       recentIssues={repository.issues}
       recentMilestones={repository.recentMilestones}
       recentReleases={repository.releases}
       stats={RepositoryStats}
       summary={repository.description}
       title={repository.name}
-      topContributors={topContributors}
+      topContributors={data.topContributors}
       topics={repository.topics}
       type="repository"
     />

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -45,9 +45,7 @@ import TopContributorsList from 'components/TopContributorsList'
 import { TruncatedText } from 'components/TruncatedText'
 
 export default function Home() {
-  const [isLoading, setIsLoading] = useState<boolean>(true)
-  const [data, setData] = useState<MainPageData>(null)
-  const { data: graphQLData, error: graphQLRequestError } = useQuery(GetMainPageDataDocument, {
+  const { data, loading, error: graphQLRequestError } = useQuery(GetMainPageDataDocument, {
     variables: { distinct: true },
   })
 
@@ -55,10 +53,6 @@ export default function Home() {
   const [modalOpenIndex, setModalOpenIndex] = useState<number | null>(null)
 
   useEffect(() => {
-    if (graphQLData) {
-      setData(graphQLData)
-      setIsLoading(false)
-    }
     if (graphQLRequestError) {
       addToast({
         description: 'Unable to complete the requested operation.',
@@ -68,9 +62,8 @@ export default function Home() {
         color: 'danger',
         variant: 'solid',
       })
-      setIsLoading(false)
     }
-  }, [graphQLData, graphQLRequestError])
+  }, [graphQLRequestError])
 
   useEffect(() => {
     const fetchData = async () => {
@@ -91,7 +84,7 @@ export default function Home() {
     fetchData()
   }, [])
 
-  if (isLoading || !graphQLData || !geoLocData) {
+  if (loading || !data || !geoLocData) {
     return <LoadingSpinner />
   }
 


### PR DESCRIPTION
Refactoring loading state management across multiple pages by removing redundant `useState` variables and using Apollo Client’s built-in `loading` property from `useQuery`. The implementation now aligns with the existing clean patterns in `frontend/src/app/projects/dashboard/metrics/page.tsx` and `frontend/src/app/about/page.tsx`.

## Problem Statement - Fixes #3135 

Several pages were manually managing loading state using `useState` (e.g., `const [isLoading, setIsLoading] = useState(true)`) and updating it inside `useEffect` after fetching data with `useQuery`. Since Apollo already provides a `loading` property, this approach was redundant, harder to maintain, and could lead to synchronization issues between local state and Apollo’s internal state.

## Changes Made

### Files Updated

* `frontend/src/app/page.tsx`
* `frontend/src/app/community/snapshots/page.tsx`
* `frontend/src/app/organizations/[organizationKey]/page.tsx`
* `frontend/src/app/committees/[committeeKey]/page.tsx`
* `frontend/src/app/chapters/[chapterKey]/page.tsx`
* `frontend/src/app/members/[memberKey]/page.tsx`
* `frontend/src/app/organizations/[organizationKey]/repositories/[repositoryKey]/page.tsx`

### Key Refactoring Steps

1. Removed redundant `useState` variables used for tracking loading state.
2. Destructured `loading` directly from `useQuery`.
3. Removed all manual `setIsLoading` updates.
4. Simplified `useEffect` hooks to handle only error scenarios.
5. Used data directly from `useQuery` instead of maintaining a local `data` state.
6. Cleaned up unused imports such as `useState`.

### Before

```typescript
const [isLoading, setIsLoading] = useState(true)
const [data, setData] = useState(null)
const { data: graphQLData, error: graphQLRequestError } = useQuery(...)

useEffect(() => {
  if (graphQLData) {
    setData(graphQLData)
    setIsLoading(false)
  }
  if (graphQLRequestError) {
    handleAppError(graphQLRequestError)
    setIsLoading(false)
  }
}, [graphQLData, graphQLRequestError])

if (isLoading) return <LoadingSpinner />
```

### After

```typescript
const { data, loading, error: graphQLRequestError } = useQuery(...)

useEffect(() => {
  if (graphQLRequestError) {
    handleAppError(graphQLRequestError)
  }
}, [graphQLRequestError])

if (loading) return <LoadingSpinner />
```

## Testing

* Verified all refactored files compile successfully with TypeScript.
* Confirmed no lint or diagnostic errors.
* Verified that loading indicators and error handling work as expected.
* Confirmed there are no UI or functional regressions.
