### PR TITLE
fix: remove redundant type assertion in EditProgramPage

### DIFF
--- a/frontend/src/app/my/mentorship/programs/[programKey]/edit/page.tsx
+++ b/frontend/src/app/my/mentorship/programs/[programKey]/edit/page.tsx
@@ -1,5 +1,5 @@
 'use client'
-
+import type { ExtendedSession } from 'types/auth'
 import { useMutation, useQuery } from '@apollo/client/react'
 import { addToast } from '@heroui/toast'
 import { useRouter, useParams } from 'next/navigation'
@@ -53,10 +53,9 @@ const EditProgramPage = () => {
       return
     }
 
-    const isAdmin = data.getProgram.admins?.some(
-      (admin: { login: string }) => admin.login === session?.user?.login
-    )
-
+ const isAdmin = data.getProgram.admins?.some(
+  (admin: { login: string }) => admin.login === (session as ExtendedSession)?.user?.login
+)
     if (isAdmin) {
       setAccessStatus('allowed')
     } else {

--- a/frontend/src/app/my/mentorship/programs/[programKey]/edit/page.tsx
+++ b/frontend/src/app/my/mentorship/programs/[programKey]/edit/page.tsx
@@ -13,7 +13,6 @@ import {
   GetMyProgramsDocument,
   GetProgramDetailsDocument,
 } from 'types/__generated__/programsQueries.generated'
-import type { ExtendedSession } from 'types/auth'
 import { formatDateForInput } from 'utils/dateFormatter'
 import { parseCommaSeparated } from 'utils/parser'
 import LoadingSpinner from 'components/LoadingSpinner'
@@ -55,7 +54,7 @@ const EditProgramPage = () => {
     }
 
     const isAdmin = data.getProgram.admins?.some(
-      (admin: { login: string }) => admin.login === (session as ExtendedSession)?.user?.login
+      (admin: { login: string }) => admin.login === session?.user?.login
     )
 
     if (isAdmin) {

--- a/frontend/src/app/organizations/page.tsx
+++ b/frontend/src/app/organizations/page.tsx
@@ -63,7 +63,7 @@ const OrganizationPage = () => {
       totalPages={totalPages}
     >
       <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-        {organizations && organizations.map(renderOrganizationCard)}
+        {organizations?.map(renderOrganizationCard)}
       </div>
     </SearchPageLayout>
   )


### PR DESCRIPTION
This PR addresses the SonarQube code smell (typescript:S4325) by removing a redundant type assertion in the EditProgramPage component.

## Changes
- Removed the unnecessary `(session as ExtendedSession)` cast in `frontend/src/app/my/mentorship/programs/[programKey]/edit/page.tsx`
- Removed the unused `ExtendedSession` import
- The type assertion was redundant because TypeScript already infers the correct type in this context

## Testing
- TypeScript compilation passes without errors
- ESLint checks pass
- The change maintains the same functionality for admin access control

## Issue
Fixes SonarQube rule typescript:S4325: Redundant casts and non-null assertions should be avoided

This improves code maintainability by removing unnecessary type assertions.

Resolves #3554

