### PR TITLE
use top-level await instead of async IIFE in graphql-codegen.ts

### DIFF
--- a/frontend/graphql-codegen.ts
+++ b/frontend/graphql-codegen.ts
@@ -2,7 +2,7 @@ import { CodegenConfig } from '@graphql-codegen/cli'
 
 const PUBLIC_API_URL = process.env.PUBLIC_API_URL || 'http://localhost:8000'
 
-let response
+let response: Response
 
 try {
   response = await fetch(`${PUBLIC_API_URL}/csrf/`, {


### PR DESCRIPTION
## Proposed change

<!-- Don't forget to link your PR to an existing issue.-->
Resolves #3087 
Replaces the async IIFE with top-level await in frontend/graphql-codegen.ts for improved readability and maintainability.
Verified by `make graphql-codegen`
<img width="615" height="141" alt="image" src="https://github.com/user-attachments/assets/c1916d59-23d9-4003-bce6-37630308ba5b" />

Please take a look at [this suggestion](https://github.com/OWASP/Nest/pull/3398#discussion_r2702125702) before merging

## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [x] I used AI for code, documentation, tests, or communication related to this PR
