### PR TITLE
fix: align project level filter values with graphql enum casing #3436

### DIFF
--- a/frontend/src/app/projects/dashboard/metrics/page.tsx
+++ b/frontend/src/app/projects/dashboard/metrics/page.tsx
@@ -146,16 +146,16 @@ const MetricsPage: FC = () => {
   }
   const levelFiltersMapping = {
     incubator: {
-      level: 'incubator',
+      level: 'INCUBATOR',
     },
     lab: {
-      level: 'lab',
+      level: 'LAB',
     },
     production: {
-      level: 'production',
+      level: 'PRODUCTION',
     },
     flagship: {
-      level: 'flagship',
+      level: 'FLAGSHIP',
     },
   }
 


### PR DESCRIPTION
Fixes #3436 : Align project level filter values with graphql enum casing

Description:
This PR fixes a bug in the Project Health Metrics dashboard where filtering by "Project Level" (Incubator, Lab, etc.) would return empty results. The frontend was sending lowercase strings (e.g., `incubator`) for the `level` filter. However, the backend GraphQL schema and database strictly require uppercase Enum values (e.g., `INCUBATOR`).

The Fix:
Updated the `levelFiltersMapping` object in `metrics/page.tsx` to use uppercase string values. This ensures the frontend sends valid Enum values that match the backend data.

Verification:
- Verified locally that the frontend now sends the correct uppercase payload.

## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [x] I used AI for code, documentation, tests, or communication related to this PR
