### PR TITLE
Fix chapters page responsiveness and country filter reset

### DIFF
--- a/frontend/src/components/SearchPageLayout.tsx
+++ b/frontend/src/components/SearchPageLayout.tsx
@@ -53,8 +53,8 @@ const SearchPageLayout = ({
   }
 
   return (
-    <div className="text-text flex min-h-screen w-full flex-col items-center justify-normal p-5">
-      <div className={`flex w-full items-center justify-center ${inlineSort ? 'gap-0' : 'gap-2'}`}>
+    <div className="text-text flex min-h-screen w-full flex-col items-center justify-normal p-5 overflow-x-hidden">
+      <div className={`flex w-full flex-wrap items-center justify-center ${inlineSort ? 'gap-0' : 'gap-2'}`}>
         {filterChildren &&
           (isFirstLoad ? (
             <Skeleton
@@ -62,7 +62,7 @@ const SearchPageLayout = ({
               aria-hidden="true"
             />
           ) : (
-            <div className={inlineSort ? '[&>div]:rounded-r-none' : ''}>{filterChildren}</div>
+            <div className={`min-w-0 ${inlineSort ? '[&>div]:rounded-r-none' : ''}`}>{filterChildren}</div>
           ))}
         <SearchBar
           isLoaded={!isFirstLoad}


### PR DESCRIPTION

## Proposed change
<!-- Don't forget to link your PR to an existing issue.-->

Resolves #4282 

<!-- Describe the big picture of your changes.-->
Changes made:
- Added flex-wrap to search/filter row so it wraps on small screens
- Added overflow-x-hidden to prevent horizontal scroll on mobile
- Added min-w-0 to fix country filter cut off on small screens
- Fixed country filter resetting to "All Countries" on backspace by
  tracking inputValue separately from selectedKey

<img width="1916" height="971" alt="image" src="https://github.com/user-attachments/assets/06e95e00-547f-43f3-8564-bae976e4e690" />


## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [ ] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [x] I used AI for code, documentation, tests, or communication related to this PR
