### PR TITLE
Fix scroll position not restored on back navigation (Members page)

### DIFF
--- a/frontend/src/components/AutoScrollToTop.tsx
+++ b/frontend/src/components/AutoScrollToTop.tsx
@@ -7,7 +7,10 @@ export default function AutoScrollToTop() {
   const pathname = usePathname()
 
   useEffect(() => {
-    window.scrollTo(0, 0)
+    // window.scrollTo(0, 0)
+    if ('scrollRestoration' in history) {
+      history.scrollRestoration = 'auto'
+    }
   }, [pathname])
 
   return null


### PR DESCRIPTION

Summary

Resolves the issue where returning to the members listing page via browser back button resets the scroll position to the top instead of restoring the previous position.

Root cause

A global route change handler was forcing window.scrollTo(0, 0) on every navigation, overriding the browser’s native scroll restoration.

Changes made

Removed forced scroll reset on route change

Enabled native browser scroll restoration using history.scrollRestoration = 'auto'

Preserved expected back/forward navigation behavior

Result

Users returning from a member profile now land exactly where they left off in the members list.

Impact

Improves navigation continuity and user experience for long scrolling pages.

Testing

Scroll down members list

Open member profile

Press browser back

Confirm previous scroll position is restored