### PR TITLE
fix: add rel='noopener noreferrer' to external Link in ItemCardList

### DIFF
--- a/frontend/src/components/ItemCardList.tsx
+++ b/frontend/src/components/ItemCardList.tsx
@@ -83,6 +83,7 @@ const ItemCardList = ({
                     className="text-blue-400 hover:underline"
                     href={item?.url || ''}
                     target="_blank"
+                    rel="noopener noreferrer"
                   >
                     <TruncatedText text={item.title || item.name} />
                   </Link>


### PR DESCRIPTION
Fixes #3669

This PR adds rel="noopener noreferrer" to the Link component when opening external URLs in a new tab (target="_blank").

Why this change?

Opening links in a new tab without rel="noopener noreferrer" can expose the application to reverse tabnabbing attacks, where the newly opened page gains access to window.opener.

Adding this attribute is a security best practice and aligns OWASP Nest with modern web security standards.

Updated the Link component to automatically include:

rel="noopener noreferrer"


when:

target="_blank" is used

the URL is external