### PR TITLE
Fix ObjectDoesNotExist using invalid keyword argument

### DIFF
--- a/backend/apps/mentorship/api/internal/mutations/module.py
+++ b/backend/apps/mentorship/api/internal/mutations/module.py
@@ -21,6 +21,7 @@ from apps.mentorship.models.task import Task
 from apps.nest.api.internal.permissions import IsAuthenticated
 from apps.owasp.models import Project
 
+ASSIGNEE_NOT_FOUND_MSG = "Assignee not found."
 ISSUE_NOT_FOUND_MSG = "Issue not found in this module."
 MODULE_NOT_FOUND_MSG = "Module not found."
 
@@ -145,7 +146,7 @@ class ModuleMutation:
             .first()
         )
         if module is None:
-            raise ObjectDoesNotExist(msg=MODULE_NOT_FOUND_MSG)
+            raise ObjectDoesNotExist(MODULE_NOT_FOUND_MSG)
 
         mentor = Mentor.objects.filter(nest_user=user).first()
         if mentor is None:
@@ -155,11 +156,11 @@ class ModuleMutation:
 
         gh_user = GithubUser.objects.filter(login=user_login).first()
         if gh_user is None:
-            raise ObjectDoesNotExist(msg="Assignee not found.")
+            raise ObjectDoesNotExist(ASSIGNEE_NOT_FOUND_MSG)
 
         issue = module.issues.filter(number=issue_number).first()
         if issue is None:
-            raise ObjectDoesNotExist(msg=ISSUE_NOT_FOUND_MSG)
+            raise ObjectDoesNotExist(ISSUE_NOT_FOUND_MSG)
 
         issue.assignees.add(gh_user)
 
@@ -187,7 +188,7 @@ class ModuleMutation:
             .first()
         )
         if module is None:
-            raise ObjectDoesNotExist(msg=MODULE_NOT_FOUND_MSG)
+            raise ObjectDoesNotExist(MODULE_NOT_FOUND_MSG)
 
         mentor = Mentor.objects.filter(nest_user=user).first()
         if mentor is None:
@@ -197,11 +198,12 @@ class ModuleMutation:
 
         gh_user = GithubUser.objects.filter(login=user_login).first()
         if gh_user is None:
-            raise ObjectDoesNotExist(msg="Assignee not found.")
+            raise ObjectDoesNotExist(ASSIGNEE_NOT_FOUND_MSG)
 
         issue = module.issues.filter(number=issue_number).first()
         if issue is None:
-            raise ObjectDoesNotExist(msg=f"Issue {issue_number} not found in this module.")
+            msg = f"Issue {issue_number} not found in this module."
+            raise ObjectDoesNotExist(msg)
 
         issue.assignees.remove(gh_user)
 
@@ -227,7 +229,7 @@ class ModuleMutation:
             .first()
         )
         if module is None:
-            raise ObjectDoesNotExist(msg=MODULE_NOT_FOUND_MSG)
+            raise ObjectDoesNotExist(MODULE_NOT_FOUND_MSG)
 
         mentor = Mentor.objects.filter(nest_user=user).first()
         if mentor is None:
@@ -242,7 +244,7 @@ class ModuleMutation:
             .first()
         )
         if issue is None:
-            raise ObjectDoesNotExist(msg=ISSUE_NOT_FOUND_MSG)
+            raise ObjectDoesNotExist(ISSUE_NOT_FOUND_MSG)
 
         assignees = issue.assignees.all()
         if not assignees.exists():
@@ -289,7 +291,7 @@ class ModuleMutation:
             .first()
         )
         if module is None:
-            raise ObjectDoesNotExist(msg=MODULE_NOT_FOUND_MSG)
+            raise ObjectDoesNotExist(MODULE_NOT_FOUND_MSG)
 
         mentor = Mentor.objects.filter(nest_user=user).first()
         if mentor is None:
@@ -304,7 +306,7 @@ class ModuleMutation:
             .first()
         )
         if issue is None:
-            raise ObjectDoesNotExist(msg=ISSUE_NOT_FOUND_MSG)
+            raise ObjectDoesNotExist(ISSUE_NOT_FOUND_MSG)
 
         assignees = issue.assignees.all()
         if not assignees.exists():
@@ -336,7 +338,7 @@ class ModuleMutation:
             )
             old_module_key = module.key
         except Module.DoesNotExist as e:
-            raise ObjectDoesNotExist(msg=MODULE_NOT_FOUND_MSG) from e
+            raise ObjectDoesNotExist(MODULE_NOT_FOUND_MSG) from e
 
         try:
             creator_as_mentor = Mentor.objects.get(nest_user=user)


### PR DESCRIPTION
## Summary

- Fix `ObjectDoesNotExist(msg=...)` which causes `TypeError` instead of the intended exception
- Django's `ObjectDoesNotExist` does not accept keyword arguments
- Replace all 11 instances with positional arguments

## Details

The bug was discovered when testing exception handling:

```python
>>> from django.core.exceptions import ObjectDoesNotExist
>>> raise ObjectDoesNotExist(msg='test')
TypeError: ObjectDoesNotExist() takes no keyword arguments
```

This means error handling was completely broken for these code paths - users would see `TypeError` instead of proper "not found" messages.

## Changes

| Before (broken) | After (fixed) |
|-----------------|---------------|
| `ObjectDoesNotExist(msg=MODULE_NOT_FOUND_MSG)` | `ObjectDoesNotExist(MODULE_NOT_FOUND_MSG)` |
| `ObjectDoesNotExist(msg="Assignee not found.")` | `ObjectDoesNotExist(ASSIGNEE_NOT_FOUND_MSG)` |
| `ObjectDoesNotExist(msg=ISSUE_NOT_FOUND_MSG)` | `ObjectDoesNotExist(ISSUE_NOT_FOUND_MSG)` |

Also added `ASSIGNEE_NOT_FOUND_MSG` constant to follow linter rules (EM101, TRY003).

## Test plan

- [x] Verified fix works in Django shell
- [x] All pre-commit checks pass (ruff, mypy, etc.)

Fixes #3521