### PR TITLE
chore(docker): merge consecutive RUN instructions

### DIFF
--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -15,16 +15,13 @@ ENV APK_CACHE_DIR="/home/owasp/.cache/apk" \
     POETRY_VIRTUALENVS_IN_PROJECT=true \
     PYTHONUNBUFFERED=1
 
-RUN mkdir -p ${APK_CACHE_DIR} ${POETRY_CACHE_DIR} && \
-    ln -fns ${APK_CACHE_DIR} ${APK_SYMLINK_DIR}
-
-&& --mount=type=cache,target=${APK_CACHE_DIR} \
-    && apk update && apk upgrade && \
+RUN --mount=type=cache,target=${APK_CACHE_DIR} \
+mkdir -p ${APK_CACHE_DIR} ${POETRY_CACHE_DIR} && \
+    ln -fns ${APK_CACHE_DIR} ${APK_SYMLINK_DIR} && \
+    apk update && apk upgrade && \
     addgroup -S -g ${OWASP_GID} owasp && \
     adduser -S -h /home/owasp -u ${OWASP_UID} -G owasp owasp && \
-    chown -R owasp:owasp /home/owasp\
-
-&& --mount=type=cache,target=${PIP_CACHE_DIR} \
+    chown -R owasp:owasp /home/owasp && \
     python -m pip install poetry --cache-dir ${PIP_CACHE_DIR}
 
 WORKDIR /home/owasp

--- a/docker/backend/Dockerfile.fuzz
+++ b/docker/backend/Dockerfile.fuzz
@@ -8,16 +8,14 @@ ENV PIP_CACHE_DIR="/home/owasp/.cache/pip" \
     APK_SYMLINK_DIR="/etc/apk/cache" \
     FORCE_COLOR=1
 
-RUN mkdir -p ${APK_CACHE_DIR} && \
-    ln -s ${APK_CACHE_DIR} ${APK_SYMLINK_DIR}
-
-&& --mount=type=cache,target=${APK_CACHE_DIR} \
+RUN --mount=type=cache,target=${APK_CACHE_DIR} \
+    --mount=type=cache,target=${PIP_CACHE_DIR} \
+    mkdir -p ${APK_CACHE_DIR} && \
+    ln -s ${APK_CACHE_DIR} ${APK_SYMLINK_DIR} && \
     apk update && apk upgrade && \
     apk add curl jq && \
     addgroup -S owasp && \
-    adduser -S -h /home/owasp -G owasp owasp
-
-&& --mount=type=cache,target=${PIP_CACHE_DIR} \
+    adduser -S -h /home/owasp -G owasp owasp && \ 
     python -m pip install --upgrade pip && \
     pip install schemathesis --cache-dir ${PIP_CACHE_DIR}
 

--- a/docker/backend/Dockerfile.local
+++ b/docker/backend/Dockerfile.local
@@ -11,16 +11,14 @@ ENV APK_CACHE_DIR="/home/owasp/.cache/apk-backend-builder" \
     POETRY_VIRTUALENVS_IN_PROJECT=true \
     PYTHONUNBUFFERED=1
 
-RUN mkdir -p ${APK_CACHE_DIR} ${POETRY_CACHE_DIR} && \
-    ln -fns ${APK_CACHE_DIR} ${APK_SYMLINK_DIR}
-
-&& --mount=type=cache,target=${APK_CACHE_DIR} \
+RUN --mount=type=cache,target=${APK_CACHE_DIR} \
+    --mount=type=cache,target=${PIP_CACHE_DIR} \
+    mkdir -p ${APK_CACHE_DIR} ${POETRY_CACHE_DIR} && \
+    ln -fns ${APK_CACHE_DIR} ${APK_SYMLINK_DIR} && \
     apk update && apk upgrade && \
     addgroup -S -g ${OWASP_GID} owasp && \
     adduser -S -h /home/owasp -u ${OWASP_UID} -G owasp owasp && \
-    chown -R owasp:owasp /home/owasp
-
-&& --mount=type=cache,target=${PIP_CACHE_DIR} \
+    chown -R owasp:owasp /home/owasp && \
     python -m pip install poetry --cache-dir ${PIP_CACHE_DIR}
 
 USER owasp
@@ -41,16 +39,14 @@ ENV APK_CACHE_DIR="/home/owasp/.cache/apk-backend-stage" \
     PATH="/home/owasp/.venv/bin:$PATH" \
     PYTHONUNBUFFERED=1
 
-RUN mkdir -p ${APK_CACHE_DIR} && \
-    ln -s ${APK_CACHE_DIR} ${APK_SYMLINK_DIR}
-
-&& --mount=type=cache,target=${APK_CACHE_DIR} \
+RUN --mount=type=cache,target=${APK_CACHE_DIR} \
+    --mount=type=cache,target=${PIP_CACHE_DIR} \
+    mkdir -p ${APK_CACHE_DIR} && \
+    ln -s ${APK_CACHE_DIR} ${APK_SYMLINK_DIR} && \
     apk update && apk upgrade && \
     apk add postgresql16-client redis && \
     addgroup -S owasp && \
-    adduser -S -h /home/owasp -G owasp owasp
-
-&& --mount=type=cache,target=${PIP_CACHE_DIR} \
+    adduser -S -h /home/owasp -G owasp owasp&& \
     python -m pip install poetry --cache-dir ${PIP_CACHE_DIR}
 
 EXPOSE 8000

--- a/docker/backend/Dockerfile.test
+++ b/docker/backend/Dockerfile.test
@@ -9,16 +9,14 @@ ENV APK_CACHE_DIR="/home/owasp/.cache/apk-backend-test" \
     POETRY_VIRTUALENVS_IN_PROJECT=true \
     PYTHONUNBUFFERED=1
 
-RUN mkdir -p ${APK_CACHE_DIR} ${POETRY_CACHE_DIR} && \
-    ln -fns ${APK_CACHE_DIR} ${APK_SYMLINK_DIR}
-
-&& --mount=type=cache,target=${APK_CACHE_DIR} \
+RUN --mount=type=cache,target=${APK_CACHE_DIR} \
+    --mount=type=cache,target=${PIP_CACHE_DIR} \
+    mkdir -p ${APK_CACHE_DIR} ${POETRY_CACHE_DIR} && \
+    ln -fns ${APK_CACHE_DIR} ${APK_SYMLINK_DIR}&& \
     apk update && apk upgrade && \
     addgroup -S -g ${OWASP_GID} owasp && \
     adduser -S -h /home/owasp -u ${OWASP_UID} -G owasp owasp && \
-    chown -R owasp:owasp /home/owasp
-
-&& --mount=type=cache,target=${PIP_CACHE_DIR} \
+    chown -R owasp:owasp /home/owasp && \
     python -m pip install poetry --cache-dir ${PIP_CACHE_DIR}
 
 WORKDIR /home/owasp

--- a/docker/backend/Dockerfile.video
+++ b/docker/backend/Dockerfile.video
@@ -11,18 +11,16 @@ ENV APK_CACHE_DIR="/home/owasp/.cache/apk-backend-video" \
     POETRY_VIRTUALENVS_IN_PROJECT=true \
     PYTHONUNBUFFERED=1
 
-RUN mkdir -p ${APK_CACHE_DIR} ${POETRY_CACHE_DIR} && \
-    ln -fns ${APK_CACHE_DIR} ${APK_SYMLINK_DIR}
-
-&& --mount=type=cache,target=${PIP_CACHE_DIR} \
+RUN --mount=type=cache,target=${PIP_CACHE_DIR} \
+    mkdir -p ${APK_CACHE_DIR} ${POETRY_CACHE_DIR} && \
+    ln -fns ${APK_CACHE_DIR} ${APK_SYMLINK_DIR} && \
     python -m pip install poetry --cache-dir ${PIP_CACHE_DIR}
 
 COPY --chmod=444 --chown=root:root poetry.lock pyproject.toml ./
 RUN --mount=type=cache,target=${POETRY_CACHE_DIR},uid=${OWASP_UID},gid=${OWASP_GID} \
+    --mount=type=cache,target=${APK_CACHE_DIR} \
     poetry install --no-root --without dev --without test && \
-    python -m pip uninstall -y poetry
-
-&& --mount=type=cache,target=${APK_CACHE_DIR} \
+    python -m pip uninstall -y poetry && \
     apk update && apk upgrade && \
     apk add ffmpeg \
     # WeasyPrint dependencies: https://doc.courtbouillon.org/weasyprint/stable/first_steps.html


### PR DESCRIPTION
Fix Dockerfile syntax by ensuring BuildKit
Immediately after RUN instructions.


Note: The previous PR was closed unintentionally.

Resolves #3465


## Checklist

- [x ] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [ x] **Required:** I verified that my code works as intended and resolves the issue as described
- [ ] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [ x] I used AI for code, documentation, tests, or communication related to this PR
