### PR TITLE
Prefer optional chaining in organizations list (typescript:S6582)

### DIFF
--- a/frontend/src/app/organizations/page.tsx
+++ b/frontend/src/app/organizations/page.tsx
@@ -1,4 +1,5 @@
 'use client'
+
 import { useSearchPage } from 'hooks/useSearchPage'
 import { useRouter } from 'next/navigation'
 import { FaRightToBracket } from 'react-icons/fa6'
@@ -63,7 +64,7 @@ const OrganizationPage = () => {
       totalPages={totalPages}
     >
       <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-        {organizations && organizations.map(renderOrganizationCard)}
+        {organizations?.map(renderOrganizationCard)}
       </div>
     </SearchPageLayout>
   )

--- a/frontend/src/components/skeletons/Card.tsx
+++ b/frontend/src/components/skeletons/Card.tsx
@@ -38,10 +38,7 @@ const CardSkeleton: React.FC<CardSkeletonProps> = ({
           {showIcons && (
             <div className="flex min-w-[30%] grow flex-row items-center justify-start gap-2 overflow-auto">
               {Array.from({ length: numIcons }).map((_, i) => (
-                <Skeleton
-                  key={`header-icon-${i}`} // NOSONAR - Safe to use index as key for static skeleton items with fixed length
-                  className="h-8 w-16"
-                />
+                <Skeleton key={`header-icon-${i}`} className="h-8 w-16" /> // NOSONAR - Safe to use index as key for static skeleton items with fixed length
               ))}
               <Skeleton />
             </div>
@@ -73,7 +70,6 @@ const CardSkeleton: React.FC<CardSkeletonProps> = ({
                   ))}
                 </div>
               )}
-
               {showSocial && (
                 <div className="flex flex-row gap-2">
                   <Skeleton className="h-8 w-8 rounded-full" />

--- a/frontend/src/components/skeletons/Card.tsx
+++ b/frontend/src/components/skeletons/Card.tsx
@@ -16,8 +16,7 @@ const CardSkeleton: React.FC<CardSkeletonProps> = ({
   const NUM_CONTRIBUTORS = 8
 
   return (
-    <div
-      role="status"
+    <output
       aria-live="polite"
       aria-busy="true"
       aria-label="Loading"
@@ -38,7 +37,10 @@ const CardSkeleton: React.FC<CardSkeletonProps> = ({
           {showIcons && (
             <div className="flex min-w-[30%] grow flex-row items-center justify-start gap-2 overflow-auto">
               {Array.from({ length: numIcons }).map((_, i) => (
-                <Skeleton key={`header-icon-${i}`} className="h-8 w-16" /> // NOSONAR - Safe to use index as key for static skeleton items with fixed length
+                <Skeleton
+                  key={`header-icon-${i}`} // NOSONAR - Safe to use index as key for static skeleton items with fixed length
+                  className="h-8 w-16"
+                />
               ))}
               <Skeleton />
             </div>
@@ -70,6 +72,7 @@ const CardSkeleton: React.FC<CardSkeletonProps> = ({
                   ))}
                 </div>
               )}
+
               {showSocial && (
                 <div className="flex flex-row gap-2">
                   <Skeleton className="h-8 w-8 rounded-full" />
@@ -88,7 +91,7 @@ const CardSkeleton: React.FC<CardSkeletonProps> = ({
           </div>
         </div>
       </div>
-    </div>
+    </output>
   )
 }
 

--- a/frontend/src/components/skeletons/Card.tsx
+++ b/frontend/src/components/skeletons/Card.tsx
@@ -16,7 +16,8 @@ const CardSkeleton: React.FC<CardSkeletonProps> = ({
   const NUM_CONTRIBUTORS = 8
 
   return (
-    <output
+    <div
+      role="status"
       aria-live="polite"
       aria-busy="true"
       aria-label="Loading"
@@ -91,7 +92,7 @@ const CardSkeleton: React.FC<CardSkeletonProps> = ({
           </div>
         </div>
       </div>
-    </output>
+    </div>
   )
 }
 


### PR DESCRIPTION
Resolves #3635.

## Description

Updates the organizations list in `frontend/src/app/organizations/page.tsx` to use optional chaining, as suggested by SonarCloud rule `typescript:S6582`.

- Before:
  ```tsx
  {organizations && organizations.map(renderOrganizationCard)}
- After:
   {organizations?.map(renderOrganizationCard)}

Behavior is unchanged: when organizations is null or undefined, nothing is rendered; when it is an array, the list renders as before.

## Checklist
- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [x] I used AI for code, documentation, tests, or communication related to this PR
