### PR TITLE
fix: optimize latest_release field by adding prefetch_related for rel…

### DIFF
--- a/backend/apps/github/api/internal/nodes/repository.py
+++ b/backend/apps/github/api/internal/nodes/repository.py
@@ -54,7 +54,7 @@ class RepositoryNode(strawberry.relay.Node):
         """Resolve languages."""
         return list(root.languages.keys())
 
-    @strawberry_django.field
+    @strawberry_django.field(prefetch_related=["releases"])
     def latest_release(self, root: Repository) -> str | None:
         """Resolve latest release."""
         return root.latest_release


### PR DESCRIPTION
### Proposed change
Resolves #3663

Optimizes the latestRelease field in the repository GraphQL node to prevent N+1 queries. Adds a prefetch_related hint so all releases are fetched in a single query, significantly improving performance when querying multiple repositories.


## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [x] I used AI for code, documentation, tests, or communication related to this PR
