### PR TITLE
chore(frontend): remove redundant return in ProjectsDashboardDropDown test

### DIFF
--- a/frontend/__tests__/unit/components/ProjectsDashboardDropDown.test.tsx
+++ b/frontend/__tests__/unit/components/ProjectsDashboardDropDown.test.tsx
@@ -161,7 +161,7 @@ describe('ProjectsDashboardDropDown Component', () => {
       ) {
         return
       }
-      return
+      
     })
   })
 


### PR DESCRIPTION
## Summary

Fixes SonarCloud rule S3626 by removing a redundant `return` statement in
`ProjectsDashboardDropDown.test.tsx`.

This change does not alter behavior and improves maintainability.


## Related issue

Resolves #3087

## Changes

- Removed a redundant jump statement inside the `console.error` mock.

## Testing

- Unable to run `npm run test:unit` locally on Windows due to the NODE_OPTIONS shell syntax used in the script.
- CI will run the full test suite.

