### PR TITLE
fix: resolve ZAP baseline scan report filename mismatch

### DIFF
--- a/.github/workflows/run-ci-cd.yaml
+++ b/.github/workflows/run-ci-cd.yaml
@@ -616,14 +616,14 @@ jobs:
           target: 'https://nest.owasp.dev'
           allow_issue_writing: false
           fail_action: false
-          cmd_options: '-a -r zap-report.html'
+          cmd_options: '-a'
 
       - name: Upload ZAP report
         if: always()
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
           name: zap-baseline-scan-report-${{ github.run_id }}
-          path: zap-report.html
+          path: report_html.html
 
 
   build-production-images:
@@ -957,11 +957,11 @@ jobs:
           target: 'https://nest.owasp.org'
           allow_issue_writing: false
           fail_action: false
-          cmd_options: '-a -r zap-report.html'
+          cmd_options: '-a'
 
       - name: Upload ZAP report
         if: always()
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
           name: zap-baseline-scan-report-${{ github.run_id }}
-          path: zap-report.html
+          path: report_html.html


### PR DESCRIPTION
## Proposed change

Resolves #3183

This PR fixes the CI/CD pipeline failure in the ZAP Baseline Scan jobs. The `zaproxy/action-baseline` action expects the HTML report to be named `report_html.html` by default, but the workflow configuration was overriding this with `-r zap-report.html` in `cmd_options`, causing a file not found error.

**Changes made:**
- Remove `-r zap-report.html` from `cmd_options` to use default filename
- Update artifact upload path to `report_html.html`
- Fixes both staging and production scan jobs
- Resolves issue where action expected `report_html.html` but got `zap-report.html`

**Files modified:**
- `.github/workflows/run-ci-cd.yaml` 

## Checklist

- [x] **Required:** I read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md)
- [x] **Required:** I ran `make check-test` locally and all tests passed
- [ ] I used AI for code, documentation, or tests in this PR