### PR TITLE
fix: remove 404 flash on mentorship module page

### DIFF
--- a/frontend/src/app/my/mentorship/programs/[programKey]/modules/[moduleKey]/page.tsx
+++ b/frontend/src/app/my/mentorship/programs/[programKey]/modules/[moduleKey]/page.tsx
@@ -2,7 +2,7 @@
 import { useQuery } from '@apollo/client/react'
 import { capitalize } from 'lodash'
 import { useParams } from 'next/navigation'
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 import { ErrorDisplay, handleAppError } from 'app/global-error'
 import { GetProgramAdminsAndModulesDocument } from 'types/__generated__/moduleQueries.generated'
 import { Module } from 'types/mentorship'
@@ -13,8 +13,6 @@ import { getSimpleDuration } from 'components/ModuleCard'
 
 const ModuleDetailsPage = () => {
   const { programKey, moduleKey } = useParams<{ programKey: string; moduleKey: string }>()
-  const [module, setModule] = useState<Module | null>(null)
-  const [admins, setAdmins] = useState(null)
 
   const {
     data,
@@ -29,17 +27,17 @@ const ModuleDetailsPage = () => {
   })
 
   useEffect(() => {
-    if (data?.getModule) {
-      setModule(data.getModule)
-      setAdmins(data.getProgram.admins)
-    } else if (error) {
+    if (error) {
       handleAppError(error)
     }
-  }, [data, error])
+  }, [error])
 
-  if (isLoading && !data) return <LoadingSpinner />
+  const mentorshipModule: Module | null | undefined = data?.getModule
+  const admins = data?.getProgram?.admins
 
-  if (!module) {
+  if (isLoading && !mentorshipModule) return <LoadingSpinner />
+
+  if (!mentorshipModule) {
     return (
       <ErrorDisplay
         statusCode={404}
@@ -50,12 +48,12 @@ const ModuleDetailsPage = () => {
   }
 
   const moduleDetails = [
-    { label: 'Experience Level', value: capitalize(module.experienceLevel) },
-    { label: 'Start Date', value: formatDate(module.startedAt) },
-    { label: 'End Date', value: formatDate(module.endedAt) },
+    { label: 'Experience Level', value: capitalize(mentorshipModule.experienceLevel) },
+    { label: 'Start Date', value: formatDate(mentorshipModule.startedAt) },
+    { label: 'End Date', value: formatDate(mentorshipModule.endedAt) },
     {
       label: 'Duration',
-      value: getSimpleDuration(module.startedAt, module.endedAt),
+      value: getSimpleDuration(mentorshipModule.startedAt, mentorshipModule.endedAt),
     },
   ]
 
@@ -64,15 +62,15 @@ const ModuleDetailsPage = () => {
       accessLevel="admin"
       admins={admins}
       details={moduleDetails}
-      domains={module.domains}
+      domains={mentorshipModule.domains}
       entityKey={moduleKey}
-      labels={module.labels}
-      mentees={module.mentees}
-      mentors={module.mentors}
+      labels={mentorshipModule.labels}
+      mentees={mentorshipModule.mentees}
+      mentors={mentorshipModule.mentors}
       programKey={programKey}
-      summary={module.description}
-      tags={module.tags}
-      title={module.name}
+      summary={mentorshipModule.description}
+      tags={mentorshipModule.tags}
+      title={mentorshipModule.name}
       type="module"
     />
   )


### PR DESCRIPTION
## Proposed change

Resolves #3574 

Fixed the intermittent 404 flash on the Mentorship Module page.

**Changes:**
- Removed unnecessary `useState` to fix the race condition on page load.

## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [ ] I used AI for code, documentation, tests, or communication related to this PR