### PR TITLE
Refactor/mentee node strawberry django

### DIFF
--- a/backend/apps/mentorship/api/internal/nodes/mentee.py
+++ b/backend/apps/mentorship/api/internal/nodes/mentee.py
@@ -34,10 +34,3 @@ class MenteeNode(strawberry.relay.Node):
     def name(self, root: Mentee) -> str:
         """Resolve name."""
         return root.github_user.name or root.github_user.login
-
-    # Explicitly map camelCase to snake_case resolvers if needed,
-    # but strawberry auto-converts field names to camelCase in schema.
-    # The previous implementation had @strawberry.field(name="avatarUrl")
-    # strawberry default is camelCase so `avatar_url` -> `avatarUrl`.
-    # Previous implementation: `resolve_avatar_url` decorated with name="avatarUrl".
-    # My new implementation: `avatar_url` field. Strawberry will make it `avatarUrl`.

--- a/backend/apps/mentorship/api/internal/queries/mentorship.py
+++ b/backend/apps/mentorship/api/internal/queries/mentorship.py
@@ -57,7 +57,6 @@ class MentorshipQuery:
         try:
             module = Module.objects.only("id").get(key=module_key, program__key=program_key)
 
-            # Optimized query to fetch mentee and related github_user in one go
             mentee = (
                 Mentee.objects.select_related("github_user")
                 .only(

--- a/backend/apps/mentorship/api/internal/queries/mentorship.py
+++ b/backend/apps/mentorship/api/internal/queries/mentorship.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 import strawberry
 from django.db.models import Prefetch
@@ -11,7 +11,6 @@ from django.db.models import Prefetch
 from apps.github.api.internal.nodes.issue import IssueNode
 from apps.github.models import Label
 from apps.github.models.user import User as GithubUser
-from apps.mentorship.api.internal.nodes.mentee import MenteeNode
 from apps.mentorship.models import Module
 from apps.mentorship.models.mentee import Mentee
 from apps.mentorship.models.mentee_module import MenteeModule
@@ -19,6 +18,7 @@ from apps.mentorship.models.mentor import Mentor
 
 if TYPE_CHECKING:
     from apps.github.api.internal.nodes.issue import IssueNode
+    from apps.mentorship.api.internal.nodes.mentee import MenteeNode
 
 logger = logging.getLogger(__name__)
 
@@ -57,13 +57,22 @@ class MentorshipQuery:
         try:
             module = Module.objects.only("id").get(key=module_key, program__key=program_key)
 
-            github_user = GithubUser.objects.only("login", "name", "avatar_url", "bio").get(
-                login=mentee_key
+            # Optimized query to fetch mentee and related github_user in one go
+            mentee = (
+                Mentee.objects.select_related("github_user")
+                .only(
+                    "id",
+                    "experience_level",
+                    "domains",
+                    "tags",
+                    "github_user__login",
+                    "github_user__name",
+                    "github_user__avatar_url",
+                    "github_user__bio",
+                )
+                .get(github_user__login=mentee_key)
             )
 
-            mentee = Mentee.objects.only("id", "experience_level", "domains", "tags").get(
-                github_user=github_user
-            )
             is_enrolled = MenteeModule.objects.filter(mentee=mentee, module=module).exists()
 
             if not is_enrolled:
@@ -71,21 +80,13 @@ class MentorshipQuery:
                 logger.warning(message)
                 return None
 
-            return MenteeNode(
-                id=cast("strawberry.ID", str(mentee.id)),
-                login=github_user.login,
-                name=github_user.name or github_user.login,
-                avatar_url=github_user.avatar_url,
-                bio=github_user.bio,
-                experience_level=mentee.experience_level,
-                domains=mentee.domains,
-                tags=mentee.tags,
-            )
-
         except (Module.DoesNotExist, GithubUser.DoesNotExist, Mentee.DoesNotExist) as e:
             message = f"Mentee details not found: {e}"
             logger.warning(message)
             return None
+
+        else:
+            return mentee
 
     @strawberry.field
     def get_mentee_module_issues(

--- a/backend/tests/apps/mentorship/api/internal/nodes/mentee_node_test.py
+++ b/backend/tests/apps/mentorship/api/internal/nodes/mentee_node_test.py
@@ -1,0 +1,80 @@
+"""Test cases for MenteeNode."""
+
+from unittest.mock import Mock
+
+from apps.mentorship.api.internal.nodes.mentee import MenteeNode
+from tests.apps.common.graphql_node_base_test import GraphQLNodeBaseTest
+
+
+class TestMenteeNode(GraphQLNodeBaseTest):
+    """Test cases for MenteeNode class."""
+
+    def test_mentee_node_inheritance(self):
+        """Test if MenteeNode inherits from BaseNode."""
+        assert hasattr(MenteeNode, "__strawberry_definition__")
+
+    def test_meta_configuration(self):
+        """Test if Meta is properly configured."""
+        field_names = {field.name for field in MenteeNode.__strawberry_definition__.fields}
+        expected_field_names = {
+            "avatar_url",
+            "bio",
+            "domains",
+            "experience_level",
+            # "id", # id is handled by relay.Node and may not appear in basic field introspection
+            "login",
+            "name",
+            "tags",
+        }
+        # Note: id is added by strawberry.relay.Node
+
+        missing = expected_field_names - field_names
+        assert not missing, f"Missing fields on MenteeNode: {sorted(missing)}"
+
+    def test_avatar_url_field(self):
+        """Test avatar_url field resolution."""
+        mock_mentee = Mock()
+        mock_mentee.github_user.avatar_url = "https://example.com/avatar.jpg"
+
+        field = self._get_field_by_name("avatar_url", MenteeNode)
+        # Using the resolver directly
+        result = field.base_resolver.wrapped_func(None, mock_mentee)
+        assert result == "https://example.com/avatar.jpg"
+
+    def test_bio_field(self):
+        """Test bio field resolution."""
+        mock_mentee = Mock()
+        mock_mentee.github_user.bio = "Test Bio"
+
+        field = self._get_field_by_name("bio", MenteeNode)
+        result = field.base_resolver.wrapped_func(None, mock_mentee)
+        assert result == "Test Bio"
+
+    def test_login_field(self):
+        """Test login field resolution."""
+        mock_mentee = Mock()
+        mock_mentee.github_user.login = "testuser"
+
+        field = self._get_field_by_name("login", MenteeNode)
+        result = field.base_resolver.wrapped_func(None, mock_mentee)
+        assert result == "testuser"
+
+    def test_name_field_with_name(self):
+        """Test name field resolution when name exists."""
+        mock_mentee = Mock()
+        mock_mentee.github_user.name = "Test User"
+        mock_mentee.github_user.login = "testuser"
+
+        field = self._get_field_by_name("name", MenteeNode)
+        result = field.base_resolver.wrapped_func(None, mock_mentee)
+        assert result == "Test User"
+
+    def test_name_field_fallback_to_login(self):
+        """Test name field resolution fallback to login when name is missing."""
+        mock_mentee = Mock()
+        mock_mentee.github_user.name = None
+        mock_mentee.github_user.login = "testuser"
+
+        field = self._get_field_by_name("name", MenteeNode)
+        result = field.base_resolver.wrapped_func(None, mock_mentee)
+        assert result == "testuser"


### PR DESCRIPTION
## Proposed change

Resolves #3555

### 1. Refactored `MenteeNode`
- Replaced the manual `@strawberry.type` definition with `@strawberry_django.type(Mentee)`.
- Continued to inherit from `strawberry.relay.Node` to preserve global ID support.
- Allowed direct model fields such as `experience_level`, `domains`, and `tags` to be automatically mapped by strawberry-django.
- Used `strawberry_django.field` to explicitly resolve fields derived from the related `github_user` model (`login`, `name`, `avatar_url`, `bio`) while preserving the existing GraphQL API shape.

### 2. Updated `get_mentee_details` query
- Updated the query in `apps/mentorship/api/internal/queries/mentorship.py` to return the underlying `Mentee` Django model instance instead of manually constructing a `MenteeNode`.
- Added `.select_related("github_user")` to efficiently fetch related data in a single query and avoid N+1 issues when resolving fields from `root.github_user`.

## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [x] I used AI for code, documentation, tests, or communication related to this PR
