### PR TITLE
This PR fixes an issue where fetchCsrfTokenServer.ts could return cached CSRF tokens

### DIFF
--- a/frontend/src/server/fetchCsrfTokenServer.ts
+++ b/frontend/src/server/fetchCsrfTokenServer.ts
@@ -3,6 +3,7 @@ export const fetchCsrfTokenServer = async (): Promise<string> => {
     throw new Error('NEXT_SERVER_CSRF_URL is not configured')
   }
   const response = await fetch(process.env.NEXT_SERVER_CSRF_URL, {
+    cache: 'no-store',
     credentials: 'include',
     method: 'GET',
   })


### PR DESCRIPTION
## Proposed change

<!-- Don't forget to link your PR to an existing issue.-->
Resolves #4082

## Description
This PR fixes an issue where fetchCsrfTokenServer.ts could return cached CSRF tokens due to default caching behavior in Next.js App Router.
In Next.js, server-side fetch() calls are cached by default unless explicitly configured otherwise. Since caching was not disabled, the CSRF token response could be reused across multiple requests, leading to intermittent CSRF validation failures caused by stale tokens.

## Checklist
- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed