### PR TITLE
feat(mentorship): add validation for tags and domains

### DIFF
--- a/backend/apps/mentorship/api/internal/nodes/module.py
+++ b/backend/apps/mentorship/api/internal/nodes/module.py
@@ -15,6 +15,7 @@ from apps.github.models.user import User
 from apps.mentorship.api.internal.nodes.enum import ExperienceLevelEnum
 from apps.mentorship.api.internal.nodes.mentor import MentorNode
 from apps.mentorship.api.internal.nodes.program import ProgramNode
+from apps.mentorship.api.internal.utils import validate_domains, validate_tags
 from apps.mentorship.models.issue_user_interest import IssueUserInterest
 from apps.mentorship.models.task import Task
 
@@ -247,8 +248,6 @@ class CreateModuleInput:
 
     def __post_init__(self):
         """Validate input."""
-        from apps.mentorship.api.internal.utils import validate_domains, validate_tags
-
         if self.tags:
             validate_tags(self.tags)
         if self.domains:
@@ -275,8 +274,6 @@ class UpdateModuleInput:
 
     def __post_init__(self):
         """Validate input."""
-        from apps.mentorship.api.internal.utils import validate_domains, validate_tags
-
         if self.tags:
             validate_tags(self.tags)
         if self.domains:

--- a/backend/apps/mentorship/api/internal/nodes/module.py
+++ b/backend/apps/mentorship/api/internal/nodes/module.py
@@ -245,6 +245,15 @@ class CreateModuleInput:
     started_at: datetime
     tags: list[str] = strawberry.field(default_factory=list)
 
+    def __post_init__(self):
+        """Validate input."""
+        from apps.mentorship.api.internal.utils import validate_domains, validate_tags
+
+        if self.tags:
+            validate_tags(self.tags)
+        if self.domains:
+            validate_domains(self.domains)
+
 
 @strawberry.input
 class UpdateModuleInput:
@@ -263,6 +272,15 @@ class UpdateModuleInput:
     project_name: str
     started_at: datetime
     tags: list[str] = strawberry.field(default_factory=list)
+
+    def __post_init__(self):
+        """Validate input."""
+        from apps.mentorship.api.internal.utils import validate_domains, validate_tags
+
+        if self.tags:
+            validate_tags(self.tags)
+        if self.domains:
+            validate_domains(self.domains)
 
 
 @strawberry.input

--- a/backend/apps/mentorship/api/internal/nodes/program.py
+++ b/backend/apps/mentorship/api/internal/nodes/program.py
@@ -13,6 +13,7 @@ from apps.mentorship.api.internal.nodes.enum import (
     ExperienceLevelEnum,  # noqa: TC001
     ProgramStatusEnum,  # noqa: TC001
 )
+from apps.mentorship.api.internal.utils import validate_domains, validate_tags
 
 # TC001/TC003: These imports must stay at runtime. Strawberry GraphQL introspects
 # type annotations when building the schema; moving them under TYPE_CHECKING would
@@ -85,8 +86,6 @@ class CreateProgramInput:
 
     def __post_init__(self):
         """Validate input."""
-        from apps.mentorship.api.internal.utils import validate_domains, validate_tags
-
         if self.tags:
             validate_tags(self.tags)
         if self.domains:
@@ -110,8 +109,6 @@ class UpdateProgramInput:
 
     def __post_init__(self):
         """Validate input."""
-        from apps.mentorship.api.internal.utils import validate_domains, validate_tags
-
         if self.tags:
             validate_tags(self.tags)
         if self.domains:

--- a/backend/apps/mentorship/api/internal/nodes/program.py
+++ b/backend/apps/mentorship/api/internal/nodes/program.py
@@ -83,6 +83,15 @@ class CreateProgramInput:
     started_at: datetime
     tags: list[str] = strawberry.field(default_factory=list)
 
+    def __post_init__(self):
+        """Validate input."""
+        from apps.mentorship.api.internal.utils import validate_domains, validate_tags
+
+        if self.tags:
+            validate_tags(self.tags)
+        if self.domains:
+            validate_domains(self.domains)
+
 
 @strawberry.input
 class UpdateProgramInput:
@@ -98,6 +107,15 @@ class UpdateProgramInput:
     started_at: datetime
     status: ProgramStatusEnum
     tags: list[str] | None = None
+
+    def __post_init__(self):
+        """Validate input."""
+        from apps.mentorship.api.internal.utils import validate_domains, validate_tags
+
+        if self.tags:
+            validate_tags(self.tags)
+        if self.domains:
+            validate_domains(self.domains)
 
 
 @strawberry.input

--- a/backend/apps/mentorship/api/internal/utils.py
+++ b/backend/apps/mentorship/api/internal/utils.py
@@ -1,0 +1,59 @@
+"""Mentorship API internal utilities."""
+
+import re
+
+import strawberry
+
+
+def validate_tags(tags: list[str]) -> list[str]:
+    """Validate tags for uniqueness and format.
+
+    Args:
+        tags: List of tags to validate.
+
+    Returns:
+        list[str]: The validated list of tags.
+
+    Raises:
+        ValueError: If tags contain duplicates or invalid characters.
+
+    """
+    if not tags:
+        return []
+
+    if len(tags) != len(set(tags)):
+        raise ValueError("Tags must be unique.")
+
+    pattern = re.compile(r"^[a-zA-Z0-9]+$")
+    for tag in tags:
+        if not pattern.match(tag):
+            raise ValueError(f"Tag '{tag}' must be alphanumeric.")
+
+    return tags
+
+
+def validate_domains(domains: list[str]) -> list[str]:
+    """Validate domains for uniqueness and format.
+
+    Args:
+        domains: List of domains to validate.
+
+    Returns:
+        list[str]: The validated list of domains.
+
+    Raises:
+        ValueError: If domains contain duplicates or invalid characters.
+
+    """
+    if not domains:
+        return []
+
+    if len(domains) != len(set(domains)):
+        raise ValueError("Domains must be unique.")
+
+    pattern = re.compile(r"^[a-zA-Z0-9 ]+$")
+    for domain in domains:
+        if not pattern.match(domain):
+            raise ValueError(f"Domain '{domain}' must be alphanumeric.")
+
+    return domains

--- a/backend/apps/mentorship/api/internal/utils.py
+++ b/backend/apps/mentorship/api/internal/utils.py
@@ -55,7 +55,7 @@ def validate_domains(domains: list[str]) -> list[str]:
     pattern = re.compile(r"^[a-zA-Z0-9 ]+$")
     for domain in domains:
         if not pattern.match(domain):
-            msg = f"Domain '{domain}' must be alphanumeric."
+            msg = f"Domain '{domain}' must contain only alphanumeric characters or spaces."
             raise ValueError(msg)
 
     return domains

--- a/backend/apps/mentorship/api/internal/utils.py
+++ b/backend/apps/mentorship/api/internal/utils.py
@@ -2,8 +2,6 @@
 
 import re
 
-import strawberry
-
 
 def validate_tags(tags: list[str]) -> list[str]:
     """Validate tags for uniqueness and format.
@@ -22,12 +20,14 @@ def validate_tags(tags: list[str]) -> list[str]:
         return []
 
     if len(tags) != len(set(tags)):
-        raise ValueError("Tags must be unique.")
+        msg = "Tags must be unique."
+        raise ValueError(msg)
 
     pattern = re.compile(r"^[a-zA-Z0-9]+$")
     for tag in tags:
         if not pattern.match(tag):
-            raise ValueError(f"Tag '{tag}' must be alphanumeric.")
+            msg = f"Tag '{tag}' must be alphanumeric."
+            raise ValueError(msg)
 
     return tags
 
@@ -49,11 +49,13 @@ def validate_domains(domains: list[str]) -> list[str]:
         return []
 
     if len(domains) != len(set(domains)):
-        raise ValueError("Domains must be unique.")
+        msg = "Domains must be unique."
+        raise ValueError(msg)
 
     pattern = re.compile(r"^[a-zA-Z0-9 ]+$")
     for domain in domains:
         if not pattern.match(domain):
-            raise ValueError(f"Domain '{domain}' must be alphanumeric.")
+            msg = f"Domain '{domain}' must be alphanumeric."
+            raise ValueError(msg)
 
     return domains

--- a/backend/apps/mentorship/api/internal/utils.py
+++ b/backend/apps/mentorship/api/internal/utils.py
@@ -48,14 +48,20 @@ def validate_domains(domains: list[str]) -> list[str]:
     if not domains:
         return []
 
-    if len(domains) != len(set(domains)):
+    normalized_domains = [re.sub(r"\s+", " ", domain.strip()) for domain in domains]
+
+    if any(not domain for domain in normalized_domains):
+        msg = "Domains cannot be blank."
+        raise ValueError(msg)
+
+    if len(normalized_domains) != len(set(normalized_domains)):
         msg = "Domains must be unique."
         raise ValueError(msg)
 
     pattern = re.compile(r"^[a-zA-Z0-9 ]+$")
-    for domain in domains:
+    for domain in normalized_domains:
         if not pattern.match(domain):
             msg = f"Domain '{domain}' must contain only alphanumeric characters or spaces."
             raise ValueError(msg)
 
-    return domains
+    return normalized_domains

--- a/backend/tests/apps/mentorship/api/internal/nodes/validation_test.py
+++ b/backend/tests/apps/mentorship/api/internal/nodes/validation_test.py
@@ -8,7 +8,12 @@ import strawberry
 from apps.mentorship.api.internal.nodes.enum import ExperienceLevelEnum, ProgramStatusEnum
 from apps.mentorship.api.internal.nodes.module import CreateModuleInput, UpdateModuleInput
 from apps.mentorship.api.internal.nodes.program import CreateProgramInput, UpdateProgramInput
-from apps.mentorship.api.internal.utils import validate_tags
+from apps.mentorship.api.internal.utils import validate_domains, validate_tags
+
+
+def test_validate_tags_empty():
+    """Test empty tags returns empty list."""
+    assert validate_tags([]) == []
 
 
 def test_validate_tags_valid():
@@ -39,18 +44,19 @@ def test_validate_tags_invalid_format():
         validate_tags(tags)
 
 
+def test_validate_domains_empty():
+    """Test empty domains returns empty list."""
+    assert validate_domains([]) == []
+
+
 def test_validate_domains_valid():
     """Test valid domains."""
-    from apps.mentorship.api.internal.utils import validate_domains
-
     domains = ["App Sec", "Web Security", "AI"]
     assert validate_domains(domains) == domains
 
 
 def test_validate_domains_duplicates():
     """Test duplicate domains raise error."""
-    from apps.mentorship.api.internal.utils import validate_domains
-
     domains = ["AppSec", "AppSec"]
     with pytest.raises(ValueError, match="Domains must be unique"):
         validate_domains(domains)
@@ -58,8 +64,6 @@ def test_validate_domains_duplicates():
 
 def test_validate_domains_invalid_format():
     """Test invalid domain format raises error."""
-    from apps.mentorship.api.internal.utils import validate_domains
-
     domains = ["App@Sec"]
     with pytest.raises(ValueError, match="alphanumeric characters or spaces"):
         validate_domains(domains)

--- a/backend/tests/apps/mentorship/api/internal/nodes/validation_test.py
+++ b/backend/tests/apps/mentorship/api/internal/nodes/validation_test.py
@@ -1,5 +1,7 @@
 """Tests for tag validation logic."""
 
+from datetime import UTC, datetime
+
 import pytest
 import strawberry
 
@@ -7,7 +9,6 @@ from apps.mentorship.api.internal.nodes.enum import ExperienceLevelEnum, Program
 from apps.mentorship.api.internal.nodes.module import CreateModuleInput, UpdateModuleInput
 from apps.mentorship.api.internal.nodes.program import CreateProgramInput, UpdateProgramInput
 from apps.mentorship.api.internal.utils import validate_tags
-from datetime import datetime
 
 
 def test_validate_tags_valid():
@@ -25,11 +26,11 @@ def test_validate_tags_duplicates():
 
 def test_validate_tags_invalid_format():
     """Test invalid tag format raises error."""
-    tags = ["python code"] 
+    tags = ["python code"]
     with pytest.raises(ValueError, match="must be alphanumeric"):
         validate_tags(tags)
 
-    tags = ["python-django"]  
+    tags = ["python-django"]
     with pytest.raises(ValueError, match="must be alphanumeric"):
         validate_tags(tags)
 
@@ -59,7 +60,7 @@ def test_validate_domains_invalid_format():
     """Test invalid domain format raises error."""
     from apps.mentorship.api.internal.utils import validate_domains
 
-    domains = ["App@Sec"]  
+    domains = ["App@Sec"]
     with pytest.raises(ValueError, match="must be alphanumeric"):
         validate_domains(domains)
 
@@ -70,36 +71,36 @@ def test_validate_domains_invalid_format():
 
 def test_program_input_validation():
     """Test program inputs trigger validation."""
-    now = datetime.now()
-    
+    now = datetime.now(tz=UTC)
+
     CreateProgramInput(
-        name="Test", 
-        description="Desc", 
-        ended_at=now, 
-        mentees_limit=1, 
-        started_at=now, 
+        name="Test",
+        description="Desc",
+        ended_at=now,
+        mentees_limit=1,
+        started_at=now,
         tags=["Valid1"],
-        domains=["Valid Domain"]
+        domains=["Valid Domain"],
     )
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="must be alphanumeric"):
         CreateProgramInput(
-            name="Test", 
-            description="Desc", 
-            ended_at=now, 
-            mentees_limit=1, 
-            started_at=now, 
-            tags=["Invalid Space"]
+            name="Test",
+            description="Desc",
+            ended_at=now,
+            mentees_limit=1,
+            started_at=now,
+            tags=["Invalid Space"],
         )
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="must be alphanumeric"):
         CreateProgramInput(
-            name="Test", 
-            description="Desc", 
-            ended_at=now, 
-            mentees_limit=1, 
-            started_at=now, 
-            domains=["Invalid@Domain"]
+            name="Test",
+            description="Desc",
+            ended_at=now,
+            mentees_limit=1,
+            started_at=now,
+            domains=["Invalid@Domain"],
         )
 
     UpdateProgramInput(
@@ -111,13 +112,13 @@ def test_program_input_validation():
         started_at=now,
         status=ProgramStatusEnum.PUBLISHED,
         tags=["Valid2"],
-        domains=["Valid Domain"]
+        domains=["Valid Domain"],
     )
 
 
 def test_module_input_validation():
     """Test module inputs trigger validation."""
-    now = datetime.now()
+    now = datetime.now(tz=UTC)
     pid = strawberry.ID("1")
     CreateModuleInput(
         name="Test",
@@ -129,9 +130,9 @@ def test_module_input_validation():
         project_id=pid,
         started_at=now,
         tags=["Valid3"],
-        domains=["Valid Domain"]
+        domains=["Valid Domain"],
     )
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="must be alphanumeric"):
         CreateModuleInput(
             name="Test",
             description="Desc",
@@ -142,7 +143,7 @@ def test_module_input_validation():
             project_id=pid,
             started_at=now,
             tags=["Valid3"],
-            domains=["Invalid@Domain"]
+            domains=["Invalid@Domain"],
         )
 
     UpdateModuleInput(
@@ -156,10 +157,10 @@ def test_module_input_validation():
         project_name="proj",
         started_at=now,
         tags=["Valid4"],
-        domains=["Valid Domain"]
+        domains=["Valid Domain"],
     )
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="must be alphanumeric"):
         UpdateModuleInput(
             key="mod-key",
             program_key="prog",
@@ -170,5 +171,5 @@ def test_module_input_validation():
             project_id=pid,
             project_name="proj",
             started_at=now,
-            tags=["invalid space"]
+            tags=["invalid space"],
         )

--- a/backend/tests/apps/mentorship/api/internal/nodes/validation_test.py
+++ b/backend/tests/apps/mentorship/api/internal/nodes/validation_test.py
@@ -1,0 +1,174 @@
+"""Tests for tag validation logic."""
+
+import pytest
+import strawberry
+
+from apps.mentorship.api.internal.nodes.enum import ExperienceLevelEnum, ProgramStatusEnum
+from apps.mentorship.api.internal.nodes.module import CreateModuleInput, UpdateModuleInput
+from apps.mentorship.api.internal.nodes.program import CreateProgramInput, UpdateProgramInput
+from apps.mentorship.api.internal.utils import validate_tags
+from datetime import datetime
+
+
+def test_validate_tags_valid():
+    """Test valid tags."""
+    tags = ["python", "Django", "123"]
+    assert validate_tags(tags) == tags
+
+
+def test_validate_tags_duplicates():
+    """Test duplicate tags raise error."""
+    tags = ["python", "python"]
+    with pytest.raises(ValueError, match="Tags must be unique"):
+        validate_tags(tags)
+
+
+def test_validate_tags_invalid_format():
+    """Test invalid tag format raises error."""
+    tags = ["python code"] 
+    with pytest.raises(ValueError, match="must be alphanumeric"):
+        validate_tags(tags)
+
+    tags = ["python-django"]  
+    with pytest.raises(ValueError, match="must be alphanumeric"):
+        validate_tags(tags)
+
+    tags = ["<script>"]
+    with pytest.raises(ValueError, match="must be alphanumeric"):
+        validate_tags(tags)
+
+
+def test_validate_domains_valid():
+    """Test valid domains."""
+    from apps.mentorship.api.internal.utils import validate_domains
+
+    domains = ["App Sec", "Web Security", "AI"]
+    assert validate_domains(domains) == domains
+
+
+def test_validate_domains_duplicates():
+    """Test duplicate domains raise error."""
+    from apps.mentorship.api.internal.utils import validate_domains
+
+    domains = ["AppSec", "AppSec"]
+    with pytest.raises(ValueError, match="Domains must be unique"):
+        validate_domains(domains)
+
+
+def test_validate_domains_invalid_format():
+    """Test invalid domain format raises error."""
+    from apps.mentorship.api.internal.utils import validate_domains
+
+    domains = ["App@Sec"]  
+    with pytest.raises(ValueError, match="must be alphanumeric"):
+        validate_domains(domains)
+
+    domains = ["<script>"]
+    with pytest.raises(ValueError, match="must be alphanumeric"):
+        validate_domains(domains)
+
+
+def test_program_input_validation():
+    """Test program inputs trigger validation."""
+    now = datetime.now()
+    
+    CreateProgramInput(
+        name="Test", 
+        description="Desc", 
+        ended_at=now, 
+        mentees_limit=1, 
+        started_at=now, 
+        tags=["Valid1"],
+        domains=["Valid Domain"]
+    )
+
+    with pytest.raises(ValueError):
+        CreateProgramInput(
+            name="Test", 
+            description="Desc", 
+            ended_at=now, 
+            mentees_limit=1, 
+            started_at=now, 
+            tags=["Invalid Space"]
+        )
+
+    with pytest.raises(ValueError):
+        CreateProgramInput(
+            name="Test", 
+            description="Desc", 
+            ended_at=now, 
+            mentees_limit=1, 
+            started_at=now, 
+            domains=["Invalid@Domain"]
+        )
+
+    UpdateProgramInput(
+        key="key",
+        name="Test",
+        description="Desc",
+        ended_at=now,
+        mentees_limit=1,
+        started_at=now,
+        status=ProgramStatusEnum.PUBLISHED,
+        tags=["Valid2"],
+        domains=["Valid Domain"]
+    )
+
+
+def test_module_input_validation():
+    """Test module inputs trigger validation."""
+    now = datetime.now()
+    pid = strawberry.ID("1")
+    CreateModuleInput(
+        name="Test",
+        description="Desc",
+        ended_at=now,
+        experience_level=ExperienceLevelEnum.BEGINNER,
+        program_key="prog",
+        project_name="proj",
+        project_id=pid,
+        started_at=now,
+        tags=["Valid3"],
+        domains=["Valid Domain"]
+    )
+    with pytest.raises(ValueError):
+        CreateModuleInput(
+            name="Test",
+            description="Desc",
+            ended_at=now,
+            experience_level=ExperienceLevelEnum.BEGINNER,
+            program_key="prog",
+            project_name="proj",
+            project_id=pid,
+            started_at=now,
+            tags=["Valid3"],
+            domains=["Invalid@Domain"]
+        )
+
+    UpdateModuleInput(
+        key="mod-key",
+        program_key="prog",
+        name="Test",
+        description="Desc",
+        ended_at=now,
+        experience_level=ExperienceLevelEnum.BEGINNER,
+        project_id=pid,
+        project_name="proj",
+        started_at=now,
+        tags=["Valid4"],
+        domains=["Valid Domain"]
+    )
+
+    with pytest.raises(ValueError):
+        UpdateModuleInput(
+            key="mod-key",
+            program_key="prog",
+            name="Test",
+            description="Desc",
+            ended_at=now,
+            experience_level=ExperienceLevelEnum.BEGINNER,
+            project_id=pid,
+            project_name="proj",
+            started_at=now,
+            tags=["invalid space"]
+        )

--- a/backend/tests/apps/mentorship/api/internal/nodes/validation_test.py
+++ b/backend/tests/apps/mentorship/api/internal/nodes/validation_test.py
@@ -61,11 +61,11 @@ def test_validate_domains_invalid_format():
     from apps.mentorship.api.internal.utils import validate_domains
 
     domains = ["App@Sec"]
-    with pytest.raises(ValueError, match="must be alphanumeric"):
+    with pytest.raises(ValueError, match="alphanumeric characters or spaces"):
         validate_domains(domains)
 
     domains = ["<script>"]
-    with pytest.raises(ValueError, match="must be alphanumeric"):
+    with pytest.raises(ValueError, match="alphanumeric characters or spaces"):
         validate_domains(domains)
 
 
@@ -93,7 +93,7 @@ def test_program_input_validation():
             tags=["Invalid Space"],
         )
 
-    with pytest.raises(ValueError, match="must be alphanumeric"):
+    with pytest.raises(ValueError, match="alphanumeric characters or spaces"):
         CreateProgramInput(
             name="Test",
             description="Desc",
@@ -132,7 +132,7 @@ def test_module_input_validation():
         tags=["Valid3"],
         domains=["Valid Domain"],
     )
-    with pytest.raises(ValueError, match="must be alphanumeric"):
+    with pytest.raises(ValueError, match="alphanumeric characters or spaces"):
         CreateModuleInput(
             name="Test",
             description="Desc",

--- a/backend/tests/apps/mentorship/api/internal/nodes/validation_test.py
+++ b/backend/tests/apps/mentorship/api/internal/nodes/validation_test.py
@@ -51,14 +51,26 @@ def test_validate_domains_empty():
 
 def test_validate_domains_valid():
     """Test valid domains."""
-    domains = ["App Sec", "Web Security", "AI"]
-    assert validate_domains(domains) == domains
+    domains = ["App Sec", "  Web   Security  ", "AI"]
+    normalized = ["App Sec", "Web Security", "AI"]
+    assert validate_domains(domains) == normalized
 
 
 def test_validate_domains_duplicates():
     """Test duplicate domains raise error."""
     domains = ["AppSec", "AppSec"]
     with pytest.raises(ValueError, match="Domains must be unique"):
+        validate_domains(domains)
+
+    domains_spacing = ["App Sec", "App Sec "]
+    with pytest.raises(ValueError, match="Domains must be unique"):
+        validate_domains(domains_spacing)
+
+
+def test_validate_domains_blank():
+    """Test blank domains raise error."""
+    domains = ["   "]
+    with pytest.raises(ValueError, match="Domains cannot be blank"):
         validate_domains(domains)
 
 


### PR DESCRIPTION
## Proposed change

Resolves #3503 

### Validation Logic Implementation
Implemented input validation for tags and domains in the Mentorship app (Programs and Modules) to ensure data consistency and security.

**Core Changes:**
*   Added backend validation `utils.py` to ensure tags and domains are unique and alphanumeric.
*   Integrated this check into Mentorship Program and Module API inputs.
*   Added unit tests to verify valid and invalid inputs.
## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [ ] I used AI for code, documentation, tests, or communication related to this PR