### PR TITLE
Add SPONSORSHIP.md with Phase 1 GitHub Sponsors setup guide

### DIFF
--- a/SPONSORSHIP.md
+++ b/SPONSORSHIP.md
@@ -6,6 +6,7 @@ Thank you for your contributions to the OWASP Nest project! This document outlin
 
 ## Phase 1 — Set Up GitHub Sponsors on Your Personal Account
 
+> [!NOTE]
 > **Official Docs:** [Setting up GitHub Sponsors for your personal account](https://docs.github.com/en/sponsors/receiving-sponsorships-through-github-sponsors/setting-up-github-sponsors-for-your-personal-account)
 
 This is a one-time setup. GitHub needs to verify your identity and set up your payout method before your profile goes live.
@@ -40,6 +41,7 @@ Once submitted, GitHub will review your application — this typically takes a f
 
 ### Step 4 — Choose Your Payout Method
 
+> [!NOTE]
 > ⚠️ This must be decided at sign-up — it is difficult to change later.
 
 GitHub offers two options:
@@ -68,6 +70,7 @@ GitHub currently supports these fiscal hosts:
 - [Software in the Public Interest](https://www.spi-inc.org/)
 - [Software Underground](https://softwareunderground.org/)
 
+> [!NOTE]
 > **Official Docs:** [Using a fiscal host to receive GitHub Sponsors payouts](https://docs.github.com/en/sponsors/receiving-sponsorships-through-github-sponsors/using-a-fiscal-host-to-receive-github-sponsors-payouts)
 
 ---


### PR DESCRIPTION
## Proposed change

Resolves #4336

Adds a new `SPONSORSHIP.md` file to the repository root covering Phase 1 of the GitHub Sponsors setup process for contributors. This includes eligibility requirements, 2FA setup, payout method options (Stripe Connect and fiscal hosts), tax information, and profile setup guidance. Follows the same documentation style as `CONTRIBUTING.md`.

## Checklist
- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [x] I used AI for code, documentation, tests, or communication related to this PR