### PR TITLE
Implement security headers for ZAP compliance in frontend and backend

### DIFF
--- a/backend/settings/base.py
+++ b/backend/settings/base.py
@@ -93,6 +93,7 @@ class Base(Configuration):
     MIDDLEWARE = [
         "corsheaders.middleware.CorsMiddleware",
         "django.middleware.security.SecurityMiddleware",
+        "django.middleware.clickjacking.XFrameOptionsMiddleware",
         "django.contrib.sessions.middleware.SessionMiddleware",
         "django.middleware.common.CommonMiddleware",
         "apps.common.middlewares.csrf_referer_fallback.CsrfRefererFallbackMiddleware",
@@ -241,6 +242,14 @@ class Base(Configuration):
     SLACK_EVENTS_ENABLED = True
     SLACK_SIGNING_SECRET = values.SecretValue()
 
+    SELF_CONSTANT = "'self'"
     SECURE_CONTENT_TYPE_NOSNIFF = True
     SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
     SECURE_SSL_REDIRECT = False
+    X_FRAME_OPTIONS = "DENY"
+    SECURE_REFERRER_POLICY = "strict-origin-when-cross-origin"
+
+    # HSTS Settings (Strict-Transport-Security)
+    SECURE_HSTS_SECONDS = 31536000  # 1 year
+    SECURE_HSTS_INCLUDE_SUBDOMAINS = True
+    SECURE_HSTS_PRELOAD = False

--- a/backend/settings/local.py
+++ b/backend/settings/local.py
@@ -32,3 +32,7 @@ class Local(Base):
 
     SLACK_COMMANDS_ENABLED = True
     SLACK_EVENTS_ENABLED = True
+
+    # HSTS Overrides for local development
+    SECURE_HSTS_SECONDS = 0
+    SECURE_HSTS_PRELOAD = False


### PR DESCRIPTION
## Proposed change

Resolves #4090

Following the security vulnerabilities identified by the ZAP scan, this PR implements several essential security headers across both the Next.js frontend and the Django backend to harden the application against common attack vectors.

**Key changes include:**
- **Frontend (Next.js):** Added `X-Frame-Options`, `X-Content-Type-Options`, `Strict-Transport-Security`, and `Permissions-Policy` via `next.config.ts`.
- **Backend (Django):** Configured corresponding security settings in `base.py` (including HSTS and frame options) to ensure defense-in-depth.

These headers mitigate risks related to clickjacking, MIME-type sniffing, and insecure connections, bringing the project closer to full ZAP scan compliance.

*Note: I encountered a timeout failure in `CreateModule.test.tsx` during local testing. After investigation, this appears to be an existing flaky test/environment timeout issue and is unrelated to these configuration-based security changes.*

## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [ ] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [ ] I used AI for code, documentation, tests, or communication related to this PR