### PR TITLE
ci: add concurrency settings to cancel redundant workflow runs

### DIFF
--- a/.github/workflows/check-pr-issue.yaml
+++ b/.github/workflows/check-pr-issue.yaml
@@ -5,6 +5,10 @@ on:
     types:
       - opened
 
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/label-issues.yaml
+++ b/.github/workflows/label-issues.yaml
@@ -6,6 +6,10 @@ on:
       - edited
       - opened
 
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.ref }}
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/label-pull-requests.yaml
+++ b/.github/workflows/label-pull-requests.yaml
@@ -3,6 +3,10 @@ name: Label Pull Requests
 on:
   - pull_request_target
 
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/run-ci-cd.yaml
+++ b/.github/workflows/run-ci-cd.yaml
@@ -19,6 +19,10 @@ on:
       - published
   workflow_dispatch:
 
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+
 permissions: {}
 
 env:

--- a/.github/workflows/run-code-ql.yaml
+++ b/.github/workflows/run-code-ql.yaml
@@ -12,6 +12,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+
 permissions: {}
 
 jobs:
@@ -46,7 +50,7 @@ jobs:
         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f
         with:
           node-version: 24
-          cache: 'pnpm'
+          cache: "pnpm"
           cache-dependency-path: frontend/pnpm-lock.yaml
 
       - name: Install dependencies for frontend

--- a/.github/workflows/update-nest-test-images.yaml
+++ b/.github/workflows/update-nest-test-images.yaml
@@ -5,6 +5,10 @@ on:
     - cron: 30 0 * * *
   workflow_dispatch:
 
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 permissions: {}
 
 env:


### PR DESCRIPTION
## Proposed change

Resolves #3293 

This PR adds `concurrency` settings to all GitHub Actions workflow files to cancel redundant CI runs when new commits are pushed to the same branch or pull request.

### Changes

Added `concurrency` block to the following workflow files:
- [run-ci-cd.yaml](cci:7://file:///Users/ankitsinghsisodya/Nest/.github/workflows/run-ci-cd.yaml:0:0-0:0)
- [run-code-ql.yaml](cci:7://file:///Users/ankitsinghsisodya/Nest/.github/workflows/run-code-ql.yaml:0:0-0:0)
- [check-pr-issue.yaml](cci:7://file:///Users/ankitsinghsisodya/Nest/.github/workflows/check-pr-issue.yaml:0:0-0:0)
- [label-issues.yaml](cci:7://file:///Users/ankitsinghsisodya/Nest/.github/workflows/label-issues.yaml:0:0-0:0)
- [label-pull-requests.yaml](cci:7://file:///Users/ankitsinghsisodya/Nest/.github/workflows/label-pull-requests.yaml:0:0-0:0)
- [update-nest-test-images.yaml](cci:7://file:///Users/ankitsinghsisodya/Nest/.github/workflows/update-nest-test-images.yaml:0:0-0:0)

Each concurrency block uses:
```yaml
concurrency:
  cancel-in-progress: true
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}