### PR TITLE
fix: replace role='status' with semantic <output> element in CardSkeleton (S6819)

### DIFF
--- a/frontend/src/components/skeletons/Card.tsx
+++ b/frontend/src/components/skeletons/Card.tsx
@@ -16,13 +16,12 @@ const CardSkeleton: React.FC<CardSkeletonProps> = ({
   const NUM_CONTRIBUTORS = 8
 
   return (
-     <output
-   aria-live="polite"
-   aria-busy="true"
-   aria-label="Loading"
-   className="flex w-full justify-center"
- >
-
+    <output
+      aria-live="polite"
+      aria-busy="true"
+      aria-label="Loading"
+      className="flex w-full justify-center"
+    >
       <div className="border-border bg-card hover:bg-accent/10 mb-6 w-full rounded-lg border-1 p-6 transition-colors duration-300 ease-linear md:max-w-6xl">
         <div className="flex flex-col gap-6">
           {/* Header Section */}

--- a/frontend/src/components/skeletons/Card.tsx
+++ b/frontend/src/components/skeletons/Card.tsx
@@ -16,7 +16,13 @@ const CardSkeleton: React.FC<CardSkeletonProps> = ({
   const NUM_CONTRIBUTORS = 8
 
   return (
-    <output aria-live="polite" aria-busy="true" aria-label="Loading" className="flex w-full justify-center">
+     <output
+   aria-live="polite"
+   aria-busy="true"
+   aria-label="Loading"
+   className="flex w-full justify-center"
+ >
+
       <div className="border-border bg-card hover:bg-accent/10 mb-6 w-full rounded-lg border-1 p-6 transition-colors duration-300 ease-linear md:max-w-6xl">
         <div className="flex flex-col gap-6">
           {/* Header Section */}

--- a/frontend/src/components/skeletons/Card.tsx
+++ b/frontend/src/components/skeletons/Card.tsx
@@ -16,13 +16,7 @@ const CardSkeleton: React.FC<CardSkeletonProps> = ({
   const NUM_CONTRIBUTORS = 8
 
   return (
-    <div
-      role="status"
-      aria-live="polite"
-      aria-busy="true"
-      aria-label="Loading"
-      className="flex w-full justify-center"
-    >
+    <output aria-live="polite" aria-busy="true" aria-label="Loading" className="flex w-full justify-center">
       <div className="border-border bg-card hover:bg-accent/10 mb-6 w-full rounded-lg border-1 p-6 transition-colors duration-300 ease-linear md:max-w-6xl">
         <div className="flex flex-col gap-6">
           {/* Header Section */}
@@ -88,7 +82,7 @@ const CardSkeleton: React.FC<CardSkeletonProps> = ({
           </div>
         </div>
       </div>
-    </div>
+    </output>
   )
 }
 


### PR DESCRIPTION
## Description
This PR improves the accessibility of the CardSkeleton component by replacing a generic `<div>` with ARIA role with a semantic HTML `<output>` element for live region announcements.

## Changes Made
- ✅ Replaced `<div role="status">` with semantic `<output>` element
- ✅ Preserved `aria-live="polite"`, `aria-busy="true"`, and `aria-label="Loading"` attributes
- ✅ Maintains full accessibility for screen readers and assistive technologies

## Why This Matters
- **WCAG Compliance**: Uses native semantic HTML over ARIA roles (preferred pattern)
- **SonarCloud S6819**: Resolves SonarQube accessibility rule violation
- **Best Practices**: Follows W3C guidelines for live regions

## Testing
- Visual rendering: ✅ No changes
- Accessibility tree: ✅ Improved semantic structure
- Screen reader announcements: ✅ Maintained with native element

## Related Issues
Fixes #3621

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed code changes
- [x] Comments added for complex logic
- [x] No breaking changes
- [x] Accessibility tested