### PR TITLE
fix: prevent crash in Slack command error handler fallback

### DIFF
--- a/backend/apps/slack/commands/command.py
+++ b/backend/apps/slack/commands/command.py
@@ -143,14 +143,18 @@ class CommandBase:
                 )
         except Exception:
             logger.exception("Failed to handle command '%s'", self.command_name)
-            blocks = [markdown(":warning: An error occurred. Please try again later.")]
-            client.chat_postMessage(
-                blocks=blocks,
-                channel=client.conversations_open(
-                    users=self.get_user_id(command),
-                )["channel"]["id"],
-                text=get_text(blocks),
-            )
+            try:
+                blocks = [markdown(":warning: An error occurred. Please try again later.")]
+                channel_response = client.conversations_open(users=self.get_user_id(command))
+                channel_id = channel_response.get("channel", {}).get("id")
+                if channel_id:
+                    client.chat_postMessage(
+                        blocks=blocks,
+                        channel=channel_id,
+                        text=get_text(blocks),
+                    )
+            except Exception:
+                logger.exception("Failed to send error message for command '%s'", self.command_name)
 
     def register(self):
         """Register this command handler with the Slack app."""


### PR DESCRIPTION
## SUMMARY

Fixes a crash in the Slack command error handler by making the fallback logic safe. Ensures failures in the recovery path don’t mask the original error.

---

## FIX 

* **Root cause**: Unsafe `["channel"]["id"]` access in the `except` block
* **Fix**: Wrap fallback in `try/except` and use `.get()` with a guard

```python
# BEFORE
channel=client.conversations_open(... )["channel"]["id"]

# AFTER
channel_response = client.conversations_open(...)
channel_id = channel_response.get("channel", {}).get("id")
if channel_id:
    client.chat_postMessage(...)
```

---

## VERIFICATION

* Trigger a failure in the main handler
* Simulate failure/malformed Slack response in fallback

