### PR TITLE
Remove unnecessary zero fractions from number literals

### DIFF
--- a/frontend/src/components/ChapterMap.tsx
+++ b/frontend/src/components/ChapterMap.tsx
@@ -41,7 +41,7 @@ const ChapterMap = ({
           [-90, -180],
           [90, 180],
         ],
-        maxBoundsViscosity: 1.0,
+        maxBoundsViscosity: 1,
         scrollWheelZoom: false,
         zoomControl: false,
       }).setView([20, 0], 2)


### PR DESCRIPTION
This PR fixes a SonarQube issue by removing unnecessary zero
fractions from number literals (e.g., 1.0 → 1).

Fixes #3222 
