### PR TITLE
Update sync process to last 365 days

### DIFF
--- a/backend/apps/github/management/commands/github_sync_user.py
+++ b/backend/apps/github/management/commands/github_sync_user.py
@@ -1,7 +1,7 @@
 """A command to sync GitHub user commits, pull requests, and issues across OWASP organizations."""
 
 import logging
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from django.core.management.base import BaseCommand
 from github.GithubException import GithubException
@@ -39,12 +39,12 @@ class Command(BaseCommand):
         parser.add_argument(
             "--start-at",
             type=str,
-            help="Start date (YYYY-MM-DD). Defaults to January 1st of current year.",
+            help="Start date (YYYY-MM-DD). Defaults to 365 days ago.",
         )
         parser.add_argument(
             "--end-at",
             type=str,
-            help="End date (YYYY-MM-DD). Defaults to October 1st of current year.",
+            help="End date (YYYY-MM-DD). Defaults to today.",
         )
         parser.add_argument(
             "--skip-sync",
@@ -204,10 +204,9 @@ class Command(BaseCommand):
             self.populate_first_contribution_only(username, user, gh)
             return
 
-        # Default to current year: Jan 1 to Oct 1
-        current_year = datetime.now(UTC).year
-        default_start = datetime(current_year, 1, 1, tzinfo=UTC)
-        default_end = datetime(current_year, 10, 1, tzinfo=UTC)
+        # Default to last 365 days
+        default_end = datetime.now(UTC)
+        default_start = default_end - timedelta(days=365)
 
         end_at = self.parse_date(options.get("end_at"), default_end)
         start_at = self.parse_date(options.get("start_at"), default_start)

--- a/backend/apps/owasp/management/commands/owasp_create_member_snapshot.py
+++ b/backend/apps/owasp/management/commands/owasp_create_member_snapshot.py
@@ -2,7 +2,7 @@
 
 import logging
 from collections import defaultdict
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from django.contrib.contenttypes.models import ContentType
 from django.core.management.base import BaseCommand
@@ -41,12 +41,12 @@ class Command(BaseCommand):
         parser.add_argument(
             "--start-at",
             type=str,
-            help="Start date (YYYY-MM-DD). Defaults to January 1st of current year.",
+            help="Start date (YYYY-MM-DD). Defaults to 365 days ago.",
         )
         parser.add_argument(
             "--end-at",
             type=str,
-            help="End date (YYYY-MM-DD). Defaults to October 1st of current year.",
+            help="End date (YYYY-MM-DD). Defaults to today.",
         )
 
     def parse_date(self, date_str: str | None, default: datetime) -> datetime:
@@ -320,10 +320,9 @@ class Command(BaseCommand):
         """
         username = options["username"]
 
-        # Default to current year: Jan 1 to Oct 1
-        current_year = datetime.now(UTC).year
-        default_start = datetime(current_year, 1, 1, tzinfo=UTC)
-        default_end = datetime(current_year, 10, 1, tzinfo=UTC)
+        # Default to last 365 days
+        default_end = datetime.now(UTC)
+        default_start = default_end - timedelta(days=365)
 
         end_at = self.parse_date(options.get("end_at"), default_end)
         start_at = self.parse_date(options.get("start_at"), default_start)

--- a/backend/tests/apps/github/management/commands/github_sync_user_test.py
+++ b/backend/tests/apps/github/management/commands/github_sync_user_test.py
@@ -155,12 +155,12 @@ class TestGithubSyncUserCommand:
         mock_parser.add_argument.assert_any_call(
             "--start-at",
             type=str,
-            help="Start date (YYYY-MM-DD). Defaults to January 1st of current year.",
+            help="Start date (YYYY-MM-DD). Defaults to 365 days ago.",
         )
         mock_parser.add_argument.assert_any_call(
             "--end-at",
             type=str,
-            help="End date (YYYY-MM-DD). Defaults to October 1st of current year.",
+            help="End date (YYYY-MM-DD). Defaults to today.",
         )
         mock_parser.add_argument.assert_any_call(
             "--skip-sync",


### PR DESCRIPTION
## Proposed change

Resolves #3184 

This PR updates the GitHub sync process to fetch and process contributions from the **last 365 days** instead of a shorter time window.

The change ensures that:
- Older but still relevant contributions are included
- Contributor activity is more accurately represented
- Snapshot and sync data remains consistent with the extended range

### What was changed
- Updated GitHub sync logic to cover the last 365 days
- Adjusted related snapshot generation logic accordingly
- Verified that existing functionality remains unaffected

### Verification / Results

**1. GitHub sync command execution**
<img width="1461" height="807" alt="Screenshot 2026-01-07 223847" src="https://github.com/user-attachments/assets/448d6609-93b1-43a6-b791-9f42244aa63e" />

**2. Database verification**
<img width="1467" height="707" alt="Screenshot 2026-01-07 223854" src="https://github.com/user-attachments/assets/b8bbf96c-f5ac-4334-891e-9dd7203f6f75" />


These results confirm that commits from the last 365 days are successfully fetched, stored, and verified.

## Checklist

- [x] **Required:** I read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md)
- [x] **Required:** I ran `make check-test` locally and all tests passed
- [ ] I used AI for code, documentation, or tests in this PR
