### PR TITLE
Nest logos reload the site

### DIFF
--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -120,7 +120,7 @@ export default function Footer() {
           {/* Vertical Separator */}
           <div className="h-8 w-px bg-slate-400 dark:bg-white"></div>
 
-          <Link
+          <a
             href="/"
             className="flex items-center gap-2 rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
             aria-label="Nest home"
@@ -133,7 +133,7 @@ export default function Footer() {
               className="h-8 w-auto"
             />
             <span className="text-lg font-semibold text-slate-800 dark:text-slate-200">Nest</span>
-          </Link>
+          </a>
         </div>
 
         {/* Footer bottom section with copyright and version */}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -59,9 +59,8 @@ export default function Header({ isGitHubAuthEnabled }: { readonly isGitHubAuthE
     <header className="bg-owasp-blue fixed inset-x-0 top-0 z-50 w-full shadow-md dark:bg-slate-800">
       <div className="flex h-16 w-full items-center px-4 max-lg:justify-between" id="navbar-sticky">
         {/* Logo */}
-        <Link
+        <a
           href="/"
-          onClick={() => setMobileMenuOpen(false)}
           className="rounded-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
         >
           <div className="flex h-full items-center">
@@ -79,7 +78,7 @@ export default function Header({ isGitHubAuthEnabled }: { readonly isGitHubAuthE
               Nest
             </div>
           </div>
-        </Link>
+        </a>
         {/* Desktop Header Links */}
         <div className="hidden flex-1 justify-between rounded-lg pl-6 font-medium lg:block">
           <div className="flex justify-start pl-6">


### PR DESCRIPTION
Resolves #4215

<!-- Describe the big picture of your changes.-->
I updated the Nest logo so that when it’s clicked, it now reloads the page and takes you back to the top.

## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [ ] I used AI for code, documentation, tests, or communication related to this PR
