### PR TITLE
ci: enable Docker layer caching for cspell spellcheck job

### DIFF
--- a/.github/workflows/run-ci-cd.yaml
+++ b/.github/workflows/run-ci-cd.yaml
@@ -104,6 +104,19 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
 
+      - name: Set up Docker buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build cspell image with cache
+        uses: docker/build-push-action@v5
+        with:
+          context: cspell
+          file: cspell/Dockerfile
+          tags: cspell:ci
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
       - name: Run cspell
         run: |
           make check-spelling

--- a/cspell/Makefile
+++ b/cspell/Makefile
@@ -1,10 +1,9 @@
 check-spelling: cspell-check
 
 cspell-install:
-	@DOCKER_BUILDKIT=1 docker build \
-		--cache-from cspell \
-		cspell \
-		-t cspell
+	@docker image inspect cspell:ci >/dev/null 2>&1 && \
+	docker tag cspell:ci cspell || \
+	docker build -t cspell cspell
 
 cspell-check: CMD="--no-progress -r /nest"
 cspell-check: cspell-install cspell-run


### PR DESCRIPTION
## Proposed change

Resolves #3269

This PR optimizes the Docker-based spellcheck job by enabling Docker Buildx with GitHub Actions cache for the `cspell` image.

Previously, the spellcheck job rebuilt the Docker image from scratch on every CI run (~26s on recent `main` runs). With this change, the first run populates the cache and subsequent runs can reuse Docker layers, avoiding repeated cold builds.

### Summary of changes
- Enable Docker Buildx and GitHub Actions cache in the `spellcheck` job
- Update the Makefile to reuse the cached `cspell:ci` image when available
- Preserve existing Docker-based spellcheck behavior with no functional changes

### Notes
- The first CI run will still be a cold build (expected)
- Subsequent runs should show reduced build time due to Docker layer reuse

## Checklist

- [x] **Required:** I read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md)
- [ ] **Required:** I ran `make check-test` locally and all tests passed  
  _(Not applicable — this change only affects CI configuration and Docker build caching)_
- [x] I used AI for code, documentation, or tests in this PR
