### PR TITLE
fix: use output element instead of status role in CardSkeleton

### DIFF
--- a/frontend/src/components/skeletons/Card.tsx
+++ b/frontend/src/components/skeletons/Card.tsx
@@ -16,8 +16,7 @@ const CardSkeleton: React.FC<CardSkeletonProps> = ({
   const NUM_CONTRIBUTORS = 8
 
   return (
-    <div
-      role="status"
+    <output
       aria-live="polite"
       aria-busy="true"
       aria-label="Loading"
@@ -38,7 +37,10 @@ const CardSkeleton: React.FC<CardSkeletonProps> = ({
           {showIcons && (
             <div className="flex min-w-[30%] grow flex-row items-center justify-start gap-2 overflow-auto">
               {Array.from({ length: numIcons }).map((_, i) => (
-                <Skeleton key={`header-icon-${i}`} className="h-8 w-16" /> // NOSONAR - Safe to use index as key for static skeleton items with fixed length
+                <Skeleton
+                  key={`header-icon-${i}`} // NOSONAR - Safe to use index as key for static skeleton items with fixed length
+                  className="h-8 w-16"
+                />
               ))}
               <Skeleton />
             </div>
@@ -70,6 +72,7 @@ const CardSkeleton: React.FC<CardSkeletonProps> = ({
                   ))}
                 </div>
               )}
+
               {showSocial && (
                 <div className="flex flex-row gap-2">
                   <Skeleton className="h-8 w-8 rounded-full" />
@@ -88,7 +91,7 @@ const CardSkeleton: React.FC<CardSkeletonProps> = ({
           </div>
         </div>
       </div>
-    </div>
+    </output>
   )
 }
 


### PR DESCRIPTION
## Proposed change

Fixes #3557
This PR updates the CardSkeleton component to use an output element instead of a div with role="status" to improve accessibility and better align with semantic HTML and the Sonar rule typescript:S6819.

## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described in #3557 
- [x] **Required:** I ran make check-test locally: all warnings addressed, tests passed
- [x] I used AI for code, documentation, tests, or communication related to this PR
