### PR TITLE
Add gsoc2026 tag projects

### DIFF
--- a/backend/apps/owasp/Makefile
+++ b/backend/apps/owasp/Makefile
@@ -1,3 +1,7 @@
+owasp-add-project-custom-tags:
+	@echo "Adding project custom tags from $(FILE)"
+	@CMD="python manage.py add_project_custom_tags $(FILE)" $(MAKE) exec-backend-command
+
 owasp-aggregate-projects:
 	@echo "Aggregating OWASP projects"
 	@CMD="python manage.py owasp_aggregate_projects" $(MAKE) exec-backend-command

--- a/backend/data/project-custom-tags/gsoc-2026.json
+++ b/backend/data/project-custom-tags/gsoc-2026.json
@@ -3,14 +3,14 @@
     "www-project-bug-logging-tool",
     "www-project-cornucopia",
     "www-project-devsecops-maturity-model",
-    "www-project-genai-security",
     "www-project-honeypot",
+    "www-project-integration-standards",
     "www-project-juice-shop",
     "www-project-nest",
     "www-project-nettacker",
-    "www-project-opencre",
     "www-project-owtf",
-    "www-project-pygoat"
+    "www-project-pygoat",
+    "www-project-top-10-for-large-language-model-applications"
   ],
   "tags": ["gsoc2026"]
 }


### PR DESCRIPTION
## Proposed change

Resolves #4177

Add `gsoc-2026.json` with the 11 OWASP projects participating in Google Summer of Code 2026, following the structure of the existing `gsoc-2025.json` file.

## Checklist
- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [x] I used AI for code, documentation, tests, or communication related to this PR
