### PR TITLE
Fix ZAP baseline scan workflow failure

### DIFF
--- a/.github/workflows/run-ci-cd.yaml
+++ b/.github/workflows/run-ci-cd.yaml
@@ -956,11 +956,10 @@ jobs:
           target: 'https://nest.owasp.org'
           allow_issue_writing: false
           fail_action: false
-          cmd_options: '-a -r zap-report.html'
 
       - name: Upload ZAP report
         if: always()
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
           name: zap-baseline-scan-report-${{ github.run_id }}
-          path: zap-report.html
+          path: report_html.html


### PR DESCRIPTION
## Proposed change
Fixes the ZAP baseline scan workflow so the generated report is uploaded correctly and the ci job completes successfully

Resolves #3183 


## Checklist

- [x] **Required:** I read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md)
- [ ] **Required:** I ran `make check-test` locally and all tests passed
- [ ] I used AI for code, documentation, or tests in this PR
