### PR TITLE
Resolve entity member admin attribute error

### DIFF
--- a/backend/apps/owasp/models/common.py
+++ b/backend/apps/owasp/models/common.py
@@ -95,7 +95,7 @@ class RepositoryBasedEntityModel(models.Model):
         EntityMember,
         content_type_field="entity_type",
         object_id_field="entity_id",
-        related_query_name="entity",
+        related_query_name="entity_member",
     )
 
     @cached_property


### PR DESCRIPTION
Resolves #3700

## Proposed change

Renamed `related_query_name` to `entity_member` (anything that is not "entity") in [backend/apps/owasp/models/common.py](https://github.com/OWASP/Nest/blob/main/backend/apps/owasp/models/common.py).

This resolves a conflict where the `related_query_name` conflicted with GenericForeignKey field in the EntityMember model . This collision caused it to return a `RelatedManager` instead of the actual entity object, leading to `AttributeError: 'RelatedManager' object has no attribute 'owasp_url'` in the admin panel.

## Checklist

- [x] Required: I followed the contributing workflow
- [x] Required: I verified that my code works as intended and resolves the issue as described
- [x] Required: I ran `make check-test` locally: all warnings addressed, tests passed
- [x] I used AI for code, documentation, tests, or communication related to this PR