### PR TITLE
fix: correct cursor display on non-interactive map areas

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -471,4 +471,12 @@ select:disabled,
 
 .leaflet-container {
   background: transparent !important;
+  cursor: default;
+}
+
+.leaflet-interactive,
+.leaflet-marker-icon,
+.leaflet-popup-content button,
+.leaflet-control-zoom a {
+  cursor: pointer !important;
 }


### PR DESCRIPTION
## Summary
The `ChapterMap` component displayed a pointer cursor across the entire map surface, including non-interactive areas, misleading users into thinking all areas are clickable.

## Changes
- Set `cursor: default` on `.leaflet-container` to use the default arrow cursor for non-interactive map areas
- Added `cursor: pointer !important` rules for interactive elements:
  - `.leaflet-interactive` (markers, vector paths)
  - `.leaflet-marker-icon` (marker icons)
  - `.leaflet-popup-content button` (popup buttons)
  - `.leaflet-control-zoom a` (zoom control buttons)

## Testing
- Verified existing unit tests in `ChapterMap.test.tsx` still pass
- The fix only modifies CSS rules without changing component logic

Fixes #4419