### PR TITLE
fix(mentorship): Prevent lost updates in concurrent Program/Module edits using select_for_update()

### DIFF
--- a/backend/apps/mentorship/api/internal/mutations/module.py
+++ b/backend/apps/mentorship/api/internal/mutations/module.py
@@ -330,8 +330,10 @@ class ModuleMutation:
         user = info.context.request.user
 
         try:
-            module = Module.objects.select_related("program").get(
-                key=input_data.key, program__key=input_data.program_key
+            module = (
+                Module.objects.select_related("program")
+                .select_for_update()
+                .get(key=input_data.key, program__key=input_data.program_key)
             )
         except Module.DoesNotExist as e:
             raise ObjectDoesNotExist(MODULE_NOT_FOUND_MSG) from e

--- a/backend/apps/mentorship/api/internal/mutations/program.py
+++ b/backend/apps/mentorship/api/internal/mutations/program.py
@@ -75,7 +75,7 @@ class ProgramMutation:
         user = info.context.request.user
 
         try:
-            program = Program.objects.get(key=input_data.key)
+            program = Program.objects.select_for_update().get(key=input_data.key)
         except Program.DoesNotExist as err:
             msg = f"Program with key '{input_data.key}' not found."
             logger.warning(msg, exc_info=True)
@@ -144,7 +144,7 @@ class ProgramMutation:
         user = info.context.request.user
 
         try:
-            program = Program.objects.get(key=input_data.key)
+            program = Program.objects.select_for_update().get(key=input_data.key)
         except Program.DoesNotExist as e:
             msg = f"Program with key '{input_data.key}' not found."
             raise ObjectDoesNotExist(msg) from e


### PR DESCRIPTION
## Summary

Fixes #3855 - Prevents lost updates when multiple admins edit the same program or module simultaneously by implementing pessimistic locking with `select_for_update()`.

## Changes

- **`backend/apps/mentorship/api/internal/mutations/program.py`**
  - `update_program()`: Added `select_for_update()` to lock program row during updates
  - `update_program_status()`: Added `select_for_update()` to lock program row during status updates

- **`backend/apps/mentorship/api/internal/mutations/module.py`**
  - `update_module()`: Added `select_for_update()` to lock module row during updates

## How It Works

The `select_for_update()` method acquires a database row lock within the existing `@transaction.atomic` context:

1. First admin to start editing acquires an exclusive lock on the row
2. Concurrent edits are blocked and wait for the lock to be released
3. Second admin's transaction proceeds with fresh data after first admin commits
4. Changes are applied sequentially, preventing overwrites

## Implementation Details

Per maintainer feedback (@arkid15r), chose `select_for_update()` as the least intrusive solution:
- ✅ No schema changes required
- ✅ No frontend changes required
- ✅ Minimal code changes
- ✅ Works with existing `@transaction.atomic` decorators

## Test Plan

- [x] All backend tests pass (`make test-backend`)
- [x] No linter errors introduced
- [ ] Manual testing: Verify concurrent edits are serialized correctly
- [ ] Manual testing: Confirm no performance degradation under normal load

cc @arkid15r @kasya

Made with [Cursor](https://cursor.com)