### PR TITLE
compose: fix Redis password env var reference in backend service

### DIFF
--- a/docker-compose/local/compose.yaml
+++ b/docker-compose/local/compose.yaml
@@ -24,7 +24,7 @@ services:
       DJANGO_DB_PORT: ${DJANGO_DB_PORT:-5432}
       DJANGO_DB_USER: ${DJANGO_DB_USER:-nest_user_dev}
       DJANGO_REDIS_HOST: ${DJANGO_REDIS_HOST:-nest-cache}
-      DJANGO_REDIS_PASSWORD: ${DJANGO_REDIS_HOST:-nest-cache-password}
+      DJANGO_REDIS_PASSWORD: ${DJANGO_REDIS_PASSWORD:-nest-cache-password}
     networks:
       - nest-network
     ports:


### PR DESCRIPTION
Resolves #3541 

Summary
The local Docker Compose configuration for the backend service incorrectly references the Redis host variable for the password, causing Redis authentication failures. This PR updates the environment variable to use the correct password reference.

File: compose.yml
Change
```
DJANGO_REDIS_PASSWORD: ${DJANGO_REDIS_HOST:-nest-cache-password}
+ DJANGO_REDIS_PASSWORD: ${DJANGO_REDIS_PASSWORD:-nest-cache-password}
```

Rationale
Prevents Redis authentication failures in local development
Ensures consistent environment variable usage across services
Aligns with the [cache](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) service (--requirepass $REDIS_PASSWORD) and the worker service, which already use the correct variable


Validation Steps
1.Set a custom password in [Nest/backend/.env](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html):
```
DJANGO_REDIS_PASSWORD=my-secure-password
```
2.Start the local stack:
```
make run
```
3.Confirm the backend starts without Redis auth errors and cache operations work.
4.Run project checks and tests:
```
make check-test
```
Scope & Risk
Limited to local development compose
One-line change; minimal risk
No impact on production/staging compose files


