### PR TITLE
Simplify heatmap data checks for contributions and communications

### DIFF
--- a/frontend/src/app/board/[year]/candidates/page.tsx
+++ b/frontend/src/app/board/[year]/candidates/page.tsx
@@ -458,7 +458,9 @@ const BoardCandidatesPage = () => {
               </div>
             </div>
             {snapshot.contributionHeatmapData &&
-              Object.keys(snapshot.contributionHeatmapData).length > 0 && (
+              Object.values(snapshot.contributionHeatmapData).some(
+              (count) => count > 0
+              ) && (
                 <div className="mt-3">
                   <ContributionHeatmap
                     contributionData={snapshot.contributionHeatmapData}
@@ -619,7 +621,9 @@ const BoardCandidatesPage = () => {
 
         {/* Slack Communications Heatmap */}
         {snapshot?.communicationHeatmapData &&
-          Object.keys(snapshot.communicationHeatmapData).length > 0 && (
+          Object.values(snapshot.communicationHeatmapData).some(
+          (count) => count > 0
+            ) && (
             <div className="mt-4 w-full border-t border-gray-200 pt-4 dark:border-gray-700">
               <ContributionHeatmap
                 contributionData={snapshot.communicationHeatmapData}


### PR DESCRIPTION
Resolves: #3262 

This PR improves the user experience for projects or chapters that don’t yet have any activity. When an entity has zero contributions, the contribution section (stats and heatmap) is no longer shown, preventing empty or confusing UI elements.

The solution adds a simple check to see whether any contribution data actually exists before rendering the contribution section. If there’s no activity, the entire section is skipped, so users only see meaningful information.

This is a UI-only change. It doesn’t modify backend logic or alter the behavior for entities that already have contribution data — those continue to work exactly as before.

### Test Plan
Manual verification of contribution rendering logic
Entities with zero contributions do not render stats or heatmap
Entities with contribution data render as before

## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [x] I used AI for code, documentation, tests, or communication related to this PR
