### PR TITLE
fix: replace empty ResizeObserver methods with jest.fn mocks

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,13 +10,14 @@ Only the latest version on the `main` branch is actively supported with security
 If you discover a security vulnerability in OWASP Nest, please report it responsibly.
 
 ### How to Report
-- Use **GitHub Security Advisories** (preferred), or
-- Follow the OWASP responsible disclosure process
 
+Please use this [form](https://github.com/OWASP/Nest/security/advisories/new) to report a security vulnerability.
 Please **do not** create public GitHub issues for security-related reports.
 
 ### What to Include
+
 When reporting a vulnerability, please include:
+
 - A clear description of the issue
 - Steps to reproduce (if applicable)
 - Potential impact
@@ -24,8 +25,8 @@ When reporting a vulnerability, please include:
 
 ## Response Timeline
 
-- Initial acknowledgment: **3–5 business days**
-- Investigation and validation: **7–14 days**
+- Initial acknowledgment: **up to 7 days**
+- Investigation and validation: **up to 14 days** depending on the issue severity
 - Fix and coordinated disclosure thereafter
 
 Thank you for helping keep OWASP Nest and the community secure.

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -113,13 +113,12 @@ beforeAll(() => {
     })
   }
 
- globalThis.ResizeObserver = class {
-  disconnect = jest.fn();
-  observe = jest.fn();
-  unobserve = jest.fn();
-}
+  globalThis.ResizeObserver = class {
+    disconnect = jest.fn()
+    observe = jest.fn()
+    unobserve = jest.fn()
+  }
 })
-
 
 beforeEach(() => {
   jest.spyOn(console, 'error').mockImplementation((...args) => {


### PR DESCRIPTION
Replaced empty ResizeObserver mock methods with jest.fn().

This resolves SonarQube typescript:S1186 warnings and improves testability by allowing assertions on mock method calls.

