### PR TITLE
Fix modal overflow and improve responsiveness on  on small screens of contribute page

### DIFF
--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -1,11 +1,5 @@
 import { Button } from '@heroui/button'
-import {
-  Modal,
-  ModalContent,
-  ModalHeader,
-  ModalBody,
-  ModalFooter,
-} from '@heroui/modal'
+import { Modal, ModalContent, ModalHeader, ModalBody, ModalFooter } from '@heroui/modal'
 import React from 'react'
 import { FaBolt } from 'react-icons/fa6'
 import type { ModalProps } from 'types/modal'
@@ -23,68 +17,21 @@ const DialogComp: React.FC<ModalProps> = ({
   description,
 }) => {
   return (
-    <Modal
-      isOpen={isOpen}
-      size="lg"
-      scrollBehavior="inside"
-      onClose={onClose}
-    >
+    <Modal isOpen={isOpen} size="lg" scrollBehavior="inside" onClose={onClose}>
       <ModalContent
         aria-labelledby="modal-title"
-        className="
-          animate-scaleIn
-          relative
-          z-50
-          w-[95vw]
-          sm:w-full
-          max-w-4xl
-          max-h-[90vh]
-          flex
-          flex-col
-          rounded-lg
-          bg-white
-          shadow-xl
-          backdrop-blur-sm
-          transition-all
-          duration-300
-          ease-in-out
-          dark:border
-          dark:border-gray-800
-          dark:bg-[#212529]
-        "
+        className="animate-scaleIn relative z-50 flex max-h-[90vh] w-[95vw] max-w-4xl flex-col rounded-lg bg-white shadow-xl backdrop-blur-sm transition-all duration-300 ease-in-out sm:w-full dark:border dark:border-gray-800 dark:bg-[#212529]"
       >
-        <ModalHeader
-          className="
-            px-5
-            py-4
-            flex
-            flex-col
-            gap-1
-            border-b
-            border-gray-200
-            dark:border-gray-700
-          "
-        >
+        <ModalHeader className="flex flex-col gap-1 border-b border-gray-200 px-5 py-4 dark:border-gray-700">
           <h2
             id="modal-title"
-            className="
-              text-lg
-              sm:text-xl
-              font-bold
-              leading-snug
-              text-gray-900
-              dark:text-white
-              break-words
-              [overflow-wrap:anywhere]
-            "
+            className="text-lg leading-snug font-bold [overflow-wrap:anywhere] break-words text-gray-900 sm:text-xl dark:text-white"
           >
             {title}
           </h2>
 
           {description && (
-            <p className="text-xs text-gray-700 dark:text-gray-300/60">
-              {description}
-            </p>
+            <p className="text-xs text-gray-700 dark:text-gray-300/60">{description}</p>
           )}
         </ModalHeader>
 
@@ -93,13 +40,7 @@ const DialogComp: React.FC<ModalProps> = ({
 
           <Markdown
             content={summary}
-            className="
-              text-base
-              text-gray-600
-              dark:text-gray-300
-              break-words
-              [overflow-wrap:anywhere]
-            "
+            className="text-base [overflow-wrap:anywhere] break-words text-gray-600 dark:text-gray-300"
           />
 
           {hint && (
@@ -111,13 +52,7 @@ const DialogComp: React.FC<ModalProps> = ({
 
               <Markdown
                 content={hint}
-                className="
-                  text-base
-                  text-gray-800
-                  dark:text-gray-200
-                  break-words
-                  [overflow-wrap:anywhere]
-                "
+                className="text-base [overflow-wrap:anywhere] break-words text-gray-800 dark:text-gray-200"
               />
             </div>
           )}
@@ -125,22 +60,7 @@ const DialogComp: React.FC<ModalProps> = ({
           {children}
         </ModalBody>
 
-        <ModalFooter
-          className="
-            sticky
-            bottom-0
-            bg-white
-            dark:bg-[#212529]
-            px-5
-            py-4
-            flex
-            justify-end
-            gap-4
-            border-t
-            border-gray-200
-            dark:border-gray-700
-          "
-        >
+        <ModalFooter className="sticky bottom-0 flex justify-end gap-4 border-t border-gray-200 bg-white px-5 py-4 dark:border-gray-700 dark:bg-[#212529]">
           <ActionButton url={button.url} onClick={button.onclick}>
             {button.icon}
             {button.label}
@@ -150,23 +70,7 @@ const DialogComp: React.FC<ModalProps> = ({
             variant="ghost"
             onPress={onClose}
             aria-label="close-modal"
-            className="
-              rounded-md
-              bg-gray-600
-              px-4
-              py-1
-              text-sm
-              font-medium
-              text-white
-              hover:bg-gray-700
-              focus:outline-none
-              focus:ring-2
-              focus:ring-gray-500
-              focus:ring-offset-2
-              dark:bg-gray-700
-              dark:hover:bg-gray-600
-              dark:focus:ring-gray-600
-            "
+            className="rounded-md bg-gray-600 px-4 py-1 text-sm font-medium text-white hover:bg-gray-700 focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 focus:outline-none dark:bg-gray-700 dark:hover:bg-gray-600 dark:focus:ring-gray-600"
           >
             Close
           </Button>


### PR DESCRIPTION
## Proposed change

Resolves #3369 

This PR fixes an issue on the **OWASP Nest Contributor page** where the **“Read more” dialog overflowed the viewport on mobile and small screen devices**, making content difficult to read and interact with.

### What was changed
- Made the modal layout fully responsive across all screen sizes
- Ensured long titles and descriptions wrap correctly instead of overflowing
- Added proper internal scrolling for modal content on smaller viewports
- Adjusted modal height constraints to prevent viewport overflow
- Improved overall usability without changing any backend logic or data flow

### Why this change
On smaller screens, the dialog content exceeded the viewport height, causing text and actions to be cut off.  
This update ensures the modal remains readable and accessible on mobile devices while preserving the existing desktop experience.

---

## Screenshots
<img width="892" height="988" alt="Screenshot 2026-01-17 202809" src="https://github.com/user-attachments/assets/371d1151-f1dd-42f9-9104-d57b79a9b32b" />


---

## Testing

- Verified modal behavior locally using the frontend development server
- Tested with long titles and content on both desktop and mobile viewports
- Confirmed content scrolls correctly and no elements overflow outside the modal

---

## Checklist

- [x] **Required:** I followed the contributing workflow
- [x] **Required:** I verified that my code works as intended and resolves the issue
- [x] **Required:** I ran relevant local checks for this UI-only change
- [ ] I used AI for code, documentation, tests, or communication related to this PR
