### PR TITLE
fix(frontend): remove unused closeDelay prop (typescript:S6767)

### DIFF
--- a/frontend/__tests__/unit/components/Card.test.tsx
+++ b/frontend/__tests__/unit/components/Card.test.tsx
@@ -17,7 +17,6 @@ interface MockTooltipProps {
   children: ReactNode
   content: string
   id?: string
-  closeDelay?: number
   delay?: number
   showArrow?: boolean
 }


### PR DESCRIPTION
## Proposed change

Resolves #3244

Removed the unused `closeDelay` prop from the `MockTooltipProps` interface in
`frontend/__tests__/unit/components/Card.test.tsx`.

This prop was declared but never used, and SonarCloud flagged it as a code smell
under rule `typescript:S6767`. Removing it keeps the interface clean and resolves
the Sonar issue without affecting functionality.

## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [ ] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [x] I used AI for code, documentation, tests, or communication related to this PR
