### PR TITLE
fix: loading spinner logic for program & module edit (#3538)

### DIFF
--- a/frontend/src/app/my/mentorship/programs/[programKey]/modules/[moduleKey]/edit/page.tsx
+++ b/frontend/src/app/my/mentorship/programs/[programKey]/modules/[moduleKey]/edit/page.tsx
@@ -39,6 +39,7 @@ const EditModulePage = () => {
 
   useEffect(() => {
     if (sessionStatus === 'loading' || queryLoading) {
+      // Wait for session + module/program query before deciding access
       return
     }
 
@@ -86,7 +87,9 @@ const EditModulePage = () => {
         tags: (m.tags || []).join(', '),
         labels: (m.labels || []).join(', '),
         projectId: m.projectId || '',
-        mentorLogins: (m.mentors || []).map((mentor: { login: string }) => mentor.login).join(', '),
+        mentorLogins: (m.mentors || [])
+          .map((mentor: { login: string }) => mentor.login)
+          .join(', '),
       })
     }
   }, [accessStatus, data])
@@ -132,7 +135,18 @@ const EditModulePage = () => {
     }
   }
 
-  if (accessStatus === 'checking' || !formData) {
+  // Single page-level loading state for the Module Edit page:
+  // - session loading
+  // - module/program query loading
+  // - access checks in progress
+  // - form not initialized yet
+  const isPageLoading =
+    sessionStatus === 'loading' ||
+    queryLoading ||
+    accessStatus === 'checking' ||
+    formData === null
+
+  if (isPageLoading) {
     return <LoadingSpinner />
   }
 


### PR DESCRIPTION
Proposed change

Resolves [#3538](https://github.com/OWASP/Nest/issues/3538).
​
This update simplifies and centralizes the loading behavior on the Program Edit and Module Edit pages by introducing a single page‑level loading state. It now waits for the session, GraphQL data, access checks, and form initialization to complete before removing the spinner, so users only see the loader while something is actually loading. Once access is confirmed and the form is ready (or access is denied), the spinner disappears cleanly without flicker or partial content states, improving the overall editing experience for admins.
​
## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow).
- [x] **Required:** I verified that my changes work as intended and correctly resolve the issue.
- [x] **Required:** I ran `make check-test` locally and fixed all warnings; all tests are passing.