### PR TITLE
fix: use max instead of sum for project forks, stars, and contributors

### DIFF
--- a/backend/apps/owasp/management/commands/owasp_aggregate_projects.py
+++ b/backend/apps/owasp/management/commands/owasp_aggregate_projects.py
@@ -71,11 +71,11 @@ class Command(BaseCommand):
 
                 # Counters.
                 commits_count += repository.commits_count
-                contributors_count += repository.contributors_count
-                forks_count += repository.forks_count
+                contributors_count = max(contributors_count, repository.contributors_count)
+                forks_count = max(forks_count, repository.forks_count)
                 open_issues_count += repository.open_issues_count
                 releases_count += repository.releases.count()
-                stars_count += repository.stars_count
+                stars_count = max(stars_count, repository.stars_count)
                 subscribers_count += repository.subscribers_count
                 watchers_count += repository.watchers_count
 

--- a/backend/tests/apps/owasp/management/commands/owasp_aggregate_projects_test.py
+++ b/backend/tests/apps/owasp/management/commands/owasp_aggregate_projects_test.py
@@ -177,3 +177,64 @@ class TestOwaspAggregateProjects:
             command.stdout = mock.MagicMock()
             command.handle(offset=0)
         mock_bulk_save.assert_called()
+
+    @mock.patch.dict("os.environ", {"GITHUB_TOKEN": "test-token"})
+    @mock.patch.object(Project, "bulk_save", autospec=True)
+    def test_handle_uses_max_for_stars_forks_contributors(
+        self, mock_bulk_save, command, mock_project
+    ):
+        """Test project-level stars, forks, contributors use max across repos."""
+        mock_repo1 = mock.Mock()
+        mock_repo1.organization = mock.Mock()
+        mock_repo1.owner = mock.Mock()
+        mock_repo1.pushed_at = "2024-12-28T00:00:00Z"
+        mock_repo1.latest_release = None
+        mock_repo1.commits_count = 15
+        mock_repo1.contributors_count = 6
+        mock_repo1.forks_count = 25
+        mock_repo1.open_issues_count = 4
+        mock_repo1.releases.count.return_value = 0
+        mock_repo1.stars_count = 120
+        mock_repo1.subscribers_count = 3
+        mock_repo1.watchers_count = 7
+        mock_repo1.top_languages = ["Python"]
+        mock_repo1.license = "MIT"
+        mock_repo1.topics = ["security"]
+
+        mock_repo2 = mock.Mock()
+        mock_repo2.organization = None
+        mock_repo2.owner = mock.Mock()
+        mock_repo2.pushed_at = "2024-12-29T00:00:00Z"
+        mock_repo2.latest_release = None
+        mock_repo2.commits_count = 25
+        mock_repo2.contributors_count = 10
+        mock_repo2.forks_count = 18
+        mock_repo2.open_issues_count = 2
+        mock_repo2.releases.count.return_value = 0
+        mock_repo2.stars_count = 60
+        mock_repo2.subscribers_count = 5
+        mock_repo2.watchers_count = 10
+        mock_repo2.top_languages = ["JavaScript"]
+        mock_repo2.license = "Apache-2.0"
+        mock_repo2.topics = ["owasp"]
+
+        mock_project.repositories.filter.return_value = MockQuerySet([mock_repo1, mock_repo2])
+        mock_projects_list = [mock_project]
+        mock_active_projects = mock.MagicMock()
+        mock_active_projects.__iter__.return_value = iter(mock_projects_list)
+        mock_active_projects.count.return_value = 1
+        mock_active_projects.__getitem__.side_effect = lambda idx: (
+            mock_projects_list[idx.start : idx.stop]
+            if isinstance(idx, slice)
+            else mock_projects_list[idx]
+        )
+        mock_active_projects.order_by.return_value = mock_active_projects
+
+        with mock.patch.object(Project, "active_projects", mock_active_projects):
+            command.stdout = mock.MagicMock()
+            command.handle(offset=0)
+
+        assert mock_project.stars_count == 120
+        assert mock_project.forks_count == 25
+        assert mock_project.contributors_count == 10
+        assert mock_project.commits_count == 40


### PR DESCRIPTION
## Proposed change

<!-- Don't forget to link your PR to an existing issue.-->
Resolves #4202 

Summary: Project-level forks, stars, and contributors are now computed as the maximum across the project’s repositories instead of the sum, avoiding inflated values from duplicate counts across multiple repos.

Changes:

`backend/apps/owasp/management/commands/owasp_aggregate_projects.py` 
Switched aggregation for forks_count, stars_count, and contributors_count from += (sum) to max (per-repo maximum). Other metrics (commits_count, open_issues_count, releases_count, etc.) still use sum.
`backend/tests/apps/owasp/management/commands/owasp_aggregate_projects_test.py` 
Added test_handle_uses_max_for_stars_forks_contributors to verify that forks, stars, and contributors use max across repos while commits use sum.


Acceptance criteria:

Project fork count = max forks among all repositories in the project
Project star count = max stars among all repositories in the project
Project contributor count = max contributors among all repositories in the project
Calculations are updated on each GitHub data sync (via owasp_aggregate_projects in the sync-data pipeline)

## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [ ] I used AI for code, documentation, tests, or communication related to this PR
