### PR TITLE
refactor: simplify Event.parse_dates method

### DIFF
--- a/backend/apps/owasp/models/event.py
+++ b/backend/apps/owasp/models/event.py
@@ -106,9 +106,13 @@ class Event(BulkSaveModel, TimestampedModel):
         """
         BulkSaveModel.bulk_save(Event, events, fields=fields)
 
-    # TODO(arkid15r): refactor this when there is a chance.
     @staticmethod
-    def parse_dates(dates: str, start_date: date) -> date | None:  # noqa: PLR0911
+    def _normalize_date_dashes(dates: str) -> str:
+        """Normalize supported date-range dash variants."""
+        return re.sub(r"[-\u2013\u2014\u00e2\u20ac\u201c\u201d]", "-", dates)  # noqa: RUF001
+
+    @staticmethod
+    def parse_dates(dates: str, start_date: date) -> date | None:
         """Parse event dates.
 
         Args:
@@ -122,42 +126,34 @@ class Event(BulkSaveModel, TimestampedModel):
         if not dates:
             return None
 
-        max_day_length = 2
-
-        # Normalize dashes (hyphen, en-dash, em-dash).
-        clean_dates = re.sub(r"[\-\–\—]", "-", dates)  # noqa: RUF001
-
-        # Guard against ISO-like single dates (e.g. "2025-05-26").
-        if re.match(r"^\d{4}-\d{2}-\d{2}$", clean_dates.strip()):
-            try:
-                return parser.parse(clean_dates.strip()).date()
-            except (TypeError, ValueError):
-                return None
-
-        try:
-            if "-" in clean_dates:
-                parts = clean_dates.split("-")
-                end_str = parts[-1].strip()
-
-                day_match = re.match(r"^(\d{1,2})", end_str)
-                if day_match:
-                    day_value = day_match.group(1)
-                    if len(end_str) <= max_day_length or "," in end_str:
-                        return start_date.replace(day=int(day_value))
-
-                end_date = parser.parse(
-                    end_str, default=datetime.combine(start_date, datetime.min.time())
-                ).date()
-                # Handle year crossover: if end_date is before start_date, assume next year.
-                if end_date < start_date:
-                    end_date = end_date.replace(year=end_date.year + 1)
-                return end_date
-
-            return parser.parse(clean_dates.strip()).date()
-
-        except (IndexError, OverflowError, TypeError, ValueError):
+        clean_dates = Event._normalize_date_dashes(dates).strip()
+        if not clean_dates:
             return None
 
+        try:
+            # Single ISO date (e.g. "2025-05-26").
+            if re.match(r"^\d{4}-\d{2}-\d{2}$", clean_dates):
+                return parser.parse(clean_dates).date()
+
+            end_str = clean_dates.rpartition("-")[2].strip() if "-" in clean_dates else ""
+            if not end_str:
+                return parser.parse(clean_dates).date()
+
+            # Fast path for ranges like "May 26-30, 2025" or "26-30".
+            day_match = re.match(r"^(\d{1,2})", end_str)
+            if day_match and (len(end_str) <= 2 or "," in end_str):
+                return start_date.replace(day=int(day_match.group(1)))
+
+            end_date = parser.parse(
+                end_str,
+                default=datetime.combine(start_date, datetime.min.time()),
+            ).date()
+            if end_date < start_date:
+                end_date = end_date.replace(year=end_date.year + 1)
+
+            return end_date
+        except (IndexError, OverflowError, TypeError, ValueError):
+            return None
     @staticmethod
     def update_data(category, data, *, save: bool = True) -> Event | None:
         """Update event data.

--- a/backend/tests/apps/owasp/models/event_test.py
+++ b/backend/tests/apps/owasp/models/event_test.py
@@ -34,65 +34,26 @@ class TestEventModel:
         [
             (None, date(2025, 5, 26), None),
             ("", date(2025, 5, 26), None),
-            ("May 26-30, 2025", date(2025, 5, 26), date(2025, 5, 30)),
             ("Invalid date range", date(2025, 5, 26), None),
-        ],
-    )
-    def test_parse_dates_unit(self, dates, start_date, expected_result):
-        """Unit test for parse_dates structure using mocks."""
-        if not dates:
-            assert Event.parse_dates(dates, start_date) is None
-            return
-
-        with patch("apps.owasp.models.event.parser.parse") as mock_parse:
-            if expected_result:
-                mock_date = Mock()
-                mock_date.date.return_value = expected_result
-                mock_parse.return_value = mock_date
-                result = Event.parse_dates(dates, start_date)
-                assert result == expected_result
-            else:
-                mock_parse.side_effect = ValueError("Invalid")
-                result = Event.parse_dates(dates, start_date)
-                assert result is None
-
-    @pytest.mark.parametrize(
-        ("dates", "start_date", "expected_result"),
-        [
+            ("0000-00-00", date(2025, 5, 26), None),
             ("2025-05-26", date(2025, 5, 26), date(2025, 5, 26)),
-            ("Dec 30, 2025 - Jan 2, 2026", date(2025, 12, 30), date(2026, 1, 2)),
             ("June 5, 2025", date(2025, 6, 5), date(2025, 6, 5)),
             ("May 26-30, 2025", date(2025, 5, 26), date(2025, 5, 30)),
             ("May 26-30", date(2025, 5, 26), date(2025, 5, 30)),
-            ("May 26–30, 2025", date(2025, 5, 26), date(2025, 5, 30)),  # noqa: RUF001
+            ("May 26â€“30, 2025", date(2025, 5, 26), date(2025, 5, 30)),  # noqa: RUF001
+            ("May 26â€”30, 2025", date(2025, 5, 26), date(2025, 5, 30)),
+            ("May 26–30, 2025", date(2025, 5, 26), date(2025, 5, 30)),
             ("May 26—30, 2025", date(2025, 5, 26), date(2025, 5, 30)),
             ("May 30 - June 2, 2025", date(2025, 5, 30), date(2025, 6, 2)),
+            ("Dec 30, 2025 - Jan 2, 2026", date(2025, 12, 30), date(2026, 1, 2)),
+            ("December 25 - January 5", date(2025, 12, 25), date(2026, 1, 5)),
+            ("May 1 - May 5", date(2025, 5, 1), date(2025, 5, 5)),
+            ("26-30th", date(2025, 5, 26), date(2025, 5, 30)),
         ],
     )
-    def test_parse_dates_integration(self, dates, start_date, expected_result):
-        """Test parse_dates with real parser to verify crossover and dash logic."""
-        result = Event.parse_dates(dates, start_date)
-        assert result == expected_result
-
-    def test_parse_dates_iso_format_invalid(self):
-        """Test parse_dates with invalid ISO-like single date returns None."""
-        result = Event.parse_dates("0000-00-00", date(2025, 5, 26))
-        assert result is None
-
-    def test_parse_dates_year_crossover(self):
-        """Test parse_dates with year crossover when end month is before start month."""
-        result = Event.parse_dates("December 25 - January 5", date(2025, 12, 25))
-        assert result == date(2026, 1, 5)
-
-    def test_parse_dates_no_year_crossover(self):
-        """Test parse_dates without year crossover when end is after start."""
-        result = Event.parse_dates("May 1 - May 5", date(2025, 5, 1))
-        assert result == date(2025, 5, 5)
-
-    def test_parse_dates_day_with_year_suffix_no_comma(self):
-        """Test parse_dates where end_str has day match, >2 chars, and no comma."""
-        result = Event.parse_dates("26-30th", date(2025, 5, 26))
-        assert result == date(2025, 5, 30)
+    def test_parse_dates(self, dates, start_date, expected_result):
+        """Test parse_dates across valid and invalid date formats."""
+        assert Event.parse_dates(dates, start_date) == expected_result
 
     def test_update_data_existing_event(self):
         """Test update_data when the event already exists."""


### PR DESCRIPTION
refactor: simplify Event.parse_dates method
Closes #4176
Changes:

Extracted dash normalization to _normalize_date_dashes helper
Simplified flow with early returns and linear logic
Used rpartition for cleaner range splitting
All existing test cases preserved and consolidated into single parametrization

All backend tests pass locally via make test-backend.