### PR TITLE
fix: prevent substring false positives in is_project_leader check

### DIFF
--- a/backend/apps/owasp/api/internal/queries/project.py
+++ b/backend/apps/owasp/api/internal/queries/project.py
@@ -2,10 +2,8 @@
 
 import strawberry
 import strawberry_django
-from django.db.models import Q
 
 from apps.common.utils import normalize_limit
-from apps.github.models.user import User as GithubUser
 from apps.owasp.api.internal.nodes.project import ProjectNode
 from apps.owasp.models.project import Project
 
@@ -68,13 +66,5 @@ class ProjectQuery:
 
     @strawberry_django.field
     def is_project_leader(self, info: strawberry.Info, login: str) -> bool:
-        """Check if a GitHub login or name is listed as a project leader."""
-        try:
-            github_user = GithubUser.objects.get(login=login)
-        except GithubUser.DoesNotExist:
-            return False
-
-        return Project.objects.filter(
-            Q(leaders_raw__icontains=github_user.login)
-            | Q(leaders_raw__icontains=(github_user.name or ""))
-        ).exists()
+        """Check if a GitHub login is listed as a project leader."""
+        return Project.objects.filter(leaders__login__iexact=login).exists()

--- a/backend/tests/apps/owasp/api/internal/queries/project_test.py
+++ b/backend/tests/apps/owasp/api/internal/queries/project_test.py
@@ -2,7 +2,6 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from apps.github.models.user import User as GithubUser
 from apps.owasp.api.internal.nodes.project import ProjectNode
 from apps.owasp.api.internal.queries.project import ProjectQuery
 from apps.owasp.models.project import Project
@@ -148,10 +147,23 @@ class TestIsProjectLeaderResolution:
     def mock_info(self):
         return Mock()
 
-    def test_is_project_leader_user_not_found(self, mock_info):
-        """Test is_project_leader returns False when user doesn't exist."""
-        with patch("apps.owasp.api.internal.queries.project.GithubUser.objects.get") as mock_get:
-            mock_get.side_effect = GithubUser.DoesNotExist
+    def test_is_project_leader_returns_true_for_exact_login(self, mock_info):
+        """Test is_project_leader returns True for exact login match."""
+        with patch("apps.owasp.api.internal.queries.project.Project.objects.filter") as mock_filter:
+            mock_filter.return_value.exists.return_value = True
+
+            query = ProjectQuery()
+            result = query.__class__.__dict__["is_project_leader"](
+                query, info=mock_info, login="anurag"
+            )
+
+            assert result
+            mock_filter.assert_called_once_with(leaders__login__iexact="anurag")
+
+    def test_is_project_leader_returns_false_for_non_leader(self, mock_info):
+        """Test is_project_leader returns False when login has no matching leader."""
+        with patch("apps.owasp.api.internal.queries.project.Project.objects.filter") as mock_filter:
+            mock_filter.return_value.exists.return_value = False
 
             query = ProjectQuery()
             result = query.__class__.__dict__["is_project_leader"](
@@ -160,46 +172,37 @@ class TestIsProjectLeaderResolution:
 
             assert not result
 
-    def test_is_project_leader_user_is_leader(self, mock_info):
-        """Test is_project_leader returns True when user is a leader."""
-        mock_user = Mock()
-        mock_user.login = "testuser"
-        mock_user.name = "Test User"
+    def test_is_project_leader_no_substring_false_positive(self, mock_info):
+        """Test that 'devanurag' does not match a project led by 'anurag'."""
+        def filter_side_effect(**kwargs):
+            mock_qs = Mock()
+            login_filter = kwargs.get("leaders__login__iexact", "")
+            # Simulate DB: only "anurag" is a leader, not "devanurag"
+            mock_qs.exists.return_value = login_filter.lower() == "anurag"
+            return mock_qs
 
-        with (
-            patch(
-                "apps.owasp.api.internal.queries.project.GithubUser.objects.get"
-            ) as mock_get_user,
-            patch("apps.owasp.models.project.Project.objects.filter") as mock_filter,
+        with patch(
+            "apps.owasp.api.internal.queries.project.Project.objects.filter",
+            side_effect=filter_side_effect,
         ):
-            mock_get_user.return_value = mock_user
+            query = ProjectQuery()
+
+            assert query.__class__.__dict__["is_project_leader"](
+                query, info=mock_info, login="anurag"
+            )
+            assert not query.__class__.__dict__["is_project_leader"](
+                query, info=mock_info, login="devanurag"
+            )
+
+    def test_is_project_leader_case_insensitive(self, mock_info):
+        """Test that login matching is case-insensitive."""
+        with patch("apps.owasp.api.internal.queries.project.Project.objects.filter") as mock_filter:
             mock_filter.return_value.exists.return_value = True
 
             query = ProjectQuery()
             result = query.__class__.__dict__["is_project_leader"](
-                query, info=mock_info, login="testuser"
+                query, info=mock_info, login="ANURAG"
             )
 
             assert result
-
-    def test_is_project_leader_user_not_leader(self, mock_info):
-        """Test is_project_leader returns False when user is not a leader."""
-        mock_user = Mock()
-        mock_user.login = "testuser"
-        mock_user.name = "Test User"
-
-        with (
-            patch(
-                "apps.owasp.api.internal.queries.project.GithubUser.objects.get"
-            ) as mock_get_user,
-            patch("apps.owasp.models.project.Project.objects.filter") as mock_filter,
-        ):
-            mock_get_user.return_value = mock_user
-            mock_filter.return_value.exists.return_value = False
-
-            query = ProjectQuery()
-            result = query.__class__.__dict__["is_project_leader"](
-                query, info=mock_info, login="testuser"
-            )
-
-            assert not result
+            mock_filter.assert_called_once_with(leaders__login__iexact="ANURAG")


### PR DESCRIPTION
Fixes #4283

  ## What was wrong

  `is_project_leader` was using `leaders_raw__icontains` to check if a
  GitHub login belongs to a project's leaders. Since `leaders_raw` is a
  JSONField that gets serialized as a raw string, `icontains` just does
  a plain text search on it — so a login like `devanurag` would wrongly
  match a project where the actual leader is `anurag`.

  ## What I changed

  - Switched from querying `leaders_raw` (JSONField) to using the M2M
    `leaders` relationship with `leaders__login__iexact`, which does a
    proper exact match (case-insensitive) against the GitHub login column
  - Removed the `GithubUser.objects.get()` call that was needed before,
    since the M2M join handles the lookup implicitly
  - Cleaned up unused imports (`Q`, `GithubUser`)

  ## Tests

  Updated the test class with 4 cases:
  - Exact login match returns `True`
  - Non-matching login returns `False`
  - **Substring false positive** — `devanurag` does NOT match `anurag`
  - Case-insensitive — `ANURAG` matches `anurag`