### PR TITLE
Update sync process to last 365 days

### DIFF
--- a/backend/tests/apps/github/common_test.py
+++ b/backend/tests/apps/github/common_test.py
@@ -139,7 +139,7 @@ class TestSyncRepository:
         now = timezone.now()
         mock_repo.latest_updated_issue = MagicMock(updated_at=now - td(days=10))
         gh_issue_new = gh_item_factory(updated_at=now - td(days=1))
-        gh_issue_old = gh_item_factory(updated_at=now - td(days=20))
+        gh_issue_old = gh_item_factory(updated_at=now - td(days=400))
         mock_gh_repository.get_issues.return_value = [gh_issue_new, gh_issue_old]
 
         sync_repository(mock_gh_repository)
@@ -233,14 +233,14 @@ class TestSyncRepository:
         )
         mock_common_deps["Release"].bulk_save.assert_called_once_with([mock_updated_release])
 
-    def test_initial_sync_uses_30_day_fallback(
+    def test_initial_sync_uses_365_day_fallback(
         self, mock_common_deps, mock_gh_repository, mock_repo, gh_item_factory
     ):
-        """Tests that the 30-day fallback is used for initial sync."""
+        """Tests that the 365-day fallback is used for initial sync."""
         now = timezone.now()
         mock_repo.latest_updated_issue = None
-        gh_issue_recent = gh_item_factory(updated_at=now - td(days=25))
-        gh_issue_ancient = gh_item_factory(updated_at=now - td(days=35))
+        gh_issue_recent = gh_item_factory(updated_at=now - td(days=100))
+        gh_issue_ancient = gh_item_factory(updated_at=now - td(days=400))
         mock_gh_repository.get_issues.return_value = [gh_issue_recent, gh_issue_ancient]
 
         sync_repository(mock_gh_repository)


### PR DESCRIPTION
## Proposed change

Resolves #3184 

This PR updates the GitHub sync process to fetch and process contributions from the **last 365 days** instead of a shorter time window.

The change ensures that:
- Older but still relevant contributions are included
- Contributor activity is more accurately represented
- Snapshot and sync data remains consistent with the extended range

### What was changed
- Updated GitHub sync logic to cover the last 365 days
- Adjusted related snapshot generation logic accordingly
- Verified that existing functionality remains unaffected

### Verification / Results
<img width="1482" height="421" alt="Screenshot 2026-01-13 030434" src="https://github.com/user-attachments/assets/3ce485af-0dd6-446e-b98e-c019a61a5ed8" />


These results confirm that commits from the last 365 days are successfully fetched, stored, and verified.

## Checklist

- [x] **Required:** I read and followed the [contributing guidelines](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md)
- [x] **Required:** I ran `make check-test` locally and all tests passed
- [ ] I used AI for code, documentation, or tests in this PR
