### PR TITLE
fix: configure Gunicorn with production-appropriate worker and timeout settings

### DIFF
--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -10,4 +10,12 @@ python manage.py migrate
 python manage.py collectstatic --noinput
 python manage.py clear_cache
 
-gunicorn wsgi:application --bind 0.0.0.0:8000
+gunicorn wsgi:application \
+  --bind 0.0.0.0:8000 \
+  --workers "${GUNICORN_WORKERS:-3}" \
+  --timeout "${GUNICORN_TIMEOUT:-30}" \
+  --graceful-timeout "${GUNICORN_GRACEFUL_TIMEOUT:-30}" \
+  --max-requests "${GUNICORN_MAX_REQUESTS:-1000}" \
+  --max-requests-jitter "${GUNICORN_MAX_REQUESTS_JITTER:-50}" \
+  --access-logfile - \
+  --error-logfile -


### PR DESCRIPTION
## Summary

Closes #4027

The previous `backend/entrypoint.sh` started Gunicorn with no configuration beyond `--bind`, leaving production with:
- A single sync worker (one stuck request blocks all traffic)
- No timeout enforcement (hung workers stay alive indefinitely)
- No worker recycling (memory accumulates over worker lifetime)
- No request logging (no visibility into traffic patterns)

This PR fixes all of the above with env-configurable defaults:

| Flag | Default | Purpose |
|------|---------|---------|
| `--workers` | `3` | Multiple workers prevent single-request blocking |
| `--timeout` | `30` | Kills unresponsive workers |
| `--graceful-timeout` | `30` | In-flight requests complete on restart/deploy |
| `--max-requests` | `1000` | Recycles workers to prevent memory accumulation |
| `--max-requests-jitter` | `50` | Staggers recycling to avoid thundering herd |
| `--access-logfile` | `-` (stdout) | Request logging captured by Docker log driver |
| `--error-logfile` | `-` (stderr) | Error logging captured by Docker log driver |

All values are overridable via environment variables (`GUNICORN_WORKERS`, `GUNICORN_TIMEOUT`, `GUNICORN_GRACEFUL_TIMEOUT`, `GUNICORN_MAX_REQUESTS`, `GUNICORN_MAX_REQUESTS_JITTER`) — no code change needed to tune per deployment.

**Not changed:** e2e and fuzz compose files — single-worker is acceptable in those test environments.

## Test plan

- [ ] `make check-test` passes
- [ ] Production and staging Docker images build successfully
- [ ] Gunicorn starts with the configured number of workers (visible in container logs as `[INFO] Booting worker with pid`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)