### PR TITLE
Add gsoc-2026 project tags (#4177)

### DIFF
--- a/backend/data/project-custom-tags/gsoc-2026.json
+++ b/backend/data/project-custom-tags/gsoc-2026.json
@@ -1,0 +1,13 @@
+{
+  "projects": [
+    "www-project-bug-logging-tool",
+    "www-project-honeypot",
+    "www-project-juice-shop",
+    "www-project-nest",
+    "www-project-nettacker",
+    "www-project-pygoat",
+    "www-project-devsecops-maturity-model",
+    "www-project-integration-standards"
+  ],
+  "tags": ["gsoc2026"]
+}


### PR DESCRIPTION
## 📋 Summary

Closes #4177

## ✅ Changes

- Added `backend/data/project-custom-tags/gsoc-2026.json`
- Includes OWASP GSoC 2026 participating projects:
  - Bug Logging Tool (BLT) ecosystem projects
  - Web Application Honeypot project  
  - Existing OWASP projects (Juice Shop, Nest, Nettacker, PyGoat, etc.)

## 📝 Format

Follows the same format as `gsoc-2025.json`:
- Projects array with www-project-* names
- Tags array with "gsoc2026"

## 🎯 Purpose

Enables proper tagging and tracking of GSoC 2026 projects in the OWASP Nest ecosystem, similar to previous years.

---

Built with ❤️ by [Halbot100](https://github.com/Halbot100) 🤖