### PR TITLE
Extend list_events endpoint with category filtering support and tests

### DIFF
--- a/backend/apps/api/rest/v0/event.py
+++ b/backend/apps/api/rest/v0/event.py
@@ -84,14 +84,22 @@ def list_events(
         None,
         description="Filter for upcoming events",
     ),
+    category: str | None = Query(
+        None,
+        description="Filter by event category (comma-separated for multiple values)",
+    ),
 ) -> list[Event]:
     """Get list of events."""
     if is_upcoming:
-        return filters.filter(
-            EventModel.upcoming_events().order_by(ordering or "start_date", "end_date")
-        )
+        queryset = EventModel.upcoming_events().order_by(ordering or "start_date", "end_date")
+    else:
+        queryset = EventModel.objects.order_by(ordering or "-start_date", "-end_date")
 
-    return filters.filter(EventModel.objects.order_by(ordering or "-start_date", "-end_date"))
+    if isinstance(category, str) and category:
+        categories = [c.strip() for c in category.split(",") if c.strip()]
+        queryset = queryset.filter(category__in=categories)
+
+    return filters.filter(queryset)
 
 
 @router.get(

--- a/backend/tests/apps/api/rest/v0/event_test.py
+++ b/backend/tests/apps/api/rest/v0/event_test.py
@@ -96,6 +96,94 @@ class TestListEvents:
         mock_event_model.upcoming_events.assert_called_once()
         assert result == mock_upcoming_qs
 
+    @patch("apps.api.rest.v0.event.EventModel")
+    def test_list_events_with_single_category(self, mock_event_model):
+        """Test listing events filtered by a single category."""
+        mock_request = MagicMock()
+        mock_filters = MagicMock()
+        mock_queryset = MagicMock()
+
+        mock_event_model.objects.order_by.return_value = mock_queryset
+        mock_queryset.filter.return_value = mock_queryset
+        mock_filters.filter.return_value = mock_queryset
+
+        result = list_events(
+            mock_request,
+            mock_filters,
+            ordering=None,
+            is_upcoming=None,
+            category="conference",
+        )
+
+        mock_queryset.filter.assert_called_with(category__in=["conference"])
+        assert result == mock_queryset
+
+    @patch("apps.api.rest.v0.event.EventModel")
+    def test_list_events_with_multiple_categories(self, mock_event_model):
+        """Test listing events filtered by multiple categories."""
+        mock_request = MagicMock()
+        mock_filters = MagicMock()
+        mock_queryset = MagicMock()
+
+        mock_event_model.objects.order_by.return_value = mock_queryset
+        mock_queryset.filter.return_value = mock_queryset
+        mock_filters.filter.return_value = mock_queryset
+
+        result = list_events(
+            mock_request,
+            mock_filters,
+            ordering=None,
+            is_upcoming=None,
+            category="conference, meetup",
+        )
+
+        mock_queryset.filter.assert_called_with(category__in=["conference", "meetup"])
+        assert result == mock_queryset
+
+    @patch("apps.api.rest.v0.event.EventModel")
+    def test_list_events_category_with_spaces(self, mock_event_model):
+        """Test category filtering trims whitespace."""
+        mock_request = MagicMock()
+        mock_filters = MagicMock()
+        mock_queryset = MagicMock()
+
+        mock_event_model.objects.order_by.return_value = mock_queryset
+        mock_queryset.filter.return_value = mock_queryset
+        mock_filters.filter.return_value = mock_queryset
+
+        result = list_events(
+            mock_request,
+            mock_filters,
+            ordering=None,
+            is_upcoming=None,
+            category="  conference ,  meetup  ",
+        )
+
+        mock_queryset.filter.assert_called_with(category__in=["conference", "meetup"])
+        assert result == mock_queryset
+
+    @patch("apps.api.rest.v0.event.EventModel")
+    def test_list_events_empty_category_values(self, mock_event_model):
+        """Test category filtering with empty comma values."""
+        mock_request = MagicMock()
+        mock_filters = MagicMock()
+        mock_queryset = MagicMock()
+
+        mock_event_model.objects.order_by.return_value = mock_queryset
+        mock_queryset.filter.return_value = mock_queryset
+        mock_filters.filter.return_value = mock_queryset
+
+        result = list_events(
+            mock_request,
+            mock_filters,
+            ordering=None,
+            is_upcoming=None,
+            category=", ,",
+        )
+
+        mock_queryset.filter.assert_called_with(category__in=[])
+        assert result == mock_queryset
+
 
 class TestGetEvent:
     """Tests for get_event endpoint."""


### PR DESCRIPTION
## Proposed change

Resolves #4120

This PR extends the `list_events` REST endpoint to support filtering events by `category` via a new query parameter.

### What was added

- Added a new optional query parameter: `category`
- Supports filtering by:
  - Single category (e.g., `?category=conference`)
  - Multiple categories (comma-separated, e.g., `?category=conference,meetup`)
- Filtering is applied at the database level using Django ORM (`category__in`)
- Whitespace in comma-separated values is safely trimmed
- When `category` is not provided, existing behavior remains unchanged
- When invalid categories are provided, the API returns an empty result set

### Implementation notes

- Filtering is applied after base queryset selection (upcoming/default ordering)
- Integrated cleanly with existing filters, ordering, and pagination
- No unrelated logic was modified
- Backward compatibility preserved

### Tests

Added unit tests covering:

- Single category filtering
- Multiple category filtering
- Whitespace handling
- Empty/invalid category values
- Ensured existing behavior remains unchanged

All backend tests pass locally (`make test-backend`).

## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [x] I used AI for code, documentation, tests, or communication related to this PR