### PR TITLE
fix(slack): NestBot deferred replies format without a second LLM call

### DIFF
--- a/backend/apps/slack/common/handlers/ai.py
+++ b/backend/apps/slack/common/handlers/ai.py
@@ -9,6 +9,82 @@ from apps.slack.utils import format_ai_response_for_slack
 
 logger = logging.getLogger(__name__)
 
+# Slack allows up to 3001 characters per mrkdwn block; stay under for safety.
+MAX_BLOCK_TEXT_LENGTH = 3000
+
+
+def format_blocks(text: str | None) -> list[dict]:
+    """Turn AI response text into Slack section blocks (no LLM calls).
+
+    Splits content so each block stays within Slack mrkdwn size limits.
+
+    Args:
+        text (str | None): Raw or model-formatted answer text (None treated as empty).
+
+    Returns:
+        list: Section blocks ready for chat.postMessage.
+
+    """
+    formatted_response = format_ai_response_for_slack(text or "")
+
+    if not formatted_response.strip():
+        return get_error_blocks()
+
+    if len(formatted_response) <= MAX_BLOCK_TEXT_LENGTH:
+        return [markdown(formatted_response)]
+
+    blocks: list[dict] = []
+    lines = formatted_response.split("\n")
+    current_block_text = ""
+
+    for line in lines:
+        line_length = len(line)
+        current_length = len(current_block_text)
+
+        if line_length > MAX_BLOCK_TEXT_LENGTH:
+            if current_block_text.strip():
+                blocks.append(markdown(current_block_text.strip()))
+                current_block_text = ""
+            for i in range(0, line_length, MAX_BLOCK_TEXT_LENGTH):
+                chunk = line[i : i + MAX_BLOCK_TEXT_LENGTH]
+                if chunk.strip():
+                    blocks.append(markdown(chunk.strip()))
+            continue
+
+        if current_block_text:
+            if current_length + line_length + 1 > MAX_BLOCK_TEXT_LENGTH:
+                blocks.append(markdown(current_block_text.strip()))
+                current_block_text = line
+            else:
+                current_block_text += "\n" + line
+        else:
+            current_block_text = line
+
+    if current_block_text.strip():
+        if len(current_block_text) > MAX_BLOCK_TEXT_LENGTH:
+            for i in range(0, len(current_block_text), MAX_BLOCK_TEXT_LENGTH):
+                chunk = current_block_text[i : i + MAX_BLOCK_TEXT_LENGTH]
+                if chunk.strip():
+                    blocks.append(markdown(chunk.strip()))
+        else:
+            blocks.append(markdown(current_block_text.strip()))
+
+    validated_blocks: list[dict] = []
+    for block in blocks:
+        block_text = block.get("text", {}).get("text", "")
+        if len(block_text) > MAX_BLOCK_TEXT_LENGTH:
+            for i in range(0, len(block_text), MAX_BLOCK_TEXT_LENGTH):
+                chunk = block_text[i : i + MAX_BLOCK_TEXT_LENGTH]
+                if chunk.strip():
+                    validated_blocks.append(markdown(chunk.strip()))
+        else:
+            validated_blocks.append(block)
+
+    if not validated_blocks:
+        return get_error_blocks()
+
+    return validated_blocks
+
 
 def get_blocks(
     query: str,
@@ -34,9 +110,7 @@ def get_blocks(
     )
 
     if ai_response:
-        # Format the AI response for Slack (remove code blocks, fix markdown)
-        formatted_response = format_ai_response_for_slack(ai_response)
-        return [markdown(formatted_response)]
+        return format_blocks(str(ai_response))
     return get_error_blocks()
 
 
@@ -62,12 +136,29 @@ def process_ai_query(
     try:
         from apps.ai.flows import process_query
 
-        return process_query(
+        result = process_query(
             query, images=images, channel_id=channel_id, is_app_mention=is_app_mention
         )
     except Exception:
-        logger.exception("Failed to process AI query")
+        logger.exception(
+            "Failed to process AI query",
+            extra={
+                "query_len": len(query or ""),
+                "channel_id": channel_id,
+                "is_app_mention": is_app_mention,
+            },
+        )
         return None
+    if result is None:
+        return None
+    result_str = str(result).strip()
+    if result_str.upper() in {"YES", "NO"}:
+        logger.error(
+            "process_ai_query received Question Detector-style output; treating as failure",
+            extra={"query_len": len(query), "channel_id": channel_id},
+        )
+        return None
+    return result_str
 
 
 def get_error_blocks() -> list[dict]:

--- a/backend/apps/slack/services/message_auto_reply.py
+++ b/backend/apps/slack/services/message_auto_reply.py
@@ -6,10 +6,14 @@ from django_rq import job
 from slack_sdk.errors import SlackApiError
 
 from apps.slack.apps import SlackConfig
-from apps.slack.common.handlers.ai import get_blocks, process_ai_query
+from apps.slack.common.handlers.ai import format_blocks, process_ai_query
 from apps.slack.models import Message
+from apps.slack.utils import format_ai_response_for_slack
 
 logger = logging.getLogger(__name__)
+
+# Plain-text fallback for chat.postMessage (notifications, clients without block support)
+_FALLBACK_TEXT_MAX = 3000
 
 
 @job("ai")
@@ -68,9 +72,17 @@ def generate_ai_reply_if_unanswered(message_id: int):
             logger.exception("Error adding reaction to message")
         return
 
+    blocks = format_blocks(ai_response_text)
+    plain = format_ai_response_for_slack(ai_response_text)
+    if len(plain) > _FALLBACK_TEXT_MAX:
+        cut = _FALLBACK_TEXT_MAX - 1
+        plain = f"{plain[:cut]}…"
+    if not plain.strip():
+        plain = "\u2014"
+
     client.chat_postMessage(
         channel=channel_id,
-        blocks=get_blocks(ai_response_text, channel_id=channel_id),
-        text=ai_response_text,
+        blocks=blocks,
+        text=plain,
         thread_ts=message.slack_message_id,
     )

--- a/backend/apps/slack/utils.py
+++ b/backend/apps/slack/utils.py
@@ -73,18 +73,21 @@ def format_links_for_slack(text: str) -> str:
     return markdown_link_pattern.sub(r"<\2|\1>", text)
 
 
-def format_ai_response_for_slack(text: str) -> str:
-    """Format AI response text for Slack by removing code blocks and fixing markdown.
+def format_ai_response_for_slack(text: str | None) -> str:
+    """Format AI response text for Slack (code fences, inline backticks).
+
+    Markdown [label](url) link conversion is applied in markdown() via
+    format_links_for_slack so it runs once per block.
 
     Args:
-        text (str): The AI response text that may contain markdown code blocks.
+        text (str | None): Raw model or user text (None treated as empty).
 
     Returns:
-        str: Text formatted for Slack mrkdwn format.
+        str: Text prepared for Slack mrkdwn section bodies.
 
     """
     if not text:
-        return text
+        return ""
 
     # Strip leading/trailing whitespace
     text = text.strip()
@@ -120,12 +123,9 @@ def format_ai_response_for_slack(text: str) -> str:
     # Remove single backticks that might wrap inline code
     # But preserve Slack channel/user links (format: <#...|...> or <@...|...>)
     # Pattern: `text` but not part of Slack link syntax
-    text = re.sub(r"`([^`<]+)`", r"\1", text)
-
-    # Preserve Slack channel links (format: <#channel_id|channel_name>)
-    # These should not be modified by format_links_for_slack
-    # Convert markdown links to Slack format (but preserve existing Slack links)
-    return format_links_for_slack(text)
+    # Link conversion is applied in markdown() / format_links_for_slack once per block
+    # to avoid double-processing when this output flows into Slack section blocks.
+    return re.sub(r"`([^`<]+)`", r"\1", text)
 
 
 # Import get_news_data and get_staff_data from owasp utils

--- a/backend/tests/apps/slack/common/handlers/ai_test.py
+++ b/backend/tests/apps/slack/common/handlers/ai_test.py
@@ -3,6 +3,8 @@
 from unittest.mock import patch
 
 from apps.slack.common.handlers.ai import (
+    MAX_BLOCK_TEXT_LENGTH,
+    format_blocks,
     get_blocks,
     get_default_response,
     get_error_blocks,
@@ -14,8 +16,8 @@ class TestAiHandler:
     """Test cases for AI handler functionality."""
 
     @patch("apps.slack.common.handlers.ai.process_ai_query")
-    @patch("apps.slack.common.handlers.ai.markdown")
-    def test_get_blocks_with_successful_response(self, mock_markdown, mock_process_ai_query):
+    @patch("apps.slack.common.handlers.ai.format_blocks")
+    def test_get_blocks_with_successful_response(self, mock_format_blocks, mock_process_ai_query):
         """Test get_blocks with successful AI response."""
         query = "What is OWASP?"
         ai_response = "OWASP is a security organization..."
@@ -25,14 +27,14 @@ class TestAiHandler:
         }
 
         mock_process_ai_query.return_value = ai_response
-        mock_markdown.return_value = expected_block
+        mock_format_blocks.return_value = [expected_block]
 
         result = get_blocks(query)
 
         mock_process_ai_query.assert_called_once_with(
             query.strip(), images=None, channel_id=None, is_app_mention=False
         )
-        mock_markdown.assert_called_once_with(ai_response)
+        mock_format_blocks.assert_called_once_with(ai_response)
         assert result == [expected_block]
 
     @patch("apps.slack.common.handlers.ai.process_ai_query")
@@ -72,8 +74,8 @@ class TestAiHandler:
         assert result == error_blocks
 
     @patch("apps.slack.common.handlers.ai.process_ai_query")
-    @patch("apps.slack.common.handlers.ai.markdown")
-    def test_get_blocks_with_images(self, mock_markdown, mock_process_ai_query):
+    @patch("apps.slack.common.handlers.ai.format_blocks")
+    def test_get_blocks_with_images(self, mock_format_blocks, mock_process_ai_query):
         """Test get_blocks passes images through to process_ai_query."""
         query = "What is in this image?"
         images = ["data:image/png;base64,abc123"]
@@ -84,7 +86,7 @@ class TestAiHandler:
         }
 
         mock_process_ai_query.return_value = ai_response
-        mock_markdown.return_value = expected_block
+        mock_format_blocks.return_value = [expected_block]
 
         result = get_blocks(query, images=images)
 
@@ -180,6 +182,43 @@ class TestAiHandler:
         mock_process_query.assert_called_once_with(
             query, images=images, channel_id=channel_id, is_app_mention=True
         )
+
+    @patch("apps.ai.flows.process_query")
+    def test_process_ai_query_rejects_yes_no(self, mock_process_query):
+        """Bare YES/NO from the model must not be returned to callers."""
+        mock_process_query.return_value = "YES"
+        assert process_ai_query("anything") is None
+        mock_process_query.return_value = "NO"
+        assert process_ai_query("anything") is None
+        mock_process_query.return_value = "  no  "
+        assert process_ai_query("anything") is None
+
+    def test_format_blocks_splits_long_text(self):
+        """Long answers become multiple Slack blocks under the size limit."""
+        chunk = "a" * MAX_BLOCK_TEXT_LENGTH
+        remainder = "tail"
+        text = f"{chunk}\n{remainder}"
+        blocks = format_blocks(text)
+        assert len(blocks) >= 2
+        for block in blocks:
+            block_text = block["text"]["text"]
+            assert len(block_text) <= 3001  # Slack mrkdwn section limit
+
+    def test_format_blocks_single_short_message(self):
+        """Short text becomes one markdown block with link conversion."""
+        text = "See [OWASP](https://owasp.org)"
+        blocks = format_blocks(text)
+        assert len(blocks) == 1
+        assert "<https://owasp.org|OWASP>" in blocks[0]["text"]["text"]
+
+    @patch("apps.slack.common.handlers.ai.get_error_blocks")
+    def test_format_blocks_empty_uses_error_blocks(self, mock_error):
+        """Whitespace-only / empty content should not produce an empty block list."""
+        err = [{"type": "section", "text": {"type": "mrkdwn", "text": "err"}}]
+        mock_error.return_value = err
+        assert format_blocks("") == err
+        assert format_blocks("   \n\t  ") == err
+        assert mock_error.call_count == 2
 
     @patch("apps.slack.common.handlers.ai.markdown")
     def test_get_error_blocks(self, mock_markdown):

--- a/backend/tests/apps/slack/services/message_auto_reply_test.py
+++ b/backend/tests/apps/slack/services/message_auto_reply_test.py
@@ -45,10 +45,10 @@ class TestMessageAutoReply:
     @patch.object(SlackConfig, "app")
     @patch("apps.slack.services.message_auto_reply.Message.objects.get")
     @patch("apps.slack.services.message_auto_reply.process_ai_query")
-    @patch("apps.slack.services.message_auto_reply.get_blocks")
+    @patch("apps.slack.services.message_auto_reply.format_blocks")
     def test_generate_ai_reply_success(
         self,
-        mock_get_blocks,
+        mock_format_blocks,
         mock_process_ai_query,
         mock_message_get,
         mock_app,
@@ -57,7 +57,7 @@ class TestMessageAutoReply:
         """Test successful AI reply generation."""
         mock_message_get.return_value = mock_message
         mock_process_ai_query.return_value = "OWASP is a security organization..."
-        mock_get_blocks.return_value = [
+        mock_format_blocks.return_value = [
             {
                 "type": "section",
                 "text": {
@@ -80,10 +80,7 @@ class TestMessageAutoReply:
         mock_process_ai_query.assert_called_once_with(
             query=mock_message.text, channel_id=mock_message.conversation.slack_channel_id
         )
-        mock_get_blocks.assert_called_once_with(
-            "OWASP is a security organization...",
-            channel_id=mock_message.conversation.slack_channel_id,
-        )
+        mock_format_blocks.assert_called_once_with("OWASP is a security organization...")
         mock_client.chat_postMessage.assert_called_once_with(
             channel=mock_message.conversation.slack_channel_id,
             blocks=[
@@ -151,12 +148,12 @@ class TestMessageAutoReply:
     @patch.object(SlackConfig, "app")
     @patch("apps.slack.services.message_auto_reply.Message.objects.get")
     @patch("apps.slack.services.message_auto_reply.process_ai_query")
-    @patch("apps.slack.services.message_auto_reply.get_blocks")
+    @patch("apps.slack.services.message_auto_reply.format_blocks")
     @patch("apps.slack.services.message_auto_reply.logger")
     def test_generate_ai_reply_slack_api_error(
         self,
         mock_logger,
-        mock_get_blocks,
+        mock_format_blocks,
         mock_process_ai_query,
         mock_message_get,
         mock_app,
@@ -168,7 +165,7 @@ class TestMessageAutoReply:
         mock_app.client = mock_client
         mock_client.conversations_replies.side_effect = SlackApiError("API Error", response=Mock())
         mock_process_ai_query.return_value = "OWASP is a security organization..."
-        mock_get_blocks.return_value = [
+        mock_format_blocks.return_value = [
             {
                 "type": "section",
                 "text": {


### PR DESCRIPTION
## Proposed change

Resolves #3693

This PR implements **reply handling** fixes for NestBot’s **delayed auto-reply** path (`generate_ai_reply_if_unanswered`): how answers are formatted and posted to Slack after the question-detector pipeline, without overlapping the Gemini provider, multi-agent orchestration, or interaction-UX PRs.

### What changed

- **Bug fix:** `generate_ai_reply_if_unanswered` no longer calls `get_blocks(ai_response_text, …)`, which incorrectly ran `process_ai_query` **again** on the model’s answer. It now uses **`format_blocks()`**, which only formats pre-rendered text.
- **`format_blocks()`** splits long answers into multiple Slack section blocks so mrkdwn stays under Slack’s per-block limit (~3001 characters; we target 3000).
- **`chat.postMessage` `text`:** fallback/notification text is derived from **`format_ai_response_for_slack`**, truncated with an ellipsis when needed, and aligned with block formatting (not raw model output only).
- **`format_ai_response_for_slack`:** stops calling `format_links_for_slack` directly; link conversion happens once via **`markdown()`** / `format_links_for_slack` per block (avoids double processing).
- **Guards:** reject bare **`YES` / `NO`** outputs from the pipeline in `process_ai_query`; treat empty/whitespace-only formatted output as error blocks instead of posting an empty block list.
- **Tests:** updated handler and auto-reply tests; added coverage for splitting, links, empty input, and YES/NO rejection.

### Files touched

- `backend/apps/slack/common/handlers/ai.py`
- `backend/apps/slack/services/message_auto_reply.py`
- `backend/apps/slack/utils.py`
- `backend/tests/apps/slack/common/handlers/ai_test.py`
- `backend/tests/apps/slack/services/message_auto_reply_test.py`

## Checklist

- [*] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [*] **Required:** I verified that my code works as intended and resolves the issue as described
- [*] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [*] I used AI for code, documentation, tests, or communication related to this PR

