### PR TITLE
reorder the COPY in dockerfiles of backend for better layer caching

### DIFF
--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -35,10 +35,11 @@ COPY --chmod=444 --chown=root:root poetry.lock pyproject.toml ./
 RUN --mount=type=cache,target=${POETRY_CACHE_DIR},uid=${OWASP_UID},gid=${OWASP_GID} \
     poetry install --no-root --verbose --without test --without video
 
+# Less likely to cause cache invalidation items go first.
 COPY entrypoint.sh manage.py wsgi.py ./
-COPY static static
-COPY templates templates
 COPY settings settings
+COPY templates templates
+COPY static static
 COPY apps apps
 
 FROM python:3.13.11-alpine3.23


### PR DESCRIPTION
Changes:
Minor improvements were made to the backend dockerfiles by reordering COPY statements. Previously, stable files like settings, static, and templates would rebuild whenever frequently changing files like apps were modified. The COPY instructions have now been reordered so that the most volatile files (apps and tests) are copied last.

Resolves #3944
 
I have scoped this for backend dockerfiles changes, if suggested by @ahmedxgouda will also review other dockerfiles for such improvements.

Files changed
```bash 
docker/backend/Dockerfile 
docker/backend/Dockerfile.test
```

- [x] I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x]  I verified that my code works as intended and resolves the issue as described
- [x]  I ran `make check-test` locally: all warnings addressed, tests passed
The mypy test is failing but that is not because of my change its due to unescaped new lines in f string.
```bash
backend/tests/apps/mentorship/management/commands/mentorship_sync_module_issues_test.py:210: error: Unterminated string literal (detected at line 210)  [syntax]
Found 1 error in 1 file (errors prevented further checking)
```
If want I can change that in this PR.
- [ ] I used AI for code, documentation, tests, or communication related to this PR
