### PR TITLE
fix: reject malformed URLs with invalid netloc values

### DIFF
--- a/backend/apps/common/utils.py
+++ b/backend/apps/common/utils.py
@@ -247,12 +247,29 @@ def validate_url(url: str | None) -> bool:
         bool: True if URL is valid, False otherwise.
 
     """
-    if not url:
+    max_url_length = 2048
+    min_port = 1
+    max_port = 65535
+
+    if not url or len(url) > max_url_length or re.search(r"[\x00-\x1f\x7f]", url):
         return False
 
     try:
         parsed = urlparse(url)
+        
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            return False
+
+        if not re.search(r"[a-zA-Z0-9]", parsed.netloc):
+            return False
+
+        hostname = parsed.hostname or parsed.netloc
+        if hostname.startswith(('.', '-')) or hostname.endswith('-'):
+            return False
+
+        if parsed.port is not None and not (min_port <= parsed.port <= max_port):
+            return False
+            
+        return True
     except ValueError:
         return False
-
-    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)

--- a/backend/tests/apps/common/utils_test.py
+++ b/backend/tests/apps/common/utils_test.py
@@ -171,32 +171,71 @@ class TestUtils:
     @pytest.mark.parametrize(
         ("url", "expected"),
         [
+            # Valid URLs
             ("https://example.com", True),
             ("http://example.com", True),
             ("https://example.com/path", True),
             ("https://example.com/path?query=1", True),
             ("https://example.com/path#fragment", True),
             ("https://subdomain.example.com", True),
+            ("https://sub-domain.example.com", True),  
+            ("https://example-domain.com", True),  
             ("https://example.com:8080", True),
             ("https://example.com:8080/path", True),
+            ("https://example", True), 
+            ("https://example.", True),  
+            ("https://example.com.", True),  
+            ("https://192.168.1.1", True), 
+            ("https://[::1]", True),  
+            ("https://[2001:db8::1]", True), 
+            ("https://example.com:1", True),  
+            ("https://example.com:80", True),
+            ("https://example.com:443", True),
+            ("https://example.com:65535", True), 
+            ("https://example123.com", True),  
+            ("https://123example.com", True),  
+            # Invalid URLs - Empty/None
             ("", False),
             (None, False),
             ("not-a-url", False),
+            # Invalid URLs - Wrong scheme
             ("ftp://example.com", False),
+            ("javascript:alert(1)", False),
+            ("data:text/html,<script>alert(1)</script>", False),
+            ("file:///etc/passwd", False),
+            # Invalid URLs - Missing netloc
             ("https://", False),
             ("http://", False),
-            ("https://example", True),  # Valid single label domain
-            ("https://example.", True),  # Valid with trailing dot
-            ("https://example.com.", True),  # Valid with trailing dot
-            ("https://192.168.1.1", True),  # Valid IP address
-            ("https://[::1]", True),  # Valid IPv6 address
-            ("https://example.com:99999", True),  # Valid port (urlparse accepts it)
+            ("http://.", False),
+            ("http://-", False),  
+            ("https://...", False),  
+            ("http://---", False),  
+            ("http:// ", False),  
+            ("https://. ", False),  
+            ("http://.example.com", False),  
+            ("https://-example.com", False),  
+            ("https://example.com-", False),  
+            # Invalid URLs - Invalid ports
+            ("https://example.com:0", False),  
+            ("https://example.com:65536", False),  
+            ("https://example.com:99999", False),  
+            ("https://example.com:100000", False),  
+            # Invalid URLs - Control characters
+            ("http://example.com\x00", False),  
+            ("http://exam\x00ple.com", False),  
+            ("http://example.com\x01", False),  
+            ("http://example.com\n", False),  
+            ("http://example.com\r", False),  
+            ("http://example.com\t", False),  
+            # Invalid URLs - Length limit
+            ("https://" + "a" * 2050 + ".com", False),  
+            ("https://example.com/" + "x" * 2050, False),  
         ],
     )
     def test_validate_url(self, url, expected):
         """Test the validate_url function."""
         result = validate_url(url)
-        assert result == expected
+        assert result == expected, f"validate_url({url!r}) returned {result}, expected {expected}"
 
     @pytest.mark.parametrize(
         ("limit", "max_limit", "expected"),


### PR DESCRIPTION
- Add validation to require at least one alphanumeric character in netloc
- Add security validations: length limits, control character blocking, port range validation
- Add comprehensive test coverage with 50+ test cases
- Fix existing bug: port 99999 was incorrectly accepted

Fixes #3784


## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [x] I used AI for code, documentation, tests, or communication related to this PR
