### PR TITLE
Fix issue timestamp bug by using dayjs.unix and filtering zero/null values

### DIFF
--- a/frontend/__tests__/unit/utils/utility.test.ts
+++ b/frontend/__tests__/unit/utils/utility.test.ts
@@ -1,4 +1,8 @@
-import { getCsrfToken } from 'utils/utility'
+import dayjs from 'dayjs'
+import relativeTime from 'dayjs/plugin/relativeTime'
+import { getCsrfToken, getFilteredIcons } from 'utils/utility'
+
+dayjs.extend(relativeTime)
 
 jest.mock('server/fetchCsrfToken', () => ({
   fetchCsrfToken: jest.fn(() => Promise.resolve('abc123')),
@@ -47,5 +51,51 @@ describe('utility tests', () => {
     document.cookie = 'csrftoken; otherid=xyz789'
     const result = await getCsrfToken()
     expect(result).toBe('abc123')
+  })
+})
+
+describe('getFilteredIcons', () => {
+  const baseIssue = {
+    url: 'https://github.com/test/issue/1',
+    title: 'Test issue',
+    commentsCount: 5,
+  }
+
+  test('does not set createdAt icon for malformed date strings', () => {
+    const issue = { ...baseIssue, createdAt: 'not-a-date' }
+    const result = getFilteredIcons(issue as never, ['createdAt'])
+    expect(result['createdAt']).toBeUndefined()
+  })
+
+  test('does not set createdAt icon when timestamp is 0', () => {
+    const issue = { ...baseIssue, createdAt: 0 }
+    const result = getFilteredIcons(issue as never, ['createdAt', 'commentsCount'])
+    expect(result['createdAt']).toBeUndefined()
+  })
+
+  test('does not set createdAt icon when timestamp is null', () => {
+    const issue = { ...baseIssue, createdAt: null }
+    const result = getFilteredIcons(issue as never, ['createdAt', 'commentsCount'])
+    expect(result['createdAt']).toBeUndefined()
+  })
+
+  test('sets createdAt icon with relative time for a valid timestamp', () => {
+    const validTimestamp = Math.floor(Date.now() / 1000) - 3600
+    const issue = { ...baseIssue, createdAt: validTimestamp }
+    const result = getFilteredIcons(issue as never, ['createdAt', 'commentsCount'])
+    expect(result['createdAt']).toBe(dayjs.unix(validTimestamp).fromNow())
+  })
+
+  test('sets createdAt icon with relative time for a valid ISO string', () => {
+    const validIsoString = new Date(Date.now() - 3600000).toISOString()
+    const issue = { ...baseIssue, createdAt: validIsoString }
+    const result = getFilteredIcons(issue as never, ['createdAt', 'commentsCount'])
+    expect(result['createdAt']).toBe(dayjs(validIsoString).fromNow())
+  })
+
+  test('still sets other icon fields when createdAt is 0', () => {
+    const issue = { ...baseIssue, createdAt: 0 }
+    const result = getFilteredIcons(issue as never, ['createdAt', 'commentsCount'])
+    expect(result['commentsCount']).toBe(5)
   })
 })

--- a/frontend/src/utils/utility.ts
+++ b/frontend/src/utils/utility.ts
@@ -24,7 +24,14 @@ export const getFilteredIcons = (project: ProjectType, params: string[]): Icon =
   const filteredIcons = params.reduce((acc: Icon, key) => {
     if (ICONS[key as IconKeys] && project[key as keyof typeof project] !== undefined) {
       if (key === 'createdAt') {
-        acc[key] = dayjs(project[key as keyof ProjectType] as unknown as string).fromNow()
+        const rawValue = project[key as keyof ProjectType]
+        if (typeof rawValue === 'number' && Number.isFinite(rawValue) && rawValue > 0) {
+          const parsed = dayjs.unix(rawValue)
+          if (parsed.isValid()) acc[key] = parsed.fromNow()
+        } else if (typeof rawValue === 'string' && rawValue.trim() !== '') {
+          const parsed = dayjs(rawValue)
+          if (parsed.isValid()) acc[key] = parsed.fromNow()
+        }
       } else {
         acc[key] = project[key as keyof typeof project] as unknown as number
       }


### PR DESCRIPTION
## Proposed change
Resolves #4247

The timestamp on the `/contribute` page was showing incorrect or broken values because it wasn't handling the Unix timestamp conversion properly and was attempting to format invalid/zeroed dates.

**Changes:**
* Updated `getFilteredIcons` in `utility.ts` to explicitly handle Unix timestamps using `dayjs.unix()`.
* Added a check to ensure we don't render a `createdAt` icon if the timestamp is `0` or `null`. This prevents "55 years ago" or "Invalid Date" bugs from showing up when data is missing.
* Added a comprehensive test suite in `utility.test.ts` covering valid timestamps, null cases, and zeroed values to ensure the logic holds up for different project data.

**Screenshots**
![Screenshot_contribute_1](https://github.com/user-attachments/assets/d8c3c422-764d-4c4e-a776-7f18dd32a5c1)
![Screenshot_contribute_2](https://github.com/user-attachments/assets/f7227e28-2c8d-4126-92c8-b3e57dc3dfd5)


## Checklist
- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [x] I used AI for code, documentation, tests, or communication related to this PR