### PR TITLE
Improved readability by replacing escaped backslashes with String.raw

### DIFF
--- a/frontend/__tests__/unit/components/Footer.test.tsx
+++ b/frontend/__tests__/unit/components/Footer.test.tsx
@@ -356,7 +356,7 @@ describe('Footer', () => {
       renderFooter()
 
       const footer = screen.getByRole('contentinfo')
-      const gridContainer = footer.querySelector('.grid.w-full.sm\\:grid-cols-2')
+      const gridContainer = footer.querySelector(String.raw`.grid.w-full.sm\:grid-cols-2`)
       expect(gridContainer).toBeInTheDocument()
     })
 

--- a/frontend/__tests__/unit/components/RecentRelease.test.tsx
+++ b/frontend/__tests__/unit/components/RecentRelease.test.tsx
@@ -381,7 +381,7 @@ describe('RecentReleases Component', () => {
 
     // Check for main card structure - look for the card wrapper
     const cardElement = container.querySelector(
-      '.mb-4.w-full.rounded-lg.bg-gray-200.p-4.dark\\:bg-gray-700'
+      String.raw`.mb-4.w-full.rounded-lg.bg-gray-200.p-4.dark\:bg-gray-700`
     )
     expect(cardElement).toBeInTheDocument()
 

--- a/frontend/__tests__/unit/pages/UserDetails.test.tsx
+++ b/frontend/__tests__/unit/pages/UserDetails.test.tsx
@@ -281,7 +281,7 @@ describe('UserDetailsPage', () => {
     await waitFor(() => {
       const heatmapContainer = screen
         .getByAltText('Heatmap Background')
-        .closest('div.hidden.lg\\:block')
+        .closest(String.raw`div.hidden.lg\:block`)
       expect(heatmapContainer).toBeInTheDocument()
       expect(heatmapContainer).toHaveClass('hidden')
       expect(heatmapContainer).toHaveClass('lg:block')


### PR DESCRIPTION
## Proposed change

Resolves #3214

This PR improves readability and maintainability in frontend unit tests by replacing string literals that contain escaped backslashes ```(\\)``` with clearer alternatives (such as ```String.raw```), as suggested in the related issue.

***The changes are:***
- Limited strictly to frontend test files
- Applied consistently across all similar cases in the codebase
- Purely non-functional (no impact on runtime behavior or test logic)
This addresses the maintainability concern raised in the issue and follows the maintainer’s request to fix all similar occurrences, not just a single file.

## Checklist

- [x] **Required:** I read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md)
- [x] **Required:** I ran `make check-test` locally and all tests passed
- [ ] I used AI for code, documentation, or tests in this PR
