### PR TITLE
Use separate KMS key per state environment

### DIFF
--- a/infrastructure/bootstrap/main.tf
+++ b/infrastructure/bootstrap/main.tf
@@ -436,6 +436,7 @@ data "aws_iam_policy_document" "part_two" {
       variable = "kms:ResourceAliases"
       values = [
         "alias/${var.project_name}-state",
+        "alias/${var.project_name}-${each.key}-state",
         "alias/${var.project_name}-${each.key}"
       ]
     }

--- a/infrastructure/modules/kms/main.tf
+++ b/infrastructure/modules/kms/main.tf
@@ -66,6 +66,6 @@ resource "aws_kms_key" "main" {
 }
 
 resource "aws_kms_alias" "main" {
-  name          = "alias/${var.project_name}-${var.environment}"
+  name          = var.alias_name
   target_key_id = aws_kms_key.main.key_id
 }

--- a/infrastructure/modules/kms/tests/kms.tftest.hcl
+++ b/infrastructure/modules/kms/tests/kms.tftest.hcl
@@ -8,6 +8,7 @@ override_data {
 }
 
 variables {
+  alias_name   = "alias/nest-test"
   common_tags  = { Environment = "test", Project = "nest" }
   environment  = "test"
   project_name = "nest"

--- a/infrastructure/modules/kms/tests/kms.tftest.hcl
+++ b/infrastructure/modules/kms/tests/kms.tftest.hcl
@@ -14,12 +14,12 @@ variables {
   project_name = "nest"
 }
 
-run "test_alias_name_format" {
+run "test_alias_name" {
   command = plan
 
   assert {
-    condition     = aws_kms_alias.main.name == "alias/${var.project_name}-${var.environment}"
-    error_message = "KMS alias must follow format: alias/{project}-{environment}."
+    condition     = aws_kms_alias.main.name == var.alias_name
+    error_message = "KMS alias must match the provided alias_name variable."
   }
 }
 

--- a/infrastructure/modules/kms/variables.tf
+++ b/infrastructure/modules/kms/variables.tf
@@ -1,3 +1,13 @@
+variable "alias_name" {
+  description = "The name of the KMS alias."
+  type        = string
+
+  validation {
+    condition     = can(regex("^alias/", var.alias_name))
+    error_message = "alias_name must start with 'alias/' (e.g., alias/nest-staging, alias/nest-production)."
+  }
+}
+
 variable "common_tags" {
   description = "A map of common tags to apply to all resources."
   type        = map(string)

--- a/infrastructure/staging/main.tf
+++ b/infrastructure/staging/main.tf
@@ -120,6 +120,7 @@ module "frontend" {
 module "kms" {
   source = "../modules/kms"
 
+  alias_name   = "alias/${var.project_name}-${var.environment}"
   common_tags  = local.common_tags
   environment  = var.environment
   project_name = var.project_name

--- a/infrastructure/state/main.tf
+++ b/infrastructure/state/main.tf
@@ -235,7 +235,7 @@ resource "aws_s3_bucket_object_lock_configuration" "state" {
 
   bucket = aws_s3_bucket.state[each.key].id
 
-  depends_on = [aws_s3_bucket_versioning.state[each.key]]
+  depends_on = [aws_s3_bucket_versioning.state]
 
   rule {
     default_retention {

--- a/infrastructure/state/main.tf
+++ b/infrastructure/state/main.tf
@@ -26,8 +26,8 @@ module "kms" {
 
   alias_name   = "alias/${var.project_name}-${each.key}-state"
   for_each     = local.state_environments
-  common_tags  = local.common_tags
-  environment  = each.key
+  common_tags  = merge(local.common_tags, { Environment = each.key })
+  environment  = "${each.key}-state"
   project_name = var.project_name
 }
 

--- a/infrastructure/state/main.tf
+++ b/infrastructure/state/main.tf
@@ -24,8 +24,10 @@ locals {
 module "kms" {
   source = "../modules/kms"
 
+  alias_name   = "alias/${var.project_name}-${each.key}-state"
+  for_each     = local.state_environments
   common_tags  = local.common_tags
-  environment  = "state"
+  environment  = each.key
   project_name = var.project_name
 }
 
@@ -110,7 +112,7 @@ resource "aws_dynamodb_table" "state_lock" {
   }
   server_side_encryption {
     enabled     = true
-    kms_key_arn = module.kms.key_arn
+    kms_key_arn = module.kms[each.key].key_arn
   }
 }
 

--- a/infrastructure/state/outputs.tf
+++ b/infrastructure/state/outputs.tf
@@ -3,6 +3,11 @@ output "dynamodb_table_names" {
   value       = { for env, table in aws_dynamodb_table.state_lock : env => table.name }
 }
 
+output "kms_key_arns" {
+  description = "The ARNs of the per-environment KMS keys for Terraform state encryption."
+  value       = { for env, kms in module.kms : env => kms.key_arn }
+}
+
 output "state_bucket_names" {
   description = "The names of the per-environment S3 buckets for Terraform state."
   value       = { for env, bucket in aws_s3_bucket.state : env => bucket.bucket }


### PR DESCRIPTION
## Proposed change

Resolves #4218

Use separate KMS key for each state environment.
This PR creates a new KMS key for `bootstrap` state. The existing KMS key can be migrated to be used for `staging` state.

Note: This requires manual intervention.

Please follow the steps:
1. Run the following in `state/` directory to migrate the KMS key state:
    ```bash
    terraform state mv 'module.kms' 'module.kms["staging"]'
    ```
    Alias can be safely recreated.

2. Run `terraform apply` in `state/`.

3. The inline permission for `nest-bootstrap` user is now outdated. Update the KMS ARN in bootstrap user's inline policy. 
Run `terraform output` in `state/` for the ARN.

## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [ ] I used AI for code, documentation, tests, or communication related to this PR
