### PR TITLE
fix: add security controls to MultiSearch window.open()

### DIFF
--- a/frontend/__tests__/unit/components/MultiSearch.test.tsx
+++ b/frontend/__tests__/unit/components/MultiSearch.test.tsx
@@ -577,7 +577,11 @@ describe('Rendering', () => {
 
       await user.click(screen.getByText('Test Event'))
 
-      expect(mockWindowOpen).toHaveBeenCalledWith('https://example.com/event', '_blank')
+      expect(mockWindowOpen).toHaveBeenCalledWith(
+        'https://example.com/event',
+        '_blank',
+        'noopener,noreferrer'
+      )
     })
 
     it('navigates to organization page when organization is clicked', async () => {

--- a/frontend/src/components/MultiSearch.tsx
+++ b/frontend/src/components/MultiSearch.tsx
@@ -92,7 +92,7 @@ const MultiSearchBar: React.FC<MultiSearchBarProps> = ({
           router.push(`/chapters/${suggestion.key}`)
           break
         case 'events':
-          globalThis.open((suggestion as Event).url, '_blank')
+          window.open((suggestion as Event).url, '_blank', 'noopener,noreferrer')
           break
         case 'organizations':
           // Use type guard to safely access login property


### PR DESCRIPTION
## Summary
- Fixes security vulnerability in `MultiSearch` component where `globalThis.open()` was used without security controls
- Replaced with `window.open(url, '_blank', 'noopener,noreferrer')` to prevent tab-napping attacks

Fixes #3752