### PR TITLE
feat: improve project fork, star and contributor count calculation logic

### DIFF
--- a/backend/apps/owasp/management/commands/owasp_aggregate_projects.py
+++ b/backend/apps/owasp/management/commands/owasp_aggregate_projects.py
@@ -71,11 +71,11 @@ class Command(BaseCommand):
 
                 # Counters.
                 commits_count += repository.commits_count
-                contributors_count += repository.contributors_count
-                forks_count += repository.forks_count
+                contributors_count = max(repository.contributors_count, contributors_count)
+                forks_count = max(repository.forks_count, forks_count)
                 open_issues_count += repository.open_issues_count
                 releases_count += repository.releases.count()
-                stars_count += repository.stars_count
+                stars_count = max(repository.stars_count, stars_count)
                 subscribers_count += repository.subscribers_count
                 watchers_count += repository.watchers_count
 


### PR DESCRIPTION
## Proposed change

<!-- Don't forget to link your PR to an existing issue.-->
Resolves #4202

<!-- Describe the big picture of your changes.-->
This PR improves the project fork, star and contributor count calculation logic. Instead of summing the counts of field values (forks, stars, and contributors), it tracks the maximum value for each of these fields from all repositories associated with a project. This avoids inflated values due to duplicates across multiple repositories. 

## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [ ] I used AI for code, documentation, tests, or communication related to this PR
