### PR TITLE
fix(frontend): remove aria-hidden from focusable canvas element

### DIFF
--- a/frontend/src/app/members/[memberKey]/page.tsx
+++ b/frontend/src/app/members/[memberKey]/page.tsx
@@ -151,7 +151,7 @@ const UserDetailsPage: React.FC = () => {
     return (
       <div className="overflow-hidden rounded-lg bg-white dark:bg-gray-800">
         <div className="relative">
-          <canvas ref={canvasRef} style={{ display: 'none' }} aria-hidden="true"></canvas>
+          <canvas ref={canvasRef} style={{ display: 'none' }} tabIndex={-1}></canvas>
           {imgSrc ? (
             <div className="h-32">
               <Image


### PR DESCRIPTION
## Proposed change

Resolves #3351

This PR fixes a SonarCloud accessibility issue where a focusable `<canvas>` element had `aria-hidden="true"` applied.

Focusable elements must not be hidden from assistive technologies. This change removes the `aria-hidden` attribute and adds `tabIndex={-1}` to ensure the canvas is not focusable, while preserving the existing visual and functional behavior of the heatmap.

This aligns the component with accessibility best practices and resolves the SonarCloud rule `typescript:S6825`.

## Checklist

- [x] I followed the contributing workflow
- [x] I verified that my code works as intended and resolves the issue as described
- [ ] I ran `make check-test` locally: all warnings addressed, tests passed
- [ ] I used AI for code, documentation, tests, or communication related to this PR
