### PR TITLE
feat(frontend): add /api/health endpoint for monitoring and docker healthchecks 

### DIFF
--- a/frontend/src/app/api/health/route.ts
+++ b/frontend/src/app/api/health/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  return NextResponse.json(
+    { status: "ok" },
+    {
+      status: 200,
+      headers: {
+        "Cache-Control": "no-store",
+      },
+    }
+  );
+}
+


### PR DESCRIPTION
Closes: #3830

### What does this PR do?

Adds a lightweight `/api/health` endpoint using the Next.js App Router.

This enables:

* Docker container healthchecks
* External uptime monitoring
* Faster debugging of frontend availability

### Response

Returns HTTP 200 with:

```json
{ "status": "ok" }
```

### Why?

Previously the frontend exposed only NextAuth routes, making automated health verification difficult.

This introduces a minimal, dependency-free endpoint suitable for infrastructure checks.
