### PR TITLE
docs: add local testing steps to NestBot development guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -264,6 +264,18 @@ To setup NestBot development environment, follow these steps:
 1. **Set up Slack application**:
    - Configure your Slack application using [NestBot manifest file](https://github.com/OWASP/Nest/blob/main/backend/apps/slack/MANIFEST.yaml) (copy its contents and save it into `Features -- App Manifest`). You'll need to replace slash commands endpoint with your ngrok static domain path.
    - Reinstall your Slack application after making the changes using `Settings -- Install App` section.
+Testing NestBot Locally:
+
+Once your environment is running, you can test NestBot by:
+
+1. Sending a direct message to your bot in your test Slack workspace.
+2. Mentioning the bot in a channel using @NestBot.
+3. Checking the Django logs for incoming events:
+
+   make logs
+
+Note: Ensure ngrok is running before testing, as Slack requires 
+a publicly accessible URL to deliver events to your local server.
 
 #### Local Access to Internal Dashboards
 


### PR DESCRIPTION
## Summary
Adds missing local testing instructions to the NestBot 
Development section in CONTRIBUTING.md.

## Motivation
As a new contributor setting up NestBot for the first 
time, I noticed there were no instructions on how to 
verify the bot is working locally after setup. This adds 
clear testing steps to help future contributors.

## Changes
- Added local testing steps under NestBot Development section
- Included make logs command for checking Django events

## Checklist
- [x] Documentation only change
- [x] No new dependencies added
- [x] Improves contributor onboarding experience