### PR TITLE
Refactor useQuery loading state usage across pages

### DIFF
--- a/frontend/src/app/committees/[committeeKey]/page.tsx
+++ b/frontend/src/app/committees/[committeeKey]/page.tsx
@@ -1,46 +1,33 @@
 'use client'
+
 import { useQuery } from '@apollo/client/react'
 import Link from 'next/link'
 import { useParams } from 'next/navigation'
-import { useState, useEffect } from 'react'
 import { FaExclamationCircle } from 'react-icons/fa'
 import { FaCode, FaCodeFork, FaStar } from 'react-icons/fa6'
 import { HiUserGroup } from 'react-icons/hi'
 import { ErrorDisplay, handleAppError } from 'app/global-error'
 import { GetCommitteeDataDocument } from 'types/__generated__/committeeQueries.generated'
-import type { Committee } from 'types/committee'
-import type { Contributor } from 'types/contributor'
 import { formatDate } from 'utils/dateFormatter'
 import DetailsCard from 'components/CardDetailsPage'
 import LoadingSpinner from 'components/LoadingSpinner'
 
 export default function CommitteeDetailsPage() {
   const { committeeKey } = useParams<{ committeeKey: string }>()
-  const [committee, setCommittee] = useState<Committee | null>(null)
-  const [topContributors, setTopContributors] = useState<Contributor[]>([])
-  const [isLoading, setIsLoading] = useState<boolean>(true)
 
-  const { data, error: graphQLRequestError } = useQuery(GetCommitteeDataDocument, {
+  const { data, error, loading } = useQuery(GetCommitteeDataDocument, {
     variables: { key: committeeKey },
   })
 
-  useEffect(() => {
-    if (data?.committee) {
-      setCommittee(data.committee)
-      setTopContributors(data.topContributors)
-      setIsLoading(false)
-    }
-    if (graphQLRequestError) {
-      handleAppError(graphQLRequestError)
-      setIsLoading(false)
-    }
-  }, [data, graphQLRequestError, committeeKey])
+  if (error) {
+    handleAppError(error)
+  }
 
-  if (isLoading) {
+  if (loading) {
     return <LoadingSpinner />
   }
 
-  if (!committee && !isLoading)
+  if (!data?.committee) {
     return (
       <ErrorDisplay
         statusCode={404}
@@ -48,6 +35,9 @@ export default function CommitteeDetailsPage() {
         message="Sorry, the committee you're looking for doesn't exist"
       />
     )
+  }
+
+  const { committee, topContributors } = data
 
   const details = [
     { label: 'Last Updated', value: formatDate(committee.updatedAt) },

--- a/frontend/src/app/community/snapshots/page.tsx
+++ b/frontend/src/app/community/snapshots/page.tsx
@@ -1,8 +1,9 @@
 'use client'
+
 import { useQuery } from '@apollo/client/react'
 import { addToast } from '@heroui/toast'
 import { useRouter } from 'next/navigation'
-import React, { useState, useEffect } from 'react'
+import React, { useEffect } from 'react'
 import { FaRightToBracket } from 'react-icons/fa6'
 import { GetCommunitySnapshotsDocument } from 'types/__generated__/snapshotQueries.generated'
 import type { Snapshot } from 'types/snapshot'
@@ -10,17 +11,12 @@ import SnapshotSkeleton from 'components/skeletons/SnapshotSkeleton'
 import SnapshotCard from 'components/SnapshotCard'
 
 const SnapshotsPage: React.FC = () => {
-  const [snapshots, setSnapshots] = useState<Snapshot[] | null>(null)
-  const [isLoading, setIsLoading] = useState<boolean>(true)
+  const router = useRouter()
 
-  const { data: graphQLData, error: graphQLRequestError } = useQuery(GetCommunitySnapshotsDocument)
+  const { data, error, loading } = useQuery(GetCommunitySnapshotsDocument)
 
   useEffect(() => {
-    if (graphQLData) {
-      setSnapshots(graphQLData.snapshots)
-      setIsLoading(false)
-    }
-    if (graphQLRequestError) {
+    if (error) {
       addToast({
         description: 'Unable to complete the requested operation.',
         title: 'GraphQL Request Failed',
@@ -29,11 +25,8 @@ const SnapshotsPage: React.FC = () => {
         color: 'danger',
         variant: 'solid',
       })
-      setIsLoading(false)
     }
-  }, [graphQLData, graphQLRequestError])
-
-  const router = useRouter()
+  }, [error])
 
   const handleButtonClick = (snapshot: Snapshot) => {
     router.push(`/community/snapshots/${snapshot.key}`)
@@ -57,10 +50,12 @@ const SnapshotsPage: React.FC = () => {
     )
   }
 
+  const snapshots = data?.snapshots ?? []
+
   return (
     <div className="min-h-screen p-8 text-gray-600 dark:bg-[#212529] dark:text-gray-300">
       <div className="text-text flex min-h-screen w-full flex-col items-center justify-normal p-5">
-        {isLoading ? (
+        {loading ? (
           <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
             {Array.from({ length: 12 }, (_, index) => (
               <SnapshotSkeleton key={`snapshot-skeleton-${index}`} />
@@ -68,7 +63,7 @@ const SnapshotsPage: React.FC = () => {
           </div>
         ) : (
           <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-            {snapshots?.length ? (
+            {snapshots.length ? (
               snapshots.map((snapshot: Snapshot) => (
                 <div key={snapshot.key}>{renderSnapshotCard(snapshot)}</div>
               ))

--- a/frontend/src/app/organizations/[organizationKey]/page.tsx
+++ b/frontend/src/app/organizations/[organizationKey]/page.tsx
@@ -1,8 +1,8 @@
 'use client'
+
 import { useQuery } from '@apollo/client/react'
 import Link from 'next/link'
 import { useParams } from 'next/navigation'
-import { useState, useEffect } from 'react'
 import { FaExclamationCircle } from 'react-icons/fa'
 import { FaCodeFork, FaFolderOpen, FaStar } from 'react-icons/fa6'
 import { HiUserGroup } from 'react-icons/hi'
@@ -11,38 +11,19 @@ import { GetOrganizationDataDocument } from 'types/__generated__/organizationQue
 import { formatDate } from 'utils/dateFormatter'
 import DetailsCard from 'components/CardDetailsPage'
 import OrganizationDetailsPageSkeleton from 'components/skeletons/OrganizationDetailsPageSkeleton'
+
 const OrganizationDetailsPage = () => {
   const { organizationKey } = useParams<{ organizationKey: string }>()
-  const [organization, setOrganization] = useState(null)
-  const [issues, setIssues] = useState(null)
-  const [milestones, setMilestones] = useState(null)
-  const [pullRequests, setPullRequests] = useState(null)
-  const [releases, setReleases] = useState(null)
-  const [repositories, setRepositories] = useState(null)
-  const [topContributors, setTopContributors] = useState(null)
-  const [isLoading, setIsLoading] = useState<boolean>(true)
-  const { data: graphQLData, error: graphQLRequestError } = useQuery(GetOrganizationDataDocument, {
+
+  const { data, error, loading } = useQuery(GetOrganizationDataDocument, {
     variables: { login: organizationKey },
   })
 
-  useEffect(() => {
-    if (graphQLData) {
-      setMilestones(graphQLData.recentMilestones)
-      setOrganization(graphQLData.organization)
-      setIssues(graphQLData.recentIssues)
-      setPullRequests(graphQLData.recentPullRequests)
-      setReleases(graphQLData.recentReleases)
-      setRepositories(graphQLData.repositories)
-      setTopContributors(graphQLData.topContributors)
-      setIsLoading(false)
-    }
-    if (graphQLRequestError) {
-      handleAppError(graphQLRequestError)
-      setIsLoading(false)
-    }
-  }, [graphQLData, graphQLRequestError, organizationKey])
+  if (error) {
+    handleAppError(error)
+  }
 
-  if (isLoading) {
+  if (loading) {
     return (
       <div data-testid="org-loading-skeleton">
         <OrganizationDetailsPageSkeleton />
@@ -50,7 +31,7 @@ const OrganizationDetailsPage = () => {
     )
   }
 
-  if (!isLoading && !graphQLData?.organization) {
+  if (!data?.organization) {
     return (
       <ErrorDisplay
         message="Sorry, the organization you're looking for doesn't exist"
@@ -59,6 +40,16 @@ const OrganizationDetailsPage = () => {
       />
     )
   }
+
+  const {
+    organization,
+    recentIssues,
+    recentMilestones,
+    recentPullRequests,
+    recentReleases,
+    repositories,
+    topContributors,
+  } = data
 
   const organizationDetails = [
     {
@@ -115,10 +106,10 @@ const OrganizationDetailsPage = () => {
   return (
     <DetailsCard
       details={organizationDetails}
-      recentIssues={issues}
-      recentReleases={releases}
-      recentMilestones={milestones}
-      pullRequests={pullRequests}
+      recentIssues={recentIssues}
+      recentReleases={recentReleases}
+      recentMilestones={recentMilestones}
+      pullRequests={recentPullRequests}
       repositories={repositories}
       stats={organizationStats}
       summary={organization.description}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,4 +1,5 @@
 'use client'
+
 import { useQuery } from '@apollo/client/react'
 import { addToast } from '@heroui/toast'
 import upperFirst from 'lodash/upperFirst'
@@ -45,9 +46,7 @@ import TopContributorsList from 'components/TopContributorsList'
 import { TruncatedText } from 'components/TruncatedText'
 
 export default function Home() {
-  const [isLoading, setIsLoading] = useState<boolean>(true)
-  const [data, setData] = useState<MainPageData>(null)
-  const { data: graphQLData, error: graphQLRequestError } = useQuery(GetMainPageDataDocument, {
+  const { data, error, loading } = useQuery(GetMainPageDataDocument, {
     variables: { distinct: true },
   })
 
@@ -55,11 +54,7 @@ export default function Home() {
   const [modalOpenIndex, setModalOpenIndex] = useState<number | null>(null)
 
   useEffect(() => {
-    if (graphQLData) {
-      setData(graphQLData)
-      setIsLoading(false)
-    }
-    if (graphQLRequestError) {
+    if (error) {
       addToast({
         description: 'Unable to complete the requested operation.',
         title: 'GraphQL Request Failed',
@@ -68,9 +63,8 @@ export default function Home() {
         color: 'danger',
         variant: 'solid',
       })
-      setIsLoading(false)
     }
-  }, [graphQLData, graphQLRequestError])
+  }, [error])
 
   useEffect(() => {
     const fetchData = async () => {
@@ -80,18 +74,18 @@ export default function Home() {
         currentPage: 1,
         hitsPerPage: 1000,
       }
-      const data: AlgoliaResponse<Chapter> = await fetchAlgoliaData(
+      const algoliaData: AlgoliaResponse<Chapter> = await fetchAlgoliaData(
         searchParams.indexName,
         searchParams.query,
         searchParams.currentPage,
         searchParams.hitsPerPage
       )
-      setGeoLocData(data.hits)
+      setGeoLocData(algoliaData.hits)
     }
     fetchData()
   }, [])
 
-  if (isLoading || !graphQLData || !geoLocData) {
+  if (loading || !data || geoLocData.length === 0) {
     return <LoadingSpinner />
   }
 
@@ -111,26 +105,11 @@ export default function Home() {
   }
 
   const counterData = [
-    {
-      label: 'Active Projects',
-      value: data.statsOverview.activeProjectsStats,
-    },
-    {
-      label: 'Contributors',
-      value: data.statsOverview.contributorsStats,
-    },
-    {
-      label: 'Local Chapters',
-      value: data.statsOverview.activeChaptersStats,
-    },
-    {
-      label: 'Countries',
-      value: data.statsOverview.countriesStats,
-    },
-    {
-      label: 'Slack Community',
-      value: data.statsOverview.slackWorkspaceStats,
-    },
+    { label: 'Active Projects', value: data.statsOverview.activeProjectsStats },
+    { label: 'Contributors', value: data.statsOverview.contributorsStats },
+    { label: 'Local Chapters', value: data.statsOverview.activeChaptersStats },
+    { label: 'Countries', value: data.statsOverview.countriesStats },
+    { label: 'Slack Community', value: data.statsOverview.slackWorkspaceStats },
   ]
 
   return (


### PR DESCRIPTION
## Summary
Refactored multiple pages to rely directly on Apollo `useQuery`'s `loading` state.
Removed redundant `useState` and manual loading management while preserving existing UI behavior.

## Changes
- Removed local `isLoading` state driven by `useQuery`
- Used `loading` directly from Apollo `useQuery`
- Simplified data flow and reduced side effects

## Testing
- Verified loading indicators appear during data fetch
- Verified content renders correctly after loading
- Verified error and 404 states behave as expected

Closes #3135
