### PR TITLE
Fix race condition in API key creation by locking user row

### DIFF
--- a/backend/apps/api/models/api_key.py
+++ b/backend/apps/api/models/api_key.py
@@ -57,7 +57,9 @@ class ApiKey(models.Model):
     @transaction.atomic
     def create(cls, user, name, expires_at):
         """Create a new API key instance."""
-        if user.active_api_keys.select_for_update().count() >= MAX_ACTIVE_KEYS:
+        type(user).objects.select_for_update().get(pk=user.pk)
+
+        if user.active_api_keys.count() >= MAX_ACTIVE_KEYS:
             return None
 
         raw_key = cls.generate_raw_key()

--- a/backend/tests/apps/api/models/api_key_test.py
+++ b/backend/tests/apps/api/models/api_key_test.py
@@ -113,7 +113,8 @@ class TestApiKeyModel:
             __enter__=MagicMock(return_value=None),
             __exit__=MagicMock(return_value=False),
         )
-        mock_user.active_api_keys.select_for_update.return_value.count.return_value = 0
+        type(mock_user).objects = MagicMock()
+        mock_user.active_api_keys.count.return_value = 0
         mock_instance = MagicMock(spec=ApiKey)
         mock_create.return_value = mock_instance
         expires_at = timezone.now() + timedelta(days=30)
@@ -130,7 +131,8 @@ class TestApiKeyModel:
 
     def test_create_max_keys_exceeded(self, mock_user):
         """Test API key creation fails when max active keys exceeded."""
-        mock_user.active_api_keys.select_for_update.return_value.count.return_value = 100
+        type(mock_user).objects = MagicMock()
+        mock_user.active_api_keys.count.return_value = 100
         expires_at = timezone.now() + timedelta(days=30)
 
         result = ApiKey.create.__wrapped__(ApiKey, mock_user, "Test Key", expires_at)


### PR DESCRIPTION
Resolves  #3634 

## Summary

The select_for_update() was applied to the active_api_keys queryset (the API key rows), which only locks existing rows. When a user has fewer than MAX_ACTIVE_KEYS, concurrent transactions can all read the same count and bypass the limit.

## PR description
> - backend/apps/api/models/api_key.py: Lock the User row via type(user).objects.select_for_update().get(pk=user.pk) before checking the active key count. Removed select_for_update() from the API keys queryset since it's no longer needed.
> - backend/tests/apps/api/models/api_key_test.py: Updated mocks to reflect the new locking strategy.

## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [ ] I used AI for code, documentation, tests, or communication related to this PR
