### PR TITLE
chore(deps): remove unused frontend dependencies

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -58,7 +58,6 @@
     "react-dom": "^19.2.3",
     "react-icons": "^5.5.0",
     "react-router-dom": "^7.11.0",
-    "rxjs": "^7.8.2",
     "tailwind-merge": "^3.4.0",
     "tailwindcss-animate": "^1.0.7"
   },
@@ -85,7 +84,6 @@
     "@types/node": "^25.0.3",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
-    "@types/react-gtm-module": "^2.0.4",
     "@typescript-eslint/eslint-plugin": "^8.51.0",
     "@typescript-eslint/parser": "^8.51.0",
     "eslint": "^9.39.2",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -131,9 +131,6 @@ importers:
       react-router-dom:
         specifier: ^7.11.0
         version: 7.11.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      rxjs:
-        specifier: ^7.8.2
-        version: 7.8.2
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
@@ -207,9 +204,6 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.7)
-      '@types/react-gtm-module':
-        specifier: ^2.0.4
-        version: 2.0.4
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.51.0
         version: 8.51.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
@@ -3293,9 +3287,6 @@ packages:
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
       '@types/react': ^19.2.0
-
-  '@types/react-gtm-module@2.0.4':
-    resolution: {integrity: sha512-5wPMWsUE5AI6O0B0K1/zbs0rFHBKu+7NWXQwDXhqvA12ooLD6W1AYiWZqR4UiOd7ixZDV1H5Ys301zEsqyIfNg==}
 
   '@types/react@19.2.7':
     resolution: {integrity: sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==}
@@ -11786,8 +11777,6 @@ snapshots:
   '@types/react-dom@19.2.3(@types/react@19.2.7)':
     dependencies:
       '@types/react': 19.2.7
-
-  '@types/react-gtm-module@2.0.4': {}
 
   '@types/react@19.2.7':
     dependencies:


### PR DESCRIPTION
## Proposed change

Resolves #3142

### Summary
This PR removes unused frontend dependencies after verification.

### Details
- Removed `rxjs` from `frontend/package.json` as it is not imported or used anywhere in the codebase or tests.
- Removed `@types/react-gtm-module` after confirming there are no references to Google Tag Manager and the runtime package is not present.
- Updated `pnpm-lock.yaml` accordingly using the repository-specified pnpm version.

This change is limited to dependency cleanup and does not affect application behavior.

## Checklist

- [x] **Required:** I read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md)
- [x] **Required:** I ran dependency installation locally and verified the frontend setup after the change
- [x] I used AI for guidance during investigation and verification; all changes were reviewed and applied manually
