### PR TITLE
fix(frontend): make dev footer version link to commit

### DIFF
--- a/frontend/__tests__/unit/components/Footer.test.tsx
+++ b/frontend/__tests__/unit/components/Footer.test.tsx
@@ -275,6 +275,55 @@ describe('Footer', () => {
     })
   })
 
+  describe('Version Link Behavior', () => {
+    let originalEnvironment: string
+    let originalReleaseVersion: string
+    let envModule: typeof import('utils/env.client')
+
+    beforeEach(() => {
+      jest.clearAllMocks()
+      envModule = jest.requireMock<typeof import('utils/env.client')>('utils/env.client')
+      originalEnvironment = envModule.ENVIRONMENT
+      originalReleaseVersion = envModule.RELEASE_VERSION
+    })
+
+    afterEach(() => {
+      if (envModule) {
+        envModule.ENVIRONMENT = originalEnvironment
+        envModule.RELEASE_VERSION = originalReleaseVersion
+      }
+    })
+
+    test('renders version as commit link in non-production environment', () => {
+      envModule.ENVIRONMENT = 'staging'
+      envModule.RELEASE_VERSION = '24.2.10-12c25c5'
+
+      const { container } = render(<Footer />)
+
+      const versionLink = container.querySelector('a[href*="commit"]')
+      expect(versionLink).toBeInTheDocument()
+      expect(versionLink).toHaveAttribute('href', 'https://github.com/OWASP/Nest/commit/12c25c5')
+      expect(versionLink).toHaveAttribute('target', '_blank')
+      expect(versionLink).toHaveAttribute('rel', 'noopener noreferrer')
+      expect(versionLink).toHaveTextContent('v24.2.10-12c25c5')
+    })
+
+    test('renders version as release tag link when RELEASE_VERSION has no dash in non-production', () => {
+      envModule.ENVIRONMENT = 'development'
+      envModule.RELEASE_VERSION = '1.2.3'
+
+      const { container } = render(<Footer />)
+
+      const versionLink = container.querySelector('a[href*="releases"]')
+      expect(versionLink).toBeInTheDocument()
+      expect(versionLink).toHaveAttribute(
+        'href',
+        'https://github.com/OWASP/Nest/releases/tag/1.2.3'
+      )
+      expect(versionLink).toHaveTextContent('v1.2.3')
+    })
+  })
+
   describe('Accessibility', () => {
     test('has correct ARIA attributes on buttons', () => {
       renderFooter()

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -93,18 +93,18 @@ export default function Footer() {
             </p>
             {RELEASE_VERSION && (
               <p className="text-sm text-slate-600 dark:text-slate-400">
-                {ENVIRONMENT === 'production' ? (
-                  <Link
-                    className="text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100"
-                    href={`https://github.com/OWASP/Nest/releases/tag/${RELEASE_VERSION}`}
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    <span>v{RELEASE_VERSION}</span>
-                  </Link>
-                ) : (
+                <Link
+                  className="text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100"
+                  href={
+                    ENVIRONMENT === 'production' || !RELEASE_VERSION.includes('-')
+                      ? `https://github.com/OWASP/Nest/releases/tag/${RELEASE_VERSION}`
+                      : `https://github.com/OWASP/Nest/commit/${RELEASE_VERSION.split('-').pop()}`
+                  }
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
                   <span>v{RELEASE_VERSION}</span>
-                )}
+                </Link>
               </p>
             )}
           </div>


### PR DESCRIPTION
## Proposed change

Resolves #3892

Makes the release version at the bottom of https://nest.owasp.dev/ a clickable link to the corresponding Git commit, while keeping the existing behavior on https://nest.owasp.org/.

**Changes:**
- `frontend/src/components/Footer.tsx`: Version is now always a clickable link. In production → links to release tag; in non-production → links to commit (parses short SHA from RELEASE_VERSION when it contains a dash). Falls back to release tag URL when RELEASE_VERSION has no dash.
- `frontend/__tests__/unit/components/Footer.test.tsx`: Added tests for non-production commit link and no-dash fallback.

## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [ ] I used AI for code, documentation, tests, or communication related to this PR