### PR TITLE
Hide Contribution activity when no contributions exist

### DIFF
--- a/frontend/src/components/CardDetailsPage.tsx
+++ b/frontend/src/components/CardDetailsPage.tsx
@@ -109,8 +109,8 @@ const DetailsCard = ({
   }
 
   const hasContributions =
-  (contributionStats && contributionStats.total > 0) ||
-  (contributionData && Object.keys(contributionData).length > 0)
+    (contributionStats && contributionStats.total > 0) ||
+    (contributionData && Object.keys(contributionData).length > 0)
 
   const secondaryCardStyles = typeStylesMap[type] ?? 'gap-2 md:col-span-5'
 


### PR DESCRIPTION
## Proposed change

Resolves #3262

This PR updates the **Project and Chapter details pages** to avoid rendering the **Contribution Activity** section when there are zero contributions.

### What was changed
- Added a guard condition so ```ContributionStats``` and ```ContributionHeatmap``` render ```only when contribution data exists and total contributions > 0```.
- Applied the same logic consistently to **both Project and Chapter** entities.
- Preserved the existing layout, styles, and component structure.
- No changes were made to fetching logic, data models, or APIs.

### What was NOT changed
- **Project Details**, **Summary**, **Leaders**, **Statistics**, **Repositories**, **Health Metrics**, and all other sections remain unchanged.
- Entities with valid contribution data continue to display the Contribution Activity exactly as before.
- No visual or behavioral changes were introduced outside the Contribution Activity section.

### Why this change is needed
Projects or chapters with zero contributions were displaying an empty or misleading Contribution Activity section.  
This change improves clarity and UX by showing contribution-related components **only when meaningful data is available**.

### ScreenShots
***Before***
- 
<img width="1919" height="934" alt="image" src="https://github.com/user-attachments/assets/76b3b84f-494c-4270-86dc-6b26aeda78e4" />

***After***
- 
<img width="1919" height="935" alt="image" src="https://github.com/user-attachments/assets/21f1932c-94ca-41f3-8a29-74d72154f0c1" />

---

## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [ ] I used AI for code, documentation, tests, or communication related to this PR
