### PR TITLE
extend list_events to filter by category

### DIFF
--- a/backend/apps/api/rest/v0/event.py
+++ b/backend/apps/api/rest/v0/event.py
@@ -26,6 +26,7 @@ class EventBase(Schema):
     name: str
     start_date: str
     url: str | None = None
+    category: str | None = None
 
     @staticmethod
     def resolve_end_date(event: EventModel) -> str | None:
@@ -36,6 +37,11 @@ class EventBase(Schema):
     def resolve_start_date(event: EventModel) -> str:
         """Resolve start date."""
         return event.start_date.isoformat()
+
+    @staticmethod
+    def resolve_category(event: EventModel) -> str | None:
+        """Resolve category."""
+        return event.category
 
 
 class Event(EventBase):
@@ -84,14 +90,26 @@ def list_events(
         None,
         description="Filter for upcoming events",
     ),
+    category: list[EventModel.Category] | None = Query(
+        None,
+        description="Filter by category",
+    ),
 ) -> list[Event]:
     """Get list of events."""
+    queryset = EventModel.objects.all()
     if is_upcoming:
-        return filters.filter(
-            EventModel.upcoming_events().order_by(ordering or "start_date", "end_date")
-        )
+        queryset = EventModel.upcoming_events()
 
-    return filters.filter(EventModel.objects.order_by(ordering or "-start_date", "-end_date"))
+    if category:
+        queryset = queryset.filter(category__in=category)
+
+    if ordering:
+        return filters.filter(queryset.order_by(ordering))
+
+    default_order = "start_date" if is_upcoming else "-start_date"
+    secondary_order = "end_date" if is_upcoming else "-end_date"
+
+    return filters.filter(queryset.order_by(default_order, secondary_order))
 
 
 @router.get(

--- a/backend/tests/apps/api/rest/v0/event_test.py
+++ b/backend/tests/apps/api/rest/v0/event_test.py
@@ -3,6 +3,7 @@ from http import HTTPStatus
 from unittest.mock import MagicMock, patch
 
 import pytest
+from django.test import Client
 from django.utils import timezone
 
 from apps.api.rest.v0.event import EventDetail, get_event, list_events
@@ -60,13 +61,17 @@ class TestListEvents:
         mock_request = MagicMock()
         mock_filters = MagicMock()
         mock_queryset = MagicMock()
-        mock_event_model.objects.order_by.return_value = mock_queryset
-        mock_filters.filter.return_value = mock_queryset
+        mock_ordered_qs = MagicMock()
+        
+        mock_event_model.objects.all.return_value = mock_queryset
+        mock_queryset.order_by.return_value = mock_ordered_qs
+        mock_filters.filter.return_value = mock_ordered_qs
 
         result = list_events(mock_request, mock_filters, ordering=None, is_upcoming=None)
 
-        mock_event_model.objects.order_by.assert_called_with("-start_date", "-end_date")
-        assert result == mock_queryset
+        mock_queryset.order_by.assert_called_with("-start_date", "-end_date")
+        mock_filters.filter.assert_called_with(mock_ordered_qs)
+        assert result == mock_ordered_qs
 
     @patch("apps.api.rest.v0.event.EventModel")
     def test_list_events_with_ordering(self, mock_event_model):
@@ -74,13 +79,58 @@ class TestListEvents:
         mock_request = MagicMock()
         mock_filters = MagicMock()
         mock_queryset = MagicMock()
-        mock_event_model.objects.order_by.return_value = mock_queryset
-        mock_filters.filter.return_value = mock_queryset
+        mock_ordered_qs = MagicMock()
+
+        mock_event_model.objects.all.return_value = mock_queryset
+        mock_queryset.order_by.return_value = mock_ordered_qs
+        mock_filters.filter.return_value = mock_ordered_qs
 
         result = list_events(mock_request, mock_filters, ordering="latitude", is_upcoming=None)
 
-        mock_event_model.objects.order_by.assert_called_with("latitude", "-end_date")
-        assert result == mock_queryset
+        mock_queryset.order_by.assert_called_with("latitude")
+        mock_filters.filter.assert_called_with(mock_ordered_qs)
+        assert result == mock_ordered_qs
+
+    @patch("apps.api.rest.v0.event.EventModel")
+    def test_list_events_single_category(self, mock_event_model):
+        """Test listing events with single category."""
+        mock_request = MagicMock()
+        mock_filters = MagicMock()
+        mock_upcoming_qs = MagicMock()
+        mock_filtered_qs = MagicMock()
+        mock_ordered_qs = MagicMock()
+
+        mock_event_model.upcoming_events.return_value = mock_upcoming_qs
+        mock_upcoming_qs.filter.return_value = mock_filtered_qs
+        mock_filtered_qs.order_by.return_value = mock_ordered_qs
+        mock_filters.filter.return_value = mock_ordered_qs
+
+        result = list_events(mock_request, mock_filters, ordering=None, is_upcoming=True, category=["global"])
+
+        mock_upcoming_qs.filter.assert_called_with(category__in=["global"])
+        mock_filtered_qs.order_by.assert_called_with("start_date", "end_date")
+        mock_filters.filter.assert_called_with(mock_ordered_qs)
+        assert result == mock_ordered_qs
+    
+    @patch("apps.api.rest.v0.event.EventModel")
+    def test_list_events_multiple_categories(self, mock_event_model):
+        """Test listing events with multiple categories filtering."""
+        mock_request = MagicMock()
+        mock_filters = MagicMock()
+        mock_upcoming_qs = MagicMock()
+        mock_filtered_qs = MagicMock()
+        mock_ordered_qs = MagicMock()
+
+        mock_event_model.upcoming_events.return_value = mock_upcoming_qs
+        mock_upcoming_qs.filter.return_value = mock_filtered_qs
+        mock_filtered_qs.order_by.return_value = mock_ordered_qs
+        mock_filters.filter.return_value = mock_ordered_qs
+
+        result = list_events(mock_request, mock_filters, ordering=None, is_upcoming=True, category=["global", "appsec_days"])
+
+        mock_upcoming_qs.filter.assert_called_with(category__in=["global", "appsec_days"])
+        mock_filtered_qs.order_by.assert_called_with("start_date", "end_date")
+        assert result == mock_ordered_qs
 
     @patch("apps.api.rest.v0.event.EventModel")
     def test_list_events_upcoming(self, mock_event_model):
@@ -88,13 +138,80 @@ class TestListEvents:
         mock_request = MagicMock()
         mock_filters = MagicMock()
         mock_upcoming_qs = MagicMock()
-        mock_event_model.upcoming_events.return_value.order_by.return_value = mock_upcoming_qs
-        mock_filters.filter.return_value = mock_upcoming_qs
+        mock_ordered_qs = MagicMock()
+
+        mock_event_model.upcoming_events.return_value = mock_upcoming_qs
+        mock_upcoming_qs.order_by.return_value = mock_ordered_qs
+        mock_filters.filter.return_value = mock_ordered_qs
 
         result = list_events(mock_request, mock_filters, ordering=None, is_upcoming=True)
 
         mock_event_model.upcoming_events.assert_called_once()
-        assert result == mock_upcoming_qs
+        mock_upcoming_qs.order_by.assert_called_with("start_date", "end_date")
+        assert result == mock_ordered_qs
+
+    @patch("apps.api.rest.v0.event.EventModel")
+    def test_list_events_category_without_upcoming(self, mock_event_model):
+        """Test listing events with category filter but without is_upcoming."""
+        mock_request = MagicMock()
+        mock_filters = MagicMock()
+        mock_queryset = MagicMock()
+        mock_filtered_qs = MagicMock()
+        mock_ordered_qs = MagicMock()
+
+        mock_event_model.objects.all.return_value = mock_queryset
+        mock_queryset.filter.return_value = mock_filtered_qs
+        mock_filtered_qs.order_by.return_value = mock_ordered_qs
+        mock_filters.filter.return_value = mock_ordered_qs
+
+        result = list_events(mock_request, mock_filters, ordering=None, is_upcoming=None, category=["global"])
+
+        mock_queryset.filter.assert_called_with(category__in=["global"])
+        mock_filtered_qs.order_by.assert_called_with("-start_date", "-end_date")
+        mock_filters.filter.assert_called_with(mock_ordered_qs)
+        assert result == mock_ordered_qs
+
+    @patch("apps.api.rest.v0.event.EventModel")
+    def test_list_events_category_with_ordering(self, mock_event_model):
+        """Test listing events with category and custom ordering."""
+        mock_request = MagicMock()
+        mock_filters = MagicMock()
+        mock_queryset = MagicMock()
+        mock_filtered_qs = MagicMock()
+        mock_ordered_qs = MagicMock()
+
+        mock_event_model.objects.all.return_value = mock_queryset
+        mock_queryset.filter.return_value = mock_filtered_qs
+        mock_filtered_qs.order_by.return_value = mock_ordered_qs
+        mock_filters.filter.return_value = mock_ordered_qs
+
+        result = list_events(mock_request, mock_filters, ordering="latitude", is_upcoming=None, category=["global"])
+
+        mock_queryset.filter.assert_called_with(category__in=["global"])
+        mock_filtered_qs.order_by.assert_called_with("latitude")
+        mock_filters.filter.assert_called_with(mock_ordered_qs)
+        assert result == mock_ordered_qs
+
+
+@pytest.mark.django_db
+class TestEventEndpointIntegration:
+    """Tests for event endpoint."""
+
+    def test_list_events(self):
+        """Test listing events."""
+        client = Client()
+        response = client.get("/api/v0/events/")
+        assert response.status_code == HTTPStatus.OK
+
+    def test_invalid_category_returns_validation_error(self):
+        """Test invalid category returns validation error."""
+
+        client = Client()
+        response = client.get("/api/v0/events/", {"category": "invalid"})
+
+        assert response.status_code == HTTPStatus.BAD_REQUEST
+        data = response.json()
+        assert "errors" in data
 
 
 class TestGetEvent:


### PR DESCRIPTION
## Proposed change

<!-- Don't forget to link your PR to an existing issue.-->
Resolves #4120

<!-- Describe the big picture of your changes.-->
Add the PR description here.

To extend the list_events to support filtering by category
- added category to events.py file : added to projectBase and a param which supports multiple categories with enum validation
- added mutiple tests : for single category, multiple categories & for categories without is_upcoming and with category + ordering / without ordering and invalid values.

## Checklist

- [X] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [X] **Required:** I verified that my code works as intended and resolves the issue as described
- [X] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [X] I used AI for code, documentation, tests, or communication related to this PR
