### PR TITLE
fix: keep OWASP logo static while spinner ring rotates

### DIFF
--- a/frontend/src/components/LoadingSpinner.tsx
+++ b/frontend/src/components/LoadingSpinner.tsx
@@ -12,25 +12,30 @@ const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({ imageUrl }) => {
 
   return (
     <div className="flex min-h-[60vh] items-center justify-center">
-      <div
-        className="animate-custom-spin relative h-16 w-16 rounded-full border-4 border-[#98AFC7] dark:border-white"
-        style={{ borderTopColor: 'transparent' }}
-      >
+      {/* Wrapper: positions the spinner ring and logo independently */}
+      <div className="relative h-16 w-16">
+        {/* Spinning ring only — logo is NOT inside this div */}
+        <div
+          className="animate-custom-spin absolute inset-0 rounded-full border-4 border-[#98AFC7] dark:border-white"
+          style={{ borderTopColor: 'transparent' }}
+          aria-hidden="true"
+        />
+        {/* Static logo — sibling of the spinner, not a child */}
         <div className="absolute inset-0 flex items-center justify-center">
           <div className="animate-fade-in-out">
             <Image
               src={image}
               alt="Loading indicator"
               className="hidden rounded-full dark:block"
-              width={60}
-              height={60}
+              width={40}
+              height={40}
             />
             <Image
               src={dark}
               alt="Loading indicator"
               className="rounded-full dark:hidden"
-              width={60}
-              height={60}
+              width={40}
+              height={40}
             />
           </div>
         </div>


### PR DESCRIPTION
## Summary

Fixes #4338 
The OWASP logo was placed *inside* the `animate-custom-spin` div in `LoadingSpinner.tsx`, causing it to rotate together with the spinner border. This violates OWASP branding guidelines which require the logo to be used without modification or alteration.

## Root Cause

```tsx
// BEFORE: logo is a child of the spinning div -> rotates with it
<div className="animate-custom-spin ...">
  <div> {/* logo here */} </div>
</div>
```

## Fix

Restructured the component so the spinning ring and logo are **siblings** inside a relative container. Only the border ring has `animate-custom-spin`, keeping the logo completely static:

```tsx
// AFTER: logo is a sibling, not a child -> stays static
<div className="relative h-16 w-16">
  <div className="animate-custom-spin absolute inset-0 ..." aria-hidden="true" />
  <div className="absolute inset-0 flex items-center justify-center">
    {/* logo here - does not rotate */}
  </div>
</div>
```

## Testing

Load any page that triggers the loading spinner. The OWASP logo should now remain stationary while only the ring border spins.

Closes #4338