### PR TITLE
docs: add detailed docstrings to model mixin properties

### DIFF
--- a/backend/apps/github/models/mixins/repository.py
+++ b/backend/apps/github/models/mixins/repository.py
@@ -14,7 +14,16 @@ class RepositoryIndexMixin:
 
     @property
     def is_indexable(self) -> bool:
-        """Repositories to index."""
+        """Indicate whether the repository should be indexed.
+
+        A repository is considered indexable if it is not archived,
+        not empty, not a template, and is associated with at least one
+        OWASP project. This is used to decide whether the repository
+        should be included in the search index.
+
+        Returns:
+            bool: True if the repository should be indexed, False otherwise.
+        """
         return (
             not self.is_archived
             and not self.is_empty
@@ -24,90 +33,218 @@ class RepositoryIndexMixin:
 
     @property
     def idx_commits_count(self) -> int:
-        """Return commits count for indexing."""
+        """Return the number of commits for indexing.
+
+        This value is used by the search index to represent the
+        total number of commits in the repository.
+
+        Returns:
+            int: The commit count of the repository.
+        """
         return self.commits_count
 
     @property
     def idx_contributors_count(self) -> int:
-        """Return contributors count for indexing."""
+        """Return the number of contributors for indexing.
+
+        This value represents how many contributors have
+        contributed to the repository and is stored in the
+        search index.
+
+        Returns:
+            int: The total number of contributors.
+        """
         return self.contributors_count
 
     @property
     def idx_created_at(self) -> float:
-        """Return created at for indexing."""
+        """Return the repository creation timestamp for indexing.
+
+        The creation time is converted to a Unix timestamp and
+        stored in the search index for sorting and filtering.
+
+        Returns:
+            float: The creation time as a Unix timestamp.
+        """
         return self.created_at.timestamp()
 
     @property
     def idx_description(self) -> str:
-        """Return description for indexing."""
+        """Return the repository description for indexing.
+
+        This value is used as the textual description of the
+        repository in the search index.
+
+        Returns:
+            str: The repository description.
+        """
         return self.description
 
     @property
     def idx_forks_count(self) -> int:
-        """Return forks count for indexing."""
+        """Return the number of forks for indexing.
+
+        This value represents how many times the repository
+        has been forked and is stored in the search index.
+
+        Returns:
+            int: The fork count of the repository.
+        """
         return self.forks_count
 
     @property
     def idx_has_funding_yml(self) -> bool:
-        """Return has funding.yml for indexing."""
+        """Return whether the repository has a funding.yml file.
+
+        This indicates whether the repository has GitHub funding
+        configuration and is included in the search index.
+
+        Returns:
+            bool: True if a funding.yml file exists, False otherwise.
+        """
         return self.has_funding_yml
 
     @property
     def idx_key(self) -> str:
-        """Return key for indexing."""
+        """Return the unique Nest key for indexing.
+
+        This key uniquely identifies the repository in the
+        Nest platform and is used as the index key.
+
+        Returns:
+            str: The Nest key of the repository.
+        """
         return self.nest_key
 
     @property
     def idx_languages(self) -> list[str]:
-        """Return languages for indexing."""
+        """Return the programming languages used by the repository.
+
+        These languages are indexed to allow filtering and
+        searching by technology.
+
+        Returns:
+            list[str]: A list of programming languages used in the repository.
+        """
         return self.languages
 
     @property
     def idx_license(self) -> str:
-        """Return license for indexing."""
+        """Return the repository license for indexing.
+
+        This value represents the software license associated
+        with the repository.
+
+        Returns:
+            str: The license name.
+        """
         return self.license
 
     @property
     def idx_name(self) -> str:
-        """Return name for indexing."""
+        """Return the repository name for indexing.
+
+        This value is used as the primary display name of the
+        repository in the search index.
+
+        Returns:
+            str: The name of the repository.
+        """
         return self.name
 
     @property
     def idx_open_issues_count(self) -> int:
-        """Return open issues count for indexing."""
+        """Return the number of open issues for indexing.
+
+        This value represents how many issues are currently
+        open on the repository.
+
+        Returns:
+            int: The number of open issues.
+        """
         return self.open_issues_count
 
     @property
     def idx_project_key(self) -> str:
-        """Return project key for indexing."""
+        """Return the Nest project key associated with this repository.
+
+        If the repository is linked to a project, its Nest key
+        is returned. Otherwise, an empty string is used.
+
+        Returns:
+            str: The Nest key of the associated project, or an empty string.
+        """
         return self.project.nest_key if self.project else ""
 
     @property
     def idx_pushed_at(self) -> float:
-        """Return pushed at for indexing."""
+        """Return the last push timestamp for indexing.
+
+        This represents when the repository was last updated
+        and is stored as a Unix timestamp.
+
+        Returns:
+            float: The last push time as a Unix timestamp.
+        """
         return self.pushed_at.timestamp()
 
     @property
     def idx_size(self) -> int:
-        """Return size for indexing."""
+        """Return the repository size for indexing.
+
+        This value represents the size of the repository
+        as reported by GitHub.
+
+        Returns:
+            int: The repository size.
+        """
         return self.size
 
     @property
     def idx_stars_count(self) -> int:
-        """Return stars count for indexing."""
+        """Return the number of stars for indexing.
+
+        This value represents how many GitHub users have starred
+        the repository.
+
+        Returns:
+            int: The star count of the repository.
+        """
         return self.stars_count
 
     @property
     def idx_subscribers_count(self) -> int:
-        """Return subscribers count for indexing."""
+        """Return the subscriber-related value used for indexing.
+
+        This property currently returns the same value as the
+        repository's star count and is indexed under the
+        subscribers field.
+
+        Returns:
+            int: The value used for the subscribers count in the index.
+        """
         return self.stars_count
 
     @property
     def idx_top_contributors(self) -> list[dict[str, Any]]:
-        """Return top contributors for indexing."""
+        """Return the top contributors for indexing.
+
+        This retrieves a list of the most active contributors
+        to the repository for display and search purposes.
+
+        Returns:
+            list[dict[str, Any]]: A list of contributor metadata dictionaries.
+        """
         return RepositoryContributor.get_top_contributors(repository=self.key)
 
     @property
     def idx_topics(self):
-        """Return topics for indexing."""
+        """Return the repository topics for indexing.
+
+        Topics are used as tags to improve discoverability
+        in the search index.
+
+        Returns:
+            Any: The topics associated with the repository.
+        """
         return self.topics

--- a/backend/apps/github/models/mixins/user.py
+++ b/backend/apps/github/models/mixins/user.py
@@ -12,7 +12,15 @@ class UserIndexMixin:
 
     @property
     def is_indexable(self):
-        """Users to index."""
+        """Indicate whether the user should be indexed.
+
+        A user is considered indexable if it is not a bot account,
+        does not have a bot-like login, and is not part of the list
+        of excluded logins.
+
+        Returns:
+            bool: True if the user should be indexed, False otherwise.
+        """
         return (
             not self.is_bot
             and not self.login.endswith(("Bot", "-bot"))
@@ -21,77 +29,180 @@ class UserIndexMixin:
 
     @property
     def idx_avatar_url(self) -> str:
-        """Return avatar URL for indexing."""
+        """Return the user's avatar URL for indexing.
+
+        This value is used to display the user's profile image
+        in search results.
+
+        Returns:
+            str: The URL of the user's avatar.
+        """
         return self.avatar_url
 
     @property
     def idx_badge_count(self) -> int:
-        """Return badge count for indexing."""
+        """Return the number of active badges for indexing.
+
+        This value represents how many active badges the user
+        currently holds.
+
+        Returns:
+            int: The count of active user badges.
+        """
         return self.user_badges.filter(is_active=True).count()
 
     @property
     def idx_bio(self) -> str:
-        """Return bio for indexing."""
+        """Return the user's bio for indexing.
+
+        This text is indexed to provide a short description
+        of the user's profile.
+
+        Returns:
+            str: The user's bio.
+        """
         return self.bio
 
     @property
     def idx_company(self) -> str:
-        """Return company for indexing."""
+        """Return the user's company for indexing.
+
+        This value represents the organization or company
+        the user is associated with.
+
+        Returns:
+            str: The user's company name.
+        """
         return self.company
 
     @property
     def idx_created_at(self) -> float:
-        """Return created at timestamp for indexing."""
+        """Return the account creation timestamp for indexing.
+
+        The timestamp is converted to a Unix timestamp for
+        storage and sorting in the search index.
+
+        Returns:
+            float: The account creation time as a Unix timestamp.
+        """
         return self.created_at.timestamp()
 
     @property
     def idx_email(self) -> str:
-        """Return email for indexing."""
+        """Return the user's email for indexing.
+
+        This value is indexed when available and allowed.
+
+        Returns:
+            str: The user's email address.
+        """
         return self.email
 
     @property
     def idx_key(self) -> str:
-        """Return key for indexing."""
+        """Return the unique user key for indexing.
+
+        The user's login is used as the unique identifier
+        in the search index.
+
+        Returns:
+            str: The user's login.
+        """
         return self.login
 
     @property
     def idx_followers_count(self) -> int:
-        """Return followers count for indexing."""
+        """Return the number of followers for indexing.
+
+        This represents how many users follow this account.
+
+        Returns:
+            int: The follower count.
+        """
         return self.followers_count
 
     @property
     def idx_following_count(self) -> int:
-        """Return following count for indexing."""
+        """Return the number of accounts the user is following.
+
+        This value represents how many other users this
+        account follows.
+
+        Returns:
+            int: The following count.
+        """
         return self.following_count
 
     @property
     def idx_location(self) -> str:
-        """Return location for indexing."""
+        """Return the user's location for indexing.
+
+        This value is used for geographic filtering
+        and display in search results.
+
+        Returns:
+            str: The user's location.
+        """
         return self.location
 
     @property
     def idx_login(self) -> str:
-        """Return login for indexing."""
+        """Return the user's login for indexing.
+
+        This value is used as the display and lookup
+        name in the search index.
+
+        Returns:
+            str: The user's login.
+        """
         return self.login
 
     @property
     def idx_name(self) -> str:
-        """Return name for indexing."""
+        """Return the user's full name for indexing.
+
+        This value is displayed in search results
+        when available.
+
+        Returns:
+            str: The user's full name.
+        """
         return self.name
 
     @property
     def idx_public_repositories_count(self) -> int:
-        """Return public repositories count for indexing."""
+        """Return the number of public repositories for indexing.
+
+        This value represents how many public repositories
+        the user owns.
+
+        Returns:
+            int: The public repository count.
+        """
         return self.public_repositories_count
 
     @property
     def idx_title(self) -> str:
-        """Return title for indexing."""
+        """Return the user's title for indexing.
+
+        This may represent the user's role or professional title.
+
+        Returns:
+            str: The user's title.
+        """
         return self.title
 
     @property
     def idx_contributions(self):
-        """Return contributions for indexing."""
+        """Return the user's repository contributions for indexing.
+
+        This property returns a list of the user's top repository
+        contributions, including repository metadata and the
+        number of contributions made.
+
+        Returns:
+            list[dict]: A list of contribution data dictionaries.
+        """
         from apps.github.models.repository_contributor import RepositoryContributor
 
         return [
@@ -123,12 +234,26 @@ class UserIndexMixin:
 
     @property
     def idx_contributions_count(self) -> int:
-        """Return contributions count for indexing."""
+        """Return the total number of contributions for indexing.
+
+        This value represents the aggregate number of
+        contributions made by the user.
+
+        Returns:
+            int: The contribution count.
+        """
         return self.contributions_count
 
     @property
     def idx_issues(self) -> list[dict]:
-        """Return issues for indexing."""
+        """Return the user's recent issues for indexing.
+
+        This includes metadata about recently created issues
+        for display and search.
+
+        Returns:
+            list[dict]: A list of issue metadata dictionaries.
+        """
         return [
             {
                 "created_at": i.created_at.timestamp(),
@@ -149,12 +274,26 @@ class UserIndexMixin:
 
     @property
     def idx_issues_count(self) -> int:
-        """Return issues count for indexing."""
+        """Return the number of issues for indexing.
+
+        This value represents how many issues are
+        associated with the user.
+
+        Returns:
+            int: The issue count.
+        """
         return self.issues.count()
 
     @property
     def idx_releases(self) -> list[dict]:
-        """Return releases for indexing."""
+        """Return the user's recent releases for indexing.
+
+        This includes metadata about releases the user
+        has published.
+
+        Returns:
+            list[dict]: A list of release metadata dictionaries.
+        """
         return [
             {
                 "is_pre_release": r.is_pre_release,
@@ -175,15 +314,36 @@ class UserIndexMixin:
 
     @property
     def idx_releases_count(self) -> int:
-        """Return releases count for indexing."""
+        """Return the number of releases for indexing.
+
+        This value represents how many releases
+        the user has published.
+
+        Returns:
+            int: The release count.
+        """
         return self.releases.count()
 
     @property
     def idx_updated_at(self) -> float:
-        """Return updated at timestamp for indexing."""
+        """Return the last updated timestamp for indexing.
+
+        This represents when the user's profile
+        was last updated.
+
+        Returns:
+            float: The last update time as a Unix timestamp.
+        """
         return self.updated_at.timestamp()
 
     @property
     def idx_url(self) -> str:
-        """Return GitHub profile URL for indexing."""
+        """Return the user's GitHub profile URL for indexing.
+
+        This value is used to link to the user's
+        GitHub profile.
+
+        Returns:
+            str: The GitHub profile URL.
+        """
         return self.url

--- a/backend/apps/owasp/models/mixins/project.py
+++ b/backend/apps/owasp/models/mixins/project.py
@@ -19,73 +19,172 @@ class ProjectIndexMixin(RepositoryBasedEntityModelMixin):
 
     @property
     def idx_companies(self) -> str:
-        """Return companies for indexing."""
+        """Return associated company names for indexing.
+
+        This aggregates the company names of all organizations
+        linked to the project and formats them for search indexing.
+
+        Returns:
+            str: A concatenated string of company names.
+        """
         return join_values(fields=[o.company for o in self.organizations.all()])
 
     @property
     def idx_contributors_count(self) -> int:
-        """Return contributors count for indexing."""
+        """Return the number of contributors for indexing.
+
+        This represents how many contributors are associated
+        with the project.
+
+        Returns:
+            int: The total contributor count.
+        """
         return self.contributors_count
 
     @property
     def idx_custom_tags(self) -> str:
-        """Return custom tags for indexing."""
+        """Return custom tags for indexing.
+
+        These tags are used to improve search and filtering
+        of OWASP projects.
+
+        Returns:
+            str: The custom tags associated with the project.
+        """
         return self.custom_tags
 
     @property
     def idx_forks_count(self) -> int:
-        """Return forks count for indexing."""
+        """Return the total fork count for indexing.
+
+        This represents how many times project repositories
+        have been forked.
+
+        Returns:
+            int: The fork count.
+        """
         return self.forks_count
 
     @property
     def idx_health_score(self) -> float | None:
-        """Return health score for indexing."""
-        # TODO(arkid15r): Enable real health score in production when ready.
+        """Return the project health score for indexing.
+
+        In production environments, a default health score
+        is returned until the real scoring system is enabled.
+        In non-production environments, the stored health
+        score is used.
+
+        Returns:
+            float | None: The project health score.
+        """
         return DEFAULT_HEALTH_SCORE if settings.IS_PRODUCTION_ENVIRONMENT else self.health_score
 
     @property
     def idx_is_active(self) -> bool:
-        """Return active status for indexing."""
+        """Return whether the project is active for indexing.
+
+        This indicates if the project is currently active
+        and should be shown in search results.
+
+        Returns:
+            bool: True if the project is active, False otherwise.
+        """
         return self.is_active
 
     @property
     def idx_issues_count(self) -> int:
-        """Return issues count for indexing."""
+        """Return the number of open issues for indexing.
+
+        This value represents how many issues are currently
+        open across the project.
+
+        Returns:
+            int: The open issue count.
+        """
         return self.open_issues.count()
 
     @property
     def idx_key(self) -> str:
-        """Return key for indexing."""
+        """Return the project key for indexing.
+
+        The key is normalized by removing the standard
+        'www-project-' prefix.
+
+        Returns:
+            str: The normalized project key.
+        """
         return self.key.replace("www-project-", "")
 
     @property
     def idx_languages(self) -> list[str]:
-        """Return languages for indexing."""
+        """Return the programming languages for indexing.
+
+        These languages represent the technologies used
+        across the project's repositories.
+
+        Returns:
+            list[str]: A list of programming languages.
+        """
         return self.languages
 
     @property
     def idx_level(self) -> str:
-        """Return level text value for indexing."""
+        """Return the project maturity level for indexing.
+
+        This is the human-readable maturity level of the project.
+
+        Returns:
+            str: The project level.
+        """
         return self.level
 
     @property
     def idx_level_raw(self) -> float | None:
-        """Return level for indexing."""
+        """Return the raw project level for indexing.
+
+        This is the numeric representation of the project's
+        maturity level.
+
+        Returns:
+            float | None: The raw project level, if available.
+        """
         return float(self.level_raw) if self.level_raw else None
 
     @property
     def idx_name(self) -> str:
-        """Return name for indexing."""
+        """Return the project name for indexing.
+
+        If a name is not explicitly set, a formatted name
+        is derived from the project key.
+
+        Returns:
+            str: The project name.
+        """
         return self.name or " ".join(self.key.replace("www-project-", "").capitalize().split("-"))
 
     @property
     def idx_organizations(self) -> str:
-        """Return organizations for indexing."""
+        """Return organization names for indexing.
+
+        This aggregates the names of all organizations
+        associated with the project.
+
+        Returns:
+            str: A concatenated string of organization names.
+        """
         return join_values(fields=[o.name for o in self.organizations.all()])
 
     @property
     def idx_repositories(self) -> list[dict]:
-        """Return repositories for indexing."""
+        """Return project repositories for indexing.
+
+        This returns a list of the top repositories associated
+        with the project, ordered by star count, including
+        key metadata for search display.
+
+        Returns:
+            list[dict]: A list of repository metadata dictionaries.
+        """
         return [
             {
                 "contributors_count": r.contributors_count,
@@ -103,25 +202,60 @@ class ProjectIndexMixin(RepositoryBasedEntityModelMixin):
 
     @property
     def idx_repositories_count(self) -> int:
-        """Return repositories count for indexing."""
+        """Return the number of repositories for indexing.
+
+        This represents how many repositories are linked
+        to the project.
+
+        Returns:
+            int: The repository count.
+        """
         return self.repositories.count()
 
     @property
     def idx_stars_count(self) -> int:
-        """Return stars count for indexing."""
+        """Return the total star count for indexing.
+
+        This represents the combined number of stars
+        across the project's repositories.
+
+        Returns:
+            int: The star count.
+        """
         return self.stars_count
 
     @property
     def idx_top_contributors(self) -> list:
-        """Return top contributors for indexing."""
+        """Return the top contributors for indexing.
+
+        This returns a list of the most active contributors
+        across the project's repositories.
+
+        Returns:
+            list: A list of contributor data.
+        """
         return RepositoryContributor.get_top_contributors(project=self.key)
 
     @property
     def idx_type(self) -> str:
-        """Return type for indexing."""
+        """Return the project type for indexing.
+
+        This value categorizes the project within
+        the OWASP ecosystem.
+
+        Returns:
+            str: The project type.
+        """
         return self.type
 
     @property
     def idx_updated_at(self) -> str | float:
-        """Return updated at for indexing."""
+        """Return the last update timestamp for indexing.
+
+        This represents when the project was last updated
+        and is used for sorting and freshness indicators.
+
+        Returns:
+            str | float: The last update time as a Unix timestamp or an empty string.
+        """
         return self.updated_at.timestamp() if self.updated_at else ""


### PR DESCRIPTION
Closes #2648

Adds clear and consistent docstrings to all index-related mixin properties in:

- RepositoryIndexMixin
- UserIndexMixin
- ProjectIndexMixin

This change improves documentation and developer understanding of what each indexed property returns and how it is used by the search/indexing layer.

No application logic was changed - documentation only.

---

- [x] I followed the contributing workflow
- [x] I verified that my changes are documentation-only and correct
- [ ] I ran make check-test locally (not required for doc-only changes)
- [ ] I used AI for this PR