### PR TITLE
Remove invalid test:e2e script from README

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -51,7 +51,7 @@ Common `pnpm` scripts defined in `package.json`:
 | Format code            | `pnpm run format`          |
 | Generate GraphQL types | `pnpm run graphql-codegen` |
 | Run unit tests         | `pnpm run test:unit`       |
-| Run e2e tests          | `pnpm run test:e2e`        |
+
 
 See the `Makefile` for Docker-based convenience targets.
 


### PR DESCRIPTION


## Proposed change

Resolves #4393

Removed invalid `test:e2e` script from README since it does not exist in package.json . This avoids confusion and keeps documentation accurate.


Resolves #4393 

Fixes incorrect reference to `test:e2e` script in README.

- Removed invalid `test:e2e` command
- Verified available scripts in package.json

Closes #4393

## Checklist

- [x] Required: I followed the contributing workflow
- [x] Required: I verified that my code works as intended and resolves the issue as described
- [x] Required: I ran `make check-test` locally
- [x] I used AI for code, documentation, tests, or communication related to this PR

### PR Category
- [x] Documentation
