### PR TITLE
fix/allow program admins to set and clear issue deadlines

### DIFF
--- a/backend/apps/mentorship/api/internal/mutations/module.py
+++ b/backend/apps/mentorship/api/internal/mutations/module.py
@@ -26,8 +26,12 @@ ASSIGNEE_NOT_FOUND_MSG = "Assignee not found."
 ISSUE_NOT_FOUND_MSG = "Issue not found in this module."
 MODULE_NOT_FOUND_MSG = "Module not found."
 NOT_MENTOR_ASSIGN_MSG = "Only mentors of this module can assign issues."
-NOT_MENTOR_CLEAR_DEADLINE_MSG = "Only mentors of this module can clear deadlines."
-NOT_MENTOR_SET_DEADLINE_MSG = "Only mentors of this module can set deadlines."
+NOT_MENTOR_OR_ADMIN_CLEAR_DEADLINE_MSG = (
+    "Only mentors of this module or program admins can clear deadlines."
+)
+NOT_MENTOR_OR_ADMIN_SET_DEADLINE_MSG = (
+    "Only mentors of this module or program admins can set deadlines."
+)
 NOT_MENTOR_UNASSIGN_MSG = "Only mentors of this module can unassign issues."
 
 logger = logging.getLogger(__name__)
@@ -244,7 +248,7 @@ class ModuleMutation:
     ) -> ModuleNode:
         """Set a deadline for a task.
 
-        The user must be a mentor of the module.
+        The user must be a mentor of the module or an admin of the program.
         """
         user = info.context.request.user
 
@@ -256,8 +260,10 @@ class ModuleMutation:
         if module is None:
             raise ObjectDoesNotExist(MODULE_NOT_FOUND_MSG)
 
-        if not _is_mentor_of_module(user, module):
-            raise PermissionDenied(NOT_MENTOR_SET_DEADLINE_MSG)
+        is_admin = module.program.admins.filter(nest_user=user).exists()
+        is_mentor = _is_mentor_of_module(user, module)
+        if not (is_admin or is_mentor):
+            raise PermissionDenied(NOT_MENTOR_OR_ADMIN_SET_DEADLINE_MSG)
 
         issue = (
             module.issues.select_related("repository")
@@ -306,7 +312,7 @@ class ModuleMutation:
     ) -> ModuleNode:
         """Clear the deadline for a task.
 
-        The user must be a mentor of the module.
+        The user must be a mentor of the module or an admin of the program.
         """
         user = info.context.request.user
 
@@ -318,8 +324,10 @@ class ModuleMutation:
         if module is None:
             raise ObjectDoesNotExist(MODULE_NOT_FOUND_MSG)
 
-        if not _is_mentor_of_module(user, module):
-            raise PermissionDenied(NOT_MENTOR_CLEAR_DEADLINE_MSG)
+        is_admin = module.program.admins.filter(nest_user=user).exists()
+        is_mentor = _is_mentor_of_module(user, module)
+        if not (is_admin or is_mentor):
+            raise PermissionDenied(NOT_MENTOR_OR_ADMIN_CLEAR_DEADLINE_MSG)
 
         issue = (
             module.issues.select_related("repository")

--- a/backend/tests/apps/mentorship/api/internal/mutations/module_mutation_test.py
+++ b/backend/tests/apps/mentorship/api/internal/mutations/module_mutation_test.py
@@ -680,6 +680,54 @@ class TestModuleMutationSetTaskDeadline:
         assert result == mock_mod
         mock_task.objects.bulk_update.assert_called_once()
 
+    @patch("apps.mentorship.api.internal.mutations.module.Task")
+    @patch("apps.mentorship.api.internal.mutations.module.Mentor")
+    @patch("apps.mentorship.api.internal.mutations.module.Module")
+    @patch("apps.mentorship.api.internal.mutations.module.timezone")
+    def test_set_task_deadline_success_as_admin(
+        self, mock_tz, mock_module, mock_mentor, mock_task
+    ):
+        """Test successful deadline setting by a program admin (non-mentor)."""
+        user = MagicMock()
+        info = self._make_info(user)
+        mock_task.Status = Task.Status
+
+        mock_mod = MagicMock()
+        mock_mod.program.admins.filter.return_value.exists.return_value = True
+        mock_module.objects.select_related.return_value.filter.return_value.first.return_value = (
+            mock_mod
+        )
+        mock_mentor.objects.filter.return_value.exists.return_value = False
+
+        mock_issue = MagicMock()
+        assignee = MagicMock()
+        assignees_qs = MagicMock()
+        assignees_qs.exists.return_value = True
+        assignees_qs.__iter__ = MagicMock(return_value=iter([assignee]))
+        mock_issue.assignees.all.return_value = assignees_qs
+        issue_qs = mock_mod.issues.select_related.return_value
+        issue_qs.prefetch_related.return_value.filter.return_value.first.return_value = mock_issue
+
+        deadline = datetime(2025, 12, 1, tzinfo=UTC)
+        mock_tz.is_naive.return_value = False
+        mock_tz.now.return_value = datetime(2025, 6, 1, tzinfo=UTC)
+
+        mock_task_obj = MagicMock()
+        mock_task_obj.assigned_at = None
+        mock_task.objects.get_or_create.return_value = (mock_task_obj, True)
+
+        mutation = ModuleMutation()
+        result = mutation.set_task_deadline(
+            info,
+            module_key="mod-1",
+            program_key="prog-1",
+            issue_number=1,
+            deadline_at=deadline,
+        )
+
+        assert result == mock_mod
+        mock_task.objects.bulk_update.assert_called_once()
+
     @patch("apps.mentorship.api.internal.mutations.module.Module")
     def test_set_deadline_module_not_found(self, mock_module):
         """Test ObjectDoesNotExist when module not found."""
@@ -701,18 +749,21 @@ class TestModuleMutationSetTaskDeadline:
 
     @patch("apps.mentorship.api.internal.mutations.module.Mentor")
     @patch("apps.mentorship.api.internal.mutations.module.Module")
-    def test_set_deadline_not_mentor(self, mock_module, mock_mentor):
-        """Test PermissionDenied when user is not a mentor."""
+    def test_set_deadline_not_mentor_or_admin(self, mock_module, mock_mentor):
+        """Test PermissionDenied when user is not a mentor or program admin."""
         user = MagicMock()
         info = self._make_info(user)
         mock_mod = MagicMock()
+        mock_mod.program.admins.filter.return_value.exists.return_value = False
         mock_module.objects.select_related.return_value.filter.return_value.first.return_value = (
             mock_mod
         )
         mock_mentor.objects.filter.return_value.exists.return_value = False
 
         mutation = ModuleMutation()
-        with pytest.raises(PermissionDenied, match="Only mentors of this module can set"):
+        with pytest.raises(
+            PermissionDenied, match="Only mentors of this module or program admins can set"
+        ):
             mutation.set_task_deadline(
                 info,
                 module_key="mod-1",
@@ -904,6 +955,43 @@ class TestModuleMutationClearTaskDeadline:
     @patch("apps.mentorship.api.internal.mutations.module.Task")
     @patch("apps.mentorship.api.internal.mutations.module.Mentor")
     @patch("apps.mentorship.api.internal.mutations.module.Module")
+    def test_clear_deadline_success_as_admin(self, mock_module, mock_mentor, mock_task):
+        """Test clearing deadline by a program admin (non-mentor)."""
+        user = MagicMock()
+        info = self._make_info(user)
+
+        mock_mod = MagicMock()
+        mock_mod.program.admins.filter.return_value.exists.return_value = True
+        mock_module.objects.select_related.return_value.filter.return_value.first.return_value = (
+            mock_mod
+        )
+        mock_mentor.objects.filter.return_value.exists.return_value = False
+
+        mock_issue = MagicMock()
+        assignee = MagicMock()
+        assignees_qs = MagicMock()
+        assignees_qs.exists.return_value = True
+        assignees_qs.__iter__ = MagicMock(return_value=iter([assignee]))
+        mock_issue.assignees.all.return_value = assignees_qs
+        issue_qs = mock_mod.issues.select_related.return_value
+        issue_qs.prefetch_related.return_value.filter.return_value.first.return_value = mock_issue
+
+        task_obj = MagicMock()
+        task_obj.deadline_at = datetime(2025, 12, 1, tzinfo=UTC)
+        mock_task.objects.filter.return_value.first.return_value = task_obj
+
+        mutation = ModuleMutation()
+        result = mutation.clear_task_deadline(
+            info, module_key="mod-1", program_key="prog-1", issue_number=1
+        )
+
+        assert result == mock_mod
+        assert task_obj.deadline_at is None
+        task_obj.save.assert_called_once_with(update_fields=["deadline_at"])
+
+    @patch("apps.mentorship.api.internal.mutations.module.Task")
+    @patch("apps.mentorship.api.internal.mutations.module.Mentor")
+    @patch("apps.mentorship.api.internal.mutations.module.Module")
     def test_clear_deadline_multiple_tasks(self, mock_module, mock_mentor, mock_task):
         """Test clearing deadline for multiple tasks uses bulk_update."""
         user = MagicMock()
@@ -1024,18 +1112,21 @@ class TestModuleMutationClearTaskDeadline:
 
     @patch("apps.mentorship.api.internal.mutations.module.Mentor")
     @patch("apps.mentorship.api.internal.mutations.module.Module")
-    def test_clear_deadline_not_mentor(self, mock_module, mock_mentor):
-        """Test PermissionDenied when user is not a mentor."""
+    def test_clear_deadline_not_mentor_or_admin(self, mock_module, mock_mentor):
+        """Test PermissionDenied when user is not a mentor or program admin."""
         user = MagicMock()
         info = self._make_info(user)
         mock_mod = MagicMock()
+        mock_mod.program.admins.filter.return_value.exists.return_value = False
         mock_module.objects.select_related.return_value.filter.return_value.first.return_value = (
             mock_mod
         )
         mock_mentor.objects.filter.return_value.exists.return_value = False
 
         mutation = ModuleMutation()
-        with pytest.raises(PermissionDenied, match="Only mentors of this module can clear"):
+        with pytest.raises(
+            PermissionDenied, match="Only mentors of this module or program admins can clear"
+        ):
             mutation.clear_task_deadline(
                 info, module_key="mod-1", program_key="prog-1", issue_number=1
             )


### PR DESCRIPTION
## Proposed change

<!-- Don't forget to link your PR to an existing issue.-->
Resolves #4236 

<!-- Describe the big picture of your changes.-->
Summary

- Allow program admins (in addition to mentors) to set task deadlines.
- Allow program admins (in addition to mentors) to clear task deadlines.
- Add/update tests to cover admin permission path for both mutations.


https://github.com/user-attachments/assets/41b0141c-760e-4cdc-b31a-28146f226c4e



## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [ ] I used AI for code, documentation, tests, or communication related to this PR
