### PR TITLE
fix: guard against None content in RAG generator

### DIFF
--- a/backend/apps/ai/agent/tools/rag/generator.py
+++ b/backend/apps/ai/agent/tools/rag/generator.py
@@ -111,7 +111,7 @@ Answer:
                 temperature=self.TEMPERATURE,
                 max_tokens=self.MAX_TOKENS,
             )
-            answer = response.choices[0].message.content.strip()
+            answer = (response.choices[0].message.content or "").strip()
         except openai.OpenAIError:
             logger.exception("OpenAI API error")
             answer = "I'm sorry, I'm currently unable to process your request."


### PR DESCRIPTION
### SUMMARY

Fixes a crash in RAG answer generation caused by calling `.strip()` on `None` when the OpenAI API returns empty content. Ensures the response handling path is safe and always returns a string without breaking the LangGraph workflow.

---

### FIX

* **Root cause:** `.strip()` called on `response.choices[0].message.content` without guarding for `None`
* **Fix:** Add a safe fallback using `or ""` before calling `.strip()`

```python
# BEFORE
answer = response.choices[0].message.content.strip()

# AFTER
answer = (response.choices[0].message.content or "").strip()
```

---

### VERIFICATION

* Trigger a response with `content=None` (e.g., content-filtered prompt)
* Run `Generator.generate_answer()`
* Confirm no crash occurs and execution continues normally
