### PR TITLE
fix: handle JSONDecodeError in LLM parsing

### DIFF
--- a/backend/apps/ai/agent/nodes.py
+++ b/backend/apps/ai/agent/nodes.py
@@ -211,7 +211,7 @@ class AgentNodes:
             content = extract_json_from_markdown(content)
             return json.loads(content)
 
-        except openai.OpenAIError:
+        except (openai.OpenAIError, json.JSONDecodeError):
             return {
                 "requested_fields": [],
                 "entity_types": [],
@@ -251,7 +251,7 @@ class AgentNodes:
             content = extract_json_from_markdown(content)
             return json.loads(content)
 
-        except openai.OpenAIError:
+        except (openai.OpenAIError, json.JSONDecodeError):
             return {
                 "complete": False,
                 "feedback": "Evaluator error or invalid response.",


### PR DESCRIPTION
## **SUMMARY**

Prevents crashes caused by malformed LLM responses by safely handling JSON parsing failures. Ensures invalid or non-JSON outputs fall back to default responses instead of breaking the pipeline.

---

## **FIX**

* **Root cause:** `json.loads()` raises `JSONDecodeError` for non-JSON LLM output, which was not caught
* **Fix:** Extend existing `except` blocks to include `json.JSONDecodeError`

```python
# BEFORE
except openai.OpenAIError:

# AFTER
except (openai.OpenAIError, json.JSONDecodeError):
```

---

## **VERIFICATION**

* Pass plain text / invalid JSON as LLM output
* Before: unhandled exception
* After: fallback response returned, no crash

