### PR TITLE
fix: return proper 404 for missing board candidates

### DIFF
--- a/frontend/src/app/board/[year]/candidates/page.tsx
+++ b/frontend/src/app/board/[year]/candidates/page.tsx
@@ -6,12 +6,12 @@ import relativeTime from 'dayjs/plugin/relativeTime'
 import millify from 'millify'
 import Image from 'next/image'
 import Link from 'next/link'
-import { useParams } from 'next/navigation'
+import { notFound, useParams } from 'next/navigation'
 import { useEffect, useState } from 'react'
 import { FaCode, FaExclamationCircle } from 'react-icons/fa'
 import { FaLinkedin, FaCodeBranch, FaCodeMerge } from 'react-icons/fa6'
 
-import { handleAppError, ErrorDisplay } from 'app/global-error'
+import { handleAppError } from 'app/global-error'
 import {
   GetBoardCandidatesDocument,
   GetMemberSnapshotDocument,
@@ -672,13 +672,7 @@ const BoardCandidatesPage = () => {
   }
 
   if (!graphQLData?.boardOfDirectors) {
-    return (
-      <ErrorDisplay
-        statusCode={404}
-        title="Board not found"
-        message={`Sorry, the board information for ${year} doesn't exist`}
-      />
-    )
+    notFound()
   }
 
   return (


### PR DESCRIPTION
Fixes #3974

## Summary

The board candidates page rendered a "Board not found" UI when data was missing but still returned HTTP 200 (soft-404). This impacts SEO and makes monitoring/caching semantics incorrect for genuinely missing resources.

## Changes

- Call `notFound()` from `next/navigation` when `!graphQLData?.boardOfDirectors` (and not loading)
- Next.js renders the not-found page and returns a proper 404 response
- Removed unused `ErrorDisplay` import

## Testing

- Verified missing board year (e.g. /board/1999/candidates) now returns HTTP 404
- Verified valid board years still render correctly