### PR TITLE
Mitigate CVE-2026-27903, CVE-2026-27904

### DIFF
--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -55,6 +55,7 @@ WORKDIR /tmp
 
 # Fix CVE-2026-23745, CVE-2026-26960: Update npm's bundled tar to 7.5.8 in runner stage
 # Fix CVE-2026-25547: Update npm's bundled @isaacs/brace-expansion to 5.0.1
+# Fix CVE-2026-27903, CVE-2026-27904: Update npm's bundled minimatch to 10.2.3
 # Note: Must download tar with npm pack BEFORE removing the old tar (npm needs it)
 RUN npm pack tar@7.5.8 && \
     tar -xzf tar-7.5.8.tgz && \
@@ -73,6 +74,14 @@ RUN npm pack tar@7.5.8 && \
     chmod -R 755 "${BRACE_DIR}" && \
     rm -rf package isaacs-brace-expansion-5.0.1.tgz && \
     grep -q '"version": "5.0.1"' "${BRACE_DIR}/package.json" && \
+    npm pack minimatch@10.2.3 && \
+    tar -xzf minimatch-10.2.3.tgz && \
+    MINIMATCH_DIR="/usr/local/lib/node_modules/npm/node_modules/minimatch" && \
+    rm -rf "${MINIMATCH_DIR}" && \
+    cp -r package "${MINIMATCH_DIR}" && \
+    chmod -R 755 "${MINIMATCH_DIR}" && \
+    rm -rf package minimatch-10.2.3.tgz && \
+    grep -q '"version": "10.2.3"' "${MINIMATCH_DIR}/package.json" && \
     addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 -G nodejs nextjs
 


### PR DESCRIPTION


## Proposed change

Mitigate CVE-2026-27903, CVE-2026-27904

`make security-scan` passes locally.
`make security-scan-frontend-image`:
<img width="1893" height="1014" alt="image" src="https://github.com/user-attachments/assets/f7ad3371-7ad1-4e3c-b989-f163d913efb2" />

## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [ ] I used AI for code, documentation, tests, or communication related to this PR
