### PR TITLE
fix: add security controls to MultiSearch window.open()

### DIFF
--- a/frontend/__tests__/unit/components/MultiSearch.test.tsx
+++ b/frontend/__tests__/unit/components/MultiSearch.test.tsx
@@ -577,7 +577,11 @@ describe('Rendering', () => {
 
       await user.click(screen.getByText('Test Event'))
 
-      expect(mockWindowOpen).toHaveBeenCalledWith('https://example.com/event', '_blank')
+      expect(mockWindowOpen).toHaveBeenCalledWith(
+        'https://example.com/event',
+        '_blank',
+        'noopener,noreferrer'
+      )
     })
 
     it('navigates to organization page when organization is clicked', async () => {

--- a/frontend/src/components/MultiSearch.tsx
+++ b/frontend/src/components/MultiSearch.tsx
@@ -92,7 +92,7 @@ const MultiSearchBar: React.FC<MultiSearchBarProps> = ({
           router.push(`/chapters/${suggestion.key}`)
           break
         case 'events':
-          globalThis.open((suggestion as Event).url, '_blank')
+          window.open((suggestion as Event).url, '_blank', 'noopener,noreferrer')
           break
         case 'organizations':
           // Use type guard to safely access login property


### PR DESCRIPTION
Replace unsafe globalThis.open() with window.open() including 'noopener,noreferrer' security parameters to prevent tab-napping attacks when opening event URLs.

Fixes #3752


## STOP AND READ BEFORE SUBMITTING! REMOVE THIS PARAGRAPH BEFORE OPENING THE PR

Thank you for your interest in contributing to OWASP Nest!

Before starting any work, all external contributors **must first be assigned to an issue** in the repository.
This is a mandatory step in the OWASP Nest workflow and ensures that effort is coordinated, approved, and tracked properly.

**Exception:** OWASP leaders are not required to follow this rule —- just make sure your username is included in the [exception list](https://github.com/OWASP/Nest/blob/main/.github/workflows/check-pr-issue-skip-usernames.txt).

**If you were not assigned to the issue you are trying to resolve, stop right now and do NOT create this PR.**
Unassigned pull requests are automatically closed by our workflows — please don't waste your time.

If you want to be assigned on any available issue, comment on it and wait for confirmation from the maintainers or project leads.

## Proposed change

<!-- Don't forget to link your PR to an existing issue.-->
Resolves #(put the issue number here)

<!-- Describe the big picture of your changes.-->
Add the PR description here.

## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [ ] I used AI for code, documentation, tests, or communication related to this PR
