### PR TITLE
Add Rishi Mondal to the mentors list

### DIFF
--- a/.github/workflows/check-pr-issue-skip-usernames.txt
+++ b/.github/workflows/check-pr-issue-skip-usernames.txt
@@ -365,6 +365,7 @@ matowasp
 matreurai
 matt-perrotti
 mavensecurity
+mavrick-1
 mbrg
 mccabe615
 meetsaad

--- a/MENTORS.md
+++ b/MENTORS.md
@@ -84,6 +84,14 @@ Product Security Engineer at Splunk
 
 Raja Nagori is a Product Security Engineer at Splunk with a strong focus on information security and continuous learning. He holds a Bachelor's degree in Computer Science and Engineering and has experience in penetration testing, threat modeling, and DevSecOps. Raja is an active member of the OWASP community and leads the Nightingale project, a Docker-based environment for penetration testers.
 
+### Rishi Mondal
+
+SRE at Obmondo | Maintainer of CNCF KubeStellar
+
+[GitHub](https://github.com/MAVRICK-1/) • [LinkedIn](https://www.linkedin.com/in/rishi-mondal-5238b2282/) • [Slack](https://owasp.slack.com/team/U0AHVMYHMJB) • [India (IST)](https://time-time.net/time/kolkata-india.php) • [About me](https://mentorship.lfx.linuxfoundation.org/mentor/711a2840-0900-42c7-b115-b59799027e80)
+
+Rishi Mondal is a Site Reliability Engineer (SRE) at Obmondo and a CNCF KubeStellar Maintainer. He is a Linux Foundation Mentor and active open-source contributor, specializing in Kubernetes, cloud-native infrastructure, Terraform, and AWS. He builds and maintains scalable, production-grade distributed systems.
+
 ---
 
 ## Google Summer of Code 2025
@@ -111,16 +119,3 @@ Full-Stack Software Engineer
 [GitHub](https://github.com/aramattamara/) • [LinkedIn](https://www.linkedin.com/in/aramattamara/) • [Slack](https://owasp.slack.com/team/U0881RRPBDY) • [United States (Pacific Time)](https://time-time.net/times/time-zones/usa-canada/current-pacific-time-pst.php)
 
 Tamara is a Fullstack Engineer who builds web applications from scratch using Node.js (Express), React, Tailwind, and MySQL. She graduated from Hackbright Academy (April 2023), is a quick learner who enjoys challenges, and collaborates well in teams.
-
-
-### Rishi Mondal
-
-SRE at Obmondo | Maintainer of CNCF kubestellar
-
-[GitHub](https://github.com/MAVRICK-1/) • [LinkedIn](https://www.linkedin.com/in/rishi-mondal-5238b2282/) • [Slack](https://owasp.slack.com/team/U0AHVMYHMJB) • [India (IST)](https://time-time.net/time/kolkata-india.php) • [About me](https://mentorship.lfx.linuxfoundation.org/mentor/711a2840-0900-42c7-b115-b59799027e80)
-
-Rishi Mondal is a Site Reliability Engineer (SRE) at Obmondo and a CNCF KubeStellar Maintainer. He is a Linux Foundation Mentor and active open-source contributor, specializing in Kubernetes, cloud-native infrastructure, Terraform, and AWS. He builds and maintains scalable, production-grade distributed systems.
-
-
-
-

--- a/cspell/custom-dict.txt
+++ b/cspell/custom-dict.txt
@@ -35,6 +35,7 @@ Keshav
 Kriti
 Manyi
 Mifos
+Mondal
 NETTACKER
 NOASSERTION
 NOSEMGREP
@@ -42,6 +43,7 @@ NOSONAR
 Nadu
 Nagori
 Nominatim
+Obmondo
 Oleksiuk
 PGPASSWORD
 PLR
@@ -50,6 +52,7 @@ PYTHONUNBUFFERED
 RUF
 SEO
 SLF
+SRE
 Sivagangai
 Sonarqube
 Stegen


### PR DESCRIPTION
This pull request adds a new mentor profile to the `MENTORS.md` file. The update introduces Rishi Mondal, providing details about their background, contact information, and relevant links.

Mentor profile addition:

* Added a new section for Rishi Mondal, including their role (SRE at Obmondo), CNCF kubestellar maintainer status, and links to GitHub, LinkedIn, Slack, timezone, and an "About me" page.