### PR TITLE
Update OWASP Nest logo aspect ratio in Footer

### DIFF
--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -127,7 +127,13 @@ export default function Footer() {
             className="flex items-center gap-2 rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
             aria-label="Nest home"
           >
-            <Image src={nestLogoSrc} alt="Nest Logo" width={32} height={32} className="h-8 w-8" />
+            <Image
+              src={nestLogoSrc}
+              alt="Nest Logo"
+              width={28}
+              height={32}
+              className="h-8 w-auto"
+            />
             <span className="text-lg font-semibold text-slate-800 dark:text-slate-200">Nest</span>
           </Link>
         </div>


### PR DESCRIPTION
Updated OWASP Nest logo aspect ratio in `Footer` component.

## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [ ] I used AI for code, documentation, tests, or communication related to this PR
