### PR TITLE
Fix CodeQL workflow branch pattern to match nested feature branches

### DIFF
--- a/.github/workflows/run-code-ql.yaml
+++ b/.github/workflows/run-code-ql.yaml
@@ -4,11 +4,11 @@ on:
   merge_group:
   pull_request:
     branches:
-      - feature/*
+      - feature/**
       - main
   push:
     branches:
-      - feature/*
+      - feature/**
       - main
   workflow_dispatch:
 


### PR DESCRIPTION
 
Resolves #3785 

## Summary

- Updated branch pattern in `run-code-ql.yaml` from `feature/*` to `feature/**`
  on both `pull_request` and `push` triggers (lines 7 and 11)
- This aligns CodeQL security scanning with `run-ci-cd.yaml`, which already
  uses `feature/**`
- Ensures nested feature branches receive
  CodeQL security scans.
  
## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [ ] I used AI for code, documentation, tests, or communication related to this PR
