### PR TITLE
fix: prevent contributor tooltip collisions across multiple projects

### DIFF
--- a/frontend/components/Contributors.tsx
+++ b/frontend/components/Contributors.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+
+export interface Contributor {
+  id: string | number;
+  name: string;
+  avatar_url?: string;
+  profile_url?: string;
+  position?: string;
+}
+
+export interface ContributorsProps {
+  projectId: string | number;
+  contributors: Contributor[];
+  className?: string;
+}
+
+const ContributorAvatar: React.FC<{ contributor: Contributor }> = ({ contributor }) => {
+  if (contributor.avatar_url) {
+    return (
+      <img
+        src={contributor.avatar_url}
+        alt={contributor.name}
+        className="h-8 w-8 rounded-full object-cover border border-gray-200"
+        loading="lazy"
+      />
+    );
+  }
+
+  const initials = contributor.name
+    ? contributor.name.split(' ').map(n => n[0]).slice(0, 2).join('').toUpperCase()
+    : '?';
+
+  return (
+    <div className="flex h-8 w-8 items-center justify-center rounded-full bg-gray-200 text-gray-700 text-xs font-semibold border border-gray-300">
+      {initials}
+    </div>
+  );
+};
+
+export const Contributors: React.FC<ContributorsProps> = ({
+  projectId,
+  contributors,
+  className = ''
+}) => {
+  if (!contributors || contributors.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={`flex flex-wrap gap-2 ${className}`.trim()}>
+      {contributors.map((contributor, index) => {
+        // Fix for Issue #1065: Tooltip Collision for Contributors Across Multiple Projects.
+        // Append projectId to ensure tooltip IDs and keys are uniquely scoped 
+        // across multiple project cards on the same page.
+        const uniqueKey = `project-${projectId}-contributor-${contributor.id}-pos-${index}`;
+        const tooltipId = `tooltip-${uniqueKey}`;
+
+        return (
+          <div key={uniqueKey} className="relative group flex items-center justify-center">
+            <div 
+              data-tooltip-id={tooltipId}
+              data-tooltip-content={`${contributor.name}${contributor.position ? ` - ${contributor.position}` : ''}`}
+              aria-describedby={tooltipId}
+            >
+              {contributor.profile_url ? (
+                <a 
+                  href={contributor.profile_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="block transition-transform hover:scale-105 focus:outline-none"
+                >
+                  <ContributorAvatar contributor={contributor} />
+                </a>
+              ) : (
+                <div className="block transition-transform hover:scale-105">
+                  <ContributorAvatar contributor={contributor} />
+                </div>
+              )}
+            </div>
+
+            {/* CSS-based fallback tooltip to guarantee unique behavior */}
+            <div
+              id={tooltipId}
+              role="tooltip"
+              className="pointer-events-none absolute bottom-full left-1/2 z-50 mb-2 -translate-x-1/2 whitespace-nowrap rounded bg-gray-900 px-2 py-1 text-xs text-white opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
+            >
+              <div className="text-center">
+                <span className="font-medium">{contributor.name}</span>
+                {contributor.position && (
+                  <span className="block text-[10px] text-gray-300">{contributor.position}</span>
+                )}
+              </div>
+              <div className="absolute left-1/2 top-full -translate-x-1/2 border-4 border-transparent border-t-gray-900" />
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default Contributors;

--- a/frontend/src/components/Contributors.tsx
+++ b/frontend/src/components/Contributors.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+
+export interface Contributor {
+  id?: string | number;
+  login: string;
+  name?: string;
+  avatar_url: string;
+  html_url: string;
+  contributions?: number;
+}
+
+export interface ContributorsProps {
+  contributors: Contributor[];
+  projectId: string | number;
+}
+
+export const Contributors: React.FC<ContributorsProps> = ({ contributors, projectId }) => {
+  if (!contributors || contributors.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex -space-x-2 overflow-visible py-1">
+      {contributors.map((contributor, index) => {
+        // Strategy: Append the project ID to the unique key used for contributor tooltips 
+        // to prevent collisions across multiple project cards on the same page.
+        const uniqueKey = `contributor-${projectId}-${contributor.id || contributor.login}-${index}`;
+        const tooltipId = `tooltip-${uniqueKey}`;
+        const displayName = contributor.name || contributor.login;
+
+        return (
+          <div key={uniqueKey} className="relative group inline-block">
+            <a
+              href={contributor.html_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-describedby={tooltipId}
+              data-tooltip-id={tooltipId}
+              data-tooltip-content={displayName}
+              className="inline-block rounded-full ring-2 ring-white dark:ring-gray-800 transition-transform hover:scale-110 hover:z-10 focus:z-10 bg-white"
+            >
+              <img
+                src={contributor.avatar_url}
+                alt={displayName}
+                className="h-8 w-8 rounded-full bg-gray-200 dark:bg-gray-700 object-cover"
+                loading="lazy"
+              />
+            </a>
+            
+            {/* Native CSS Fallback Tooltip */}
+            <div
+              id={tooltipId}
+              role="tooltip"
+              className="invisible group-hover:visible opacity-0 group-hover:opacity-100 absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-2 py-1 bg-gray-900 text-white text-xs rounded whitespace-nowrap z-50 transition-opacity duration-200 pointer-events-none shadow-lg"
+            >
+              <span className="font-medium">{displayName}</span>
+              {contributor.contributions !== undefined && (
+                <span className="block text-gray-300 text-[10px] mt-0.5">
+                  {contributor.contributions} contribution{contributor.contributions !== 1 && 's'}
+                </span>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default Contributors;


### PR DESCRIPTION
Closes #1065

## Summary
Append the project ID to the unique key used for contributor tooltips to prevent collisions across multiple project cards on the same page.

## Changes
- `frontend/src/components/Contributors.tsx`
- `frontend/components/Contributors.tsx`