### PR TITLE
fix: prefer optional chaining when accessing menu attribute (S6582)

### DIFF
--- a/frontend/__tests__/unit/pages/Header.test.tsx
+++ b/frontend/__tests__/unit/pages/Header.test.tsx
@@ -156,7 +156,7 @@ const findMobileMenu = () => {
 // Helper function to check if mobile menu is open
 const isMobileMenuOpen = () => {
   const menu = findMobileMenu()
-  if (menu && menu.getAttribute('aria-expanded') === 'true') {
+  if (menu?.getAttribute('aria-expanded') === 'true') {
     return true
   }
   return menu?.className.includes('translate-x-0') || false
@@ -165,7 +165,7 @@ const isMobileMenuOpen = () => {
 // Helper function to check if mobile menu is closed
 const isMobileMenuClosed = () => {
   const menu = findMobileMenu()
-  if (menu && menu.getAttribute('aria-expanded') === 'false') {
+  if (menu?.getAttribute('aria-expanded') === 'false') {
     return true
   }
   return menu?.className.includes('-translate-x-full') || false


### PR DESCRIPTION
## Proposed change

Resolves #3667

This PR resolves SonarCloud rule `typescript:S6582` by replacing a logical AND guard with optional chaining when accessing the menu element attribute.

The change improves readability and maintainability while preserving existing behavior.

## Checklist

- [x] I followed the contributing workflow
- [x] I verified that the code works as intended and resolves the issue
- [x] I ran the relevant local checks (lint)
- [ ] I used AI for code, documentation, tests, or communication related to this PR
