### PR TITLE
Added return type hints to model manager methods

### DIFF
--- a/backend/apps/mentorship/models/managers/module.py
+++ b/backend/apps/mentorship/models/managers/module.py
@@ -8,6 +8,6 @@ from apps.mentorship.models.program import Program
 class PublishedModuleManager(models.Manager):
     """Published Modules."""
 
-    def get_queryset(self):
+    def get_queryset(self) -> models.QuerySet:
         """Get queryset."""
         return super().get_queryset().filter(program__status=Program.ProgramStatus.PUBLISHED)


### PR DESCRIPTION
Implements task 1 from issue #2646: Add return type hints to model manager methods.

## Changes
- Added return type hint `-> models.QuerySet` to `PublishedModuleManager.get_queryset()` method in `backend/apps/mentorship/models/managers/module.py`

Fixes #2646