### PR TITLE
test: add smoke tests for public mentorship programs listing page

### DIFF
--- a/frontend/__tests__/e2e/pages/MentorshipPrograms.spec.ts
+++ b/frontend/__tests__/e2e/pages/MentorshipPrograms.spec.ts
@@ -29,6 +29,14 @@ test.describe('Mentorship Programs Page', () => {
     await expect(page.getByText('This is a summary of Program 1.')).toBeVisible()
   })
 
+  test('program card link navigates to program details', async ({ page }) => {
+    const programLink = page.getByRole('link', { name: 'Program 1' })
+    await programLink.waitFor({ state: 'visible' })
+    await expect(programLink).toHaveAttribute('href', '/mentorship/programs/program_1')
+    await programLink.click()
+    await expect(page).toHaveURL('/mentorship/programs/program_1')
+  })
+
   test('search input is visible', async ({ page }) => {
     await expect(page.getByPlaceholder('Search for programs...')).toBeVisible()
   })


### PR DESCRIPTION
## Proposed change

<!-- Don't forget to link your PR to an existing issue.-->
Resolves #4404 

<!-- Describe the big picture of your changes.-->
## Summary
- Added `MentorshipPrograms.spec.ts` as a dedicated e2e test file for the `/mentorship/programs` route
- Mocks the Algolia search endpoint (`**/idx/`) with inlined mock data => no auth flows required
- Covers: program card renders, search input visible, empty state message, and breadcrumb segments

## Test plan
- [x] Program card renders from mock data (`Program 1` link and description visible)
- [x] Search input placeholder `"Search for programs..."` is visible
- [x] Empty state displays `"No programs found"` when no results returned
- [x] Breadcrumb renders `['Home', 'Mentorship']` (programs segment is hidden per `useBreadcrumbs` logic)

## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [ ] I used AI for code, documentation, tests, or communication related to this PR
