### PR TITLE
fix: add cursor-pointer to avatar and sign-out button (#4084)

### DIFF
--- a/frontend/src/components/UserMenu.tsx
+++ b/frontend/src/components/UserMenu.tsx
@@ -60,8 +60,7 @@ export default function UserMenu({
   }
 
   const userMenuItemClasses =
-    'block w-full px-4 py-2 text-left text-sm font-medium text-slate-600 hover:bg-slate-100 hover:text-slate-900 dark:text-slate-400 dark:hover:bg-slate-700 dark:hover:text-white'
-
+  'block w-full cursor-pointer px-4 py-2 text-left text-sm font-medium text-slate-600 hover:bg-slate-100 hover:text-slate-900 dark:text-slate-400 dark:hover:bg-slate-700 dark:hover:text-white'
   return (
     <div ref={dropdownRef} className="relative flex items-center justify-center">
       <button
@@ -70,7 +69,7 @@ export default function UserMenu({
         aria-expanded={isOpen}
         aria-haspopup="true"
         aria-controls={dropdownId}
-        className="w-auto focus:outline-hidden"
+        className="w-auto cursor-pointer focus:outline-hidden"
         disabled={isLoggingOut}
       >
         <div className="h-10 w-10 overflow-hidden rounded-full">


### PR DESCRIPTION
## Proposed change

Resolves #4084

### Summary

This PR fixes inconsistent cursor behavior in the header user menu.

### Changes

- Added `cursor-pointer` to the user avatar button.
- Added `cursor-pointer` to the sign-out dropdown button.

Previously, these interactive elements did not display the pointer cursor on hover, unlike the GitHub sign-in button. This update ensures consistent UX across all clickable elements in the header.

### Impact

- Improves visual feedback for interactive elements.
- Aligns avatar and sign-out behavior with existing sign-in button.
- No functional changes introduced — styling improvement only.

---

## Checklist

- [x] **Required:** I followed the contributing workflow  
- [x] **Required:** I verified that my code works as intended and resolves the issue as described  
- [x] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed  
- [ ] I used AI for code, documentation, tests, or communication related to this PR  