### PR TITLE
Refactor initialization test for QuestionDetector

### DIFF
--- a/backend/tests/apps/slack/common/question_detector_test.py
+++ b/backend/tests/apps/slack/common/question_detector_test.py
@@ -176,7 +176,6 @@ class TestQuestionDetector:
             detector = QuestionDetector()
 
             # Test that detector initializes properly
-            assert detector is not None
             assert hasattr(detector, "openai_client")
             assert hasattr(detector, "retriever")
 


### PR DESCRIPTION
## Summary

Removes the redundant `assert detector is not None` check from the `test_mocked_initialization` method in `question_detector_test.py`.

## Why This Change?

The SonarQube scanner (python:S5727) flagged this assertion as always being True, indicating it's a code smell. The `detector` object will always be initialized at this point due to the fixture, making the check unnecessary.

## Changes Made

- Removed line 179: `assert detector is not None` from the test file

Fixes: Addresses the SonarQube issue about constant comparison checks.