### PR TITLE
Fix deprecated parameter `use_lockfile` warning

### DIFF
--- a/.github/workflows/run-ci-cd.yaml
+++ b/.github/workflows/run-ci-cd.yaml
@@ -664,12 +664,10 @@ jobs:
         env:
           AWS_REGION: ${{ vars.AWS_REGION }}
           TF_STATE_BUCKET_NAME: ${{ secrets.BOOTSTRAP_TF_STATE_BUCKET_NAME }}
-          TF_STATE_DYNAMODB_TABLE_NAME: ${{ secrets.BOOTSTRAP_TF_STATE_DYNAMODB_TABLE_NAME }}
         run: |
           umask 377
           cat > infrastructure/bootstrap/terraform.tfbackend <<-EOF
           bucket="$TF_STATE_BUCKET_NAME"
-          dynamodb_table="$TF_STATE_DYNAMODB_TABLE_NAME"
           region="$AWS_REGION"
           EOF
 
@@ -752,12 +750,10 @@ jobs:
         env:
           AWS_REGION: ${{ vars.AWS_REGION }}
           TF_STATE_BUCKET_NAME: ${{ secrets.TF_STATE_BUCKET_NAME }}
-          TF_STATE_DYNAMODB_TABLE_NAME: ${{ secrets.TF_STATE_DYNAMODB_TABLE_NAME }}
         run: |
           umask 377
           cat > infrastructure/staging/terraform.tfbackend <<-EOF
           bucket="$TF_STATE_BUCKET_NAME"
-          dynamodb_table="$TF_STATE_DYNAMODB_TABLE_NAME"
           region="$AWS_REGION"
           EOF
 
@@ -854,12 +850,10 @@ jobs:
         env:
           AWS_REGION: ${{ vars.AWS_REGION }}
           TF_STATE_BUCKET_NAME: ${{ secrets.TF_STATE_BUCKET_NAME }}
-          TF_STATE_DYNAMODB_TABLE_NAME: ${{ secrets.TF_STATE_DYNAMODB_TABLE_NAME }}
         run: |
           umask 377
           cat > infrastructure/staging/terraform.tfbackend <<-EOF
           bucket="$TF_STATE_BUCKET_NAME"
-          dynamodb_table="$TF_STATE_DYNAMODB_TABLE_NAME"
           region="$AWS_REGION"
           EOF
 

--- a/infrastructure/bootstrap/README.md
+++ b/infrastructure/bootstrap/README.md
@@ -32,17 +32,6 @@ Use the following inline permissions for the `nest-bootstrap` IAM User
    ]
   },
   {
-   "Sid": "DynamoDBStateLocking",
-   "Effect": "Allow",
-   "Action": [
-    "dynamodb:DeleteItem",
-    "dynamodb:DescribeTable",
-    "dynamodb:GetItem",
-    "dynamodb:PutItem"
-   ],
-   "Resource": "arn:aws:dynamodb:*:AWS_ACCOUNT_ID:table/nest-bootstrap-terraform-state-lock"
-  },
-  {
    "Sid": "IAMManagement",
    "Effect": "Allow",
    "Action": [

--- a/infrastructure/bootstrap/README.md
+++ b/infrastructure/bootstrap/README.md
@@ -21,6 +21,7 @@ Use the following inline permissions for the `nest-bootstrap` IAM User
    "Sid": "S3StateAccess",
    "Effect": "Allow",
    "Action": [
+    "s3:DeleteObject",
     "s3:GetObject",
     "s3:ListBucket",
     "s3:PutObject"

--- a/infrastructure/bootstrap/backend.tf
+++ b/infrastructure/bootstrap/backend.tf
@@ -1,6 +1,7 @@
 terraform {
   backend "s3" {
-    encrypt = true
-    key     = "bootstrap/terraform.tfstate"
+    encrypt      = true
+    key          = "bootstrap/terraform.tfstate"
+    use_lockfile = true
   }
 }

--- a/infrastructure/bootstrap/main.tf
+++ b/infrastructure/bootstrap/main.tf
@@ -85,7 +85,6 @@ data "aws_iam_policy_document" "part_one" {
     sid    = "CloudWatchLogsManagement"
     effect = "Allow"
     actions = [
-      "logs:AssociateKmsKey",
       "logs:CreateLogGroup",
       "logs:DeleteLogGroup",
       "logs:DescribeLogStreams",

--- a/infrastructure/bootstrap/main.tf
+++ b/infrastructure/bootstrap/main.tf
@@ -85,6 +85,7 @@ data "aws_iam_policy_document" "part_one" {
     sid    = "CloudWatchLogsManagement"
     effect = "Allow"
     actions = [
+      "logs:AssociateKmsKey",
       "logs:CreateLogGroup",
       "logs:DeleteLogGroup",
       "logs:DescribeLogStreams",

--- a/infrastructure/bootstrap/terraform.tfbackend.example
+++ b/infrastructure/bootstrap/terraform.tfbackend.example
@@ -1,3 +1,2 @@
 bucket         = "REPLACE_WITH_TF_STATE_BUCKET_NAME"
-dynamodb_table = "nest-bootstrap-terraform-state-lock"
 region         = "us-east-2"

--- a/infrastructure/modules/kms/outputs.tf
+++ b/infrastructure/modules/kms/outputs.tf
@@ -1,3 +1,8 @@
+output "key_alias" {
+  description = "The alias of the KMS key."
+  value       = aws_kms_alias.main.name
+}
+
 output "key_arn" {
   description = "The ARN of the KMS key."
   value       = aws_kms_key.main.arn

--- a/infrastructure/staging/README.md
+++ b/infrastructure/staging/README.md
@@ -6,19 +6,15 @@ Before the first CI/CD run you must:
    The staging pipeline assumes this role (see the "STSStateManagement" resource below). The role is **created automatically** by the bootstrap when you run it (e.g. the bootstrap workflow that applies `infrastructure/bootstrap` with `staging` in the environments list). On first deployment, the bootstrap run creates `aws_iam_role.terraform` (named `${project}-${env}-terraform`, here `nest-staging-terraform`); subsequent bootstrap runs **update** the existing role. No code or workflow changes are required for this.
    **Manual intervention** may still be needed if you delete the role in AWS, remove it from Terraform state, or need to change the ExternalId (e.g. in the role trust policy or in the staging pipeline configuration).
 
-2. **Create the `nest-staging` IAM user** and attach the inline permissions documented below. This user is used to assume the `nest-staging-terraform` role and to access the Terraform backend (S3 state bucket, DynamoDB state lock table, KMS key).
+2. **Create the `nest-staging` IAM user** and attach the inline permissions documented below. This user is used to assume the `nest-staging-terraform` role.
 
 3. **Ensure backend resources exist** and replace the placeholders in the policy and pipeline configuration:
    - **AWS_ACCOUNT_ID** — Your AWS account ID (used in the role ARN and DynamoDB resource).
-   - **AWS_REGION** — The region where the state DynamoDB table and (if applicable) KMS key live.
-   - **AWS_BACKEND_KMS_KEY_ARN** — The ARN of the KMS key used to encrypt the Terraform state bucket.
-
-   The S3 state bucket name pattern (`nest-staging-terraform-state-*`), DynamoDB table name (`nest-staging-terraform-state-lock`), and the role name must match what is provisioned (e.g. by the state and bootstrap steps). Replace all placeholders before running the pipeline.
 
 ## Inline Permissions
 
 Use the following inline permissions for the `nest-staging` IAM User.
-*Note*: replace the placeholders `AWS_ACCOUNT_ID` with appropriate values before running the pipeline.
+*Note*: replace the placeholder `AWS_ACCOUNT_ID` with the appropriate value before running the pipeline.
 
 ```json
 {

--- a/infrastructure/staging/README.md
+++ b/infrastructure/staging/README.md
@@ -18,34 +18,12 @@ Before the first CI/CD run you must:
 ## Inline Permissions
 
 Use the following inline permissions for the `nest-staging` IAM User.
-*Note*: replace the placeholders (`AWS_ACCOUNT_ID`, `AWS_REGION`, `AWS_BACKEND_KMS_KEY_ARN`) with appropriate values before running the pipeline.
+*Note*: replace the placeholders `AWS_ACCOUNT_ID` with appropriate values before running the pipeline.
 
 ```json
 {
     "Version": "2012-10-17",
         "Statement": [
-  {
-   "Sid": "S3StateManagement",
-   "Effect": "Allow",
-   "Action": [
-    "s3:DeleteObject",
-    "s3:GetObject",
-    "s3:PutObject",
-    "s3:ListBucket"
-   ],
-   "Resource": [
-    "arn:aws:s3:::nest-staging-terraform-state-*",
-    "arn:aws:s3:::nest-staging-terraform-state-*/*"
-   ]
-  },
-        {
-            "Sid": "KMSStateManagement",
-            "Effect": "Allow",
-            "Action": [
-                "kms:Decrypt"
-            ],
-            "Resource": "AWS_BACKEND_KMS_KEY_ARN"
-        },
         {
             "Sid": "STSStateManagement",
             "Effect": "Allow",

--- a/infrastructure/staging/README.md
+++ b/infrastructure/staging/README.md
@@ -38,16 +38,6 @@ Use the following inline permissions for the `nest-staging` IAM User.
     "arn:aws:s3:::nest-staging-terraform-state-*/*"
    ]
   },
-  {
-   "Sid": "DynamoDBStateManagement",
-   "Effect": "Allow",
-   "Action": [
-    "dynamodb:GetItem",
-    "dynamodb:PutItem",
-    "dynamodb:DeleteItem"
-   ],
-   "Resource": "arn:aws:dynamodb:AWS_REGION:AWS_ACCOUNT_ID:table/nest-staging-terraform-state-lock"
-  },
         {
             "Sid": "KMSStateManagement",
             "Effect": "Allow",

--- a/infrastructure/staging/README.md
+++ b/infrastructure/staging/README.md
@@ -28,6 +28,7 @@ Use the following inline permissions for the `nest-staging` IAM User.
    "Sid": "S3StateManagement",
    "Effect": "Allow",
    "Action": [
+    "s3:DeleteObject",
     "s3:GetObject",
     "s3:PutObject",
     "s3:ListBucket"

--- a/infrastructure/staging/README.md
+++ b/infrastructure/staging/README.md
@@ -9,7 +9,7 @@ Before the first CI/CD run you must:
 2. **Create the `nest-staging` IAM user** and attach the inline permissions documented below. This user is used to assume the `nest-staging-terraform` role.
 
 3. **Ensure backend resources exist** and replace the placeholders in the policy and pipeline configuration:
-   - **AWS_ACCOUNT_ID** — Your AWS account ID (used in the role ARN and DynamoDB resource).
+   - **AWS_ACCOUNT_ID** — Your AWS account ID (used in the role ARN).
 
 ## Inline Permissions
 

--- a/infrastructure/staging/backend.tf
+++ b/infrastructure/staging/backend.tf
@@ -1,6 +1,7 @@
 terraform {
   backend "s3" {
-    encrypt = true
-    key     = "staging/terraform.tfstate"
+    encrypt      = true
+    key          = "staging/terraform.tfstate"
+    use_lockfile = true
   }
 }

--- a/infrastructure/staging/terraform.tfbackend.example
+++ b/infrastructure/staging/terraform.tfbackend.example
@@ -1,3 +1,2 @@
 bucket         = "REPLACE_WITH_TF_STATE_BUCKET_NAME"
-dynamodb_table = "nest-staging-terraform-state-lock"
 region         = "us-east-2"

--- a/infrastructure/state/README.md
+++ b/infrastructure/state/README.md
@@ -47,23 +47,6 @@ Use the following inline permissions for the `nest-state` IAM User
    ]
   },
   {
-   "Sid": "DynamoDBManagement",
-   "Effect": "Allow",
-   "Action": [
-    "dynamodb:CreateTable",
-    "dynamodb:DeleteTable",
-    "dynamodb:DescribeContinuousBackups",
-    "dynamodb:DescribeTable",
-    "dynamodb:DescribeTimeToLive",
-    "dynamodb:ListTagsOfResource",
-    "dynamodb:TagResource",
-    "dynamodb:UntagResource",
-    "dynamodb:UpdateContinuousBackups",
-    "dynamodb:UpdateTable"
-   ],
-   "Resource": "arn:aws:dynamodb:*:AWS_ACCOUNT_ID:table/nest-*-terraform-state-lock"
-  },
-  {
    "Sid": "KMSCreateManagement",
    "Effect": "Allow",
    "Action": [

--- a/infrastructure/state/main.tf
+++ b/infrastructure/state/main.tf
@@ -89,33 +89,6 @@ data "aws_iam_policy_document" "state_https_only" {
   }
 }
 
-resource "aws_dynamodb_table" "state_lock" {
-  for_each = local.state_environments
-
-  billing_mode = "PAY_PER_REQUEST"
-  hash_key     = "LockID"
-  name         = "${var.project_name}-${each.key}-terraform-state-lock"
-  tags = merge(local.common_tags, {
-    Environment = each.key
-    Name        = "${var.project_name}-${each.key}-terraform-state-lock"
-  })
-
-  attribute {
-    name = "LockID"
-    type = "S"
-  }
-  lifecycle {
-    prevent_destroy = true
-  }
-  point_in_time_recovery {
-    enabled = true
-  }
-  server_side_encryption {
-    enabled     = true
-    kms_key_arn = module.kms[each.key].key_arn
-  }
-}
-
 resource "aws_s3_bucket" "logs" { # NOSONAR
   for_each = local.state_environments
 

--- a/infrastructure/state/outputs.tf
+++ b/infrastructure/state/outputs.tf
@@ -1,8 +1,3 @@
-output "dynamodb_table_names" {
-  description = "The names of the per-environment DynamoDB tables for Terraform state locking."
-  value       = { for env, table in aws_dynamodb_table.state_lock : env => table.name }
-}
-
 output "kms_key_aliases" {
   description = "The Aliases of the per-environment KMS keys for Terraform state encryption."
   value       = { for env, kms in module.kms : env => kms.key_alias }

--- a/infrastructure/state/outputs.tf
+++ b/infrastructure/state/outputs.tf
@@ -3,6 +3,11 @@ output "dynamodb_table_names" {
   value       = { for env, table in aws_dynamodb_table.state_lock : env => table.name }
 }
 
+output "kms_key_aliases" {
+  description = "The Aliases of the per-environment KMS keys for Terraform state encryption."
+  value       = { for env, kms in module.kms : env => kms.key_alias }
+}
+
 output "kms_key_arns" {
   description = "The ARNs of the per-environment KMS keys for Terraform state encryption."
   value       = { for env, kms in module.kms : env => kms.key_arn }

--- a/infrastructure/state/outputs.tf
+++ b/infrastructure/state/outputs.tf
@@ -1,5 +1,5 @@
 output "kms_key_aliases" {
-  description = "The Aliases of the per-environment KMS keys for Terraform state encryption."
+  description = "The aliases of the per-environment KMS keys for Terraform state encryption."
   value       = { for env, kms in module.kms : env => kms.key_alias }
 }
 


### PR DESCRIPTION

## Proposed change

<!-- Don't forget to link your PR to an existing issue.-->
Resolves #4220 
Fix:
```bash
╷
│ Warning: Deprecated Parameter
│ 
│ The parameter "dynamodb_table" is deprecated. Use parameter "use_lockfile"
│ instead.
╵
```

### Note
Please run a `terraform apply` in `state/` after CI/CD completes.

## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [ ] I used AI for code, documentation, tests, or communication related to this PR
