### PR TITLE
refactor: replace eslint-disable console comments with console.warn

### DIFF
--- a/frontend/__tests__/unit/components/CalendarButton.test.tsx
+++ b/frontend/__tests__/unit/components/CalendarButton.test.tsx
@@ -121,7 +121,7 @@ describe('CalendarButton', () => {
     })
 
     it('handles errors gracefully when generation fails', async () => {
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
       const errorMock = new Error('Failed to generate')
       ;(getIcsFileUrl as jest.Mock).mockRejectedValueOnce(errorMock)
 
@@ -141,7 +141,7 @@ describe('CalendarButton', () => {
         })
         expect(consoleSpy).toHaveBeenCalledWith(
           expect.stringContaining('Failed to download ICS file'),
-          errorMock
+          errorMock.message
         )
       })
 

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -141,7 +141,7 @@ const eslintConfig = [
           pathGroupsExcludedImportTypes: ['builtin'],
         },
       ],
-      'no-console': 'error',
+      'no-console': ['error', { allow: ['warn'] }],
       'no-restricted-imports': [
         'error',
         {

--- a/frontend/src/components/CalendarButton.tsx
+++ b/frontend/src/components/CalendarButton.tsx
@@ -41,8 +41,7 @@ export default function CalendarButton(props: Readonly<CalendarButtonProps>) {
         variant: 'solid',
       })
     } catch (err) {
-      // eslint-disable-next-line no-console
-      console.error('Failed to download ICS file:', err)
+      console.warn('Failed to download ICS file:', (err as Error)?.message || err)
       addToast({
         description: 'Failed to download ICS file',
         title: 'Download Failed',

--- a/frontend/src/utils/geolocationUtils.ts
+++ b/frontend/src/utils/geolocationUtils.ts
@@ -31,7 +31,6 @@ export const calculateDistance = (
 export const getUserLocationFromBrowser = (): Promise<UserLocation | null> => {
   return new Promise((resolve) => {
     if (!navigator.geolocation) {
-      // eslint-disable-next-line no-console
       console.warn('Geolocation API not supported')
       resolve(null)
       return
@@ -50,7 +49,6 @@ export const getUserLocationFromBrowser = (): Promise<UserLocation | null> => {
         })
       },
       (error) => {
-        // eslint-disable-next-line no-console
         console.warn('Browser geolocation error:', error.message)
         resolve(null)
       },


### PR DESCRIPTION
- Remove // eslint-disable-next-line no-console comments from CalendarButton.tsx and geolocationUtils.ts
- Change console.error to console.warn in CalendarButton catch block and log err.message instead of the raw error object
- Update ESLint config to allow console.warn globally (no-console rule)
- Update CalendarButton unit test to spy on console.warn and match the new error message format

This makes the code cleaner by avoiding inline ESLint disable pragmas while still providing useful diagnostic output in browser consoles.

## STOP AND READ BEFORE SUBMITTING! REMOVE THIS PARAGRAPH BEFORE OPENING THE PR

Thank you for your interest in contributing to OWASP Nest!

Before starting any work, all external contributors **must first be assigned to an issue** in the repository.
This is a mandatory step in the OWASP Nest workflow and ensures that effort is coordinated, approved, and tracked properly.

**Exception:** OWASP leaders are not required to follow this rule —- just make sure your username is included in the [exception list](https://github.com/OWASP/Nest/blob/main/.github/workflows/check-pr-issue-skip-usernames.txt).

**If you were not assigned to the issue you are trying to resolve, stop right now and do NOT create this PR.**
Unassigned pull requests are automatically closed by our workflows — please don't waste your time.

If you want to be assigned on any available issue, comment on it and wait for confirmation from the maintainers or project leads.

## Proposed change

<!-- Don't forget to link your PR to an existing issue.-->
Resolves #(put the issue number here)

<!-- Describe the big picture of your changes.-->
Add the PR description here.

## Checklist

- [ ] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [ ] **Required:** I verified that my code works as intended and resolves the issue as described
- [ ] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [ ] I used AI for code, documentation, tests, or communication related to this PR
