### PR TITLE
fix: lock user to remove possible data race chances when creating api…

### DIFF
--- a/backend/apps/api/models/api_key.py
+++ b/backend/apps/api/models/api_key.py
@@ -55,7 +55,9 @@ class ApiKey(models.Model):
     @transaction.atomic
     def create(cls, user, name, expires_at):
         """Create a new API key instance."""
-        if user.active_api_keys.select_for_update().count() >= MAX_ACTIVE_KEYS:
+        User = type(user)
+        user = User.objects.select_for_update().get(pk=user.pk)
+        if user.api_keys.filter(is_revoked=False).count() >= MAX_ACTIVE_KEYS:
             return None
 
         raw_key = cls.generate_raw_key()


### PR DESCRIPTION
… key

## Proposed change

<!-- Don't forget to link your PR to an existing issue.-->
Resolves #3634 

<!-- Describe the big picture of your changes.-->
currently the way we count the number of api keys only locks the api key row. but the count itself isn't dependent on the locked rows but the whole user. the pr updates the code to lock the user. also a minor fix to count only those api keys that have not been revoked.

## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [x] I used AI for code, documentation, tests, or communication related to this PR
