### PR TITLE
Fix stale latest date displayed in Project Health Dashboard metrics

### DIFF
--- a/frontend/src/app/projects/dashboard/metrics/[projectKey]/page.tsx
+++ b/frontend/src/app/projects/dashboard/metrics/[projectKey]/page.tsx
@@ -43,7 +43,7 @@ const ProjectHealthMetricsDetails: FC = () => {
       setMetricsLatest(data.project.healthMetricsLatest)
     }
     if (data?.project?.healthMetricsList) {
-      setMetricsList([...data.project.healthMetricsList].reverse())
+      setMetricsList(data.project.healthMetricsList)
     }
   }, [graphqlError, data])
 

--- a/frontend/src/components/HealthMetrics.tsx
+++ b/frontend/src/components/HealthMetrics.tsx
@@ -6,15 +6,14 @@ import BarChart from 'components/BarChart'
 import LineChart from 'components/LineChart'
 
 const HealthMetrics: React.FC<{ data: HealthMetricsProps[] }> = ({ data }) => {
-  const chronological = [...data].reverse()
-  const openIssuesCountArray = chronological.map((item) => item.openIssuesCount)
-  const labels = chronological.map((item) => {
+  const openIssuesCountArray = data.map((item) => item.openIssuesCount)
+  const labels = data.map((item) => {
     return new Date(item.createdAt).toLocaleDateString('en-US', {
       month: 'short',
       day: 'numeric',
     })
   })
-  const length = chronological.length
+  const length = data.length
   return (
     <>
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
@@ -28,11 +27,11 @@ const HealthMetrics: React.FC<{ data: HealthMetricsProps[] }> = ({ data }) => {
             },
             {
               name: 'Unassigned Issues',
-              data: chronological.map((item) => item.unassignedIssuesCount),
+              data: data.map((item) => item.unassignedIssuesCount),
             },
             {
               name: 'Unanswered Issues',
-              data: chronological.map((item) => item.unansweredIssuesCount),
+              data: data.map((item) => item.unansweredIssuesCount),
             },
           ]}
           labels={labels}
@@ -44,7 +43,7 @@ const HealthMetrics: React.FC<{ data: HealthMetricsProps[] }> = ({ data }) => {
           series={[
             {
               name: 'Open Pull Requests',
-              data: chronological.map((item) => item.openPullRequestsCount),
+              data: data.map((item) => item.openPullRequestsCount),
             },
           ]}
           labels={labels}
@@ -58,7 +57,7 @@ const HealthMetrics: React.FC<{ data: HealthMetricsProps[] }> = ({ data }) => {
           series={[
             {
               name: 'Stars',
-              data: chronological.map((item) => item.starsCount),
+              data: data.map((item) => item.starsCount),
             },
           ]}
           labels={labels}
@@ -70,7 +69,7 @@ const HealthMetrics: React.FC<{ data: HealthMetricsProps[] }> = ({ data }) => {
           series={[
             {
               name: 'Forks',
-              data: chronological.map((item) => item.forksCount),
+              data: data.map((item) => item.forksCount),
             },
           ]}
           labels={labels}
@@ -82,13 +81,10 @@ const HealthMetrics: React.FC<{ data: HealthMetricsProps[] }> = ({ data }) => {
         title="Days Since Last Commit and Release"
         icon={FaCodeCommit}
         labels={['Days Since Last Commit', 'Days Since Last Release']}
-        days={[
-          chronological[length - 1]?.lastCommitDays ?? 0,
-          chronological[length - 1]?.lastReleaseDays ?? 0,
-        ]}
+        days={[data[length - 1]?.lastCommitDays ?? 0, data[length - 1]?.lastReleaseDays ?? 0]}
         requirements={[
-          chronological[length - 1]?.lastCommitDaysRequirement ?? 0,
-          chronological[length - 1]?.lastReleaseDaysRequirement ?? 0,
+          data[length - 1]?.lastCommitDaysRequirement ?? 0,
+          data[length - 1]?.lastReleaseDaysRequirement ?? 0,
         ]}
       />
     </>


### PR DESCRIPTION
## Proposed change
This PR fixes an issue where the Project Health Metrics dashboard was displaying outdated data

Resolves #3795 

<img width="1920" height="1030" alt="image" src="https://github.com/user-attachments/assets/cac2ad3b-35d8-4253-9683-298cc1810e64" />


## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [ ] I used AI for code, documentation, tests, or communication related to this PR
