### PR TITLE
fix: send uppercase ProjectLevel enum in health metrics filters

### DIFF
--- a/frontend/src/app/projects/dashboard/metrics/page.tsx
+++ b/frontend/src/app/projects/dashboard/metrics/page.tsx
@@ -146,16 +146,16 @@ const MetricsPage: FC = () => {
   }
   const levelFiltersMapping = {
     incubator: {
-      level: 'incubator',
+      level: 'INCUBATOR',
     },
     lab: {
-      level: 'lab',
+      level: 'LAB',
     },
     production: {
-      level: 'production',
+      level: 'PRODUCTION',
     },
     flagship: {
-      level: 'flagship',
+      level: 'FLAGSHIP',
     },
   }
 


### PR DESCRIPTION
## Proposed change

Resolves #3436 

### What was fixed
- Updated project level filters to send UPPERCASE enum values
- Matches backend ProjectLevel enum
- Fixes GraphQL error when filtering by project level
