### PR TITLE
fix(ui): prevent OWASP logo from rotating with spinner

### DIFF
--- a/frontend/src/components/LoadingSpinner.tsx
+++ b/frontend/src/components/LoadingSpinner.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import Image from 'next/image'
 import React from 'react'
 
@@ -11,30 +13,33 @@ const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({ imageUrl }) => {
   const dark = image.replace('white', 'blue')
 
   return (
-    <div className="flex min-h-[60vh] items-center justify-center">
-      <div
-        className="animate-custom-spin relative h-16 w-16 rounded-full border-4 border-[#98AFC7] dark:border-white"
-        style={{ borderTopColor: 'transparent' }}
-      >
-        <div className="absolute inset-0 flex items-center justify-center">
-          <div className="animate-fade-in-out">
-            <Image
-              src={image}
-              alt="Loading indicator"
-              className="hidden rounded-full dark:block"
-              width={60}
-              height={60}
-            />
-            <Image
-              src={dark}
-              alt="Loading indicator"
-              className="rounded-full dark:hidden"
-              width={60}
-              height={60}
-            />
-          </div>
-        </div>
+    <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4">
+      
+      {/* ✅ STATIC LOGO (NO ANIMATION) */}
+      <div className="animate-fade-in-out">
+        <Image
+          src={image}
+          alt="OWASP"
+          className="hidden rounded-full dark:block"
+          width={60}
+          height={60}
+        />
+        <Image
+          src={dark}
+          alt="OWASP"
+          className="rounded-full dark:hidden"
+          width={60}
+          height={60}
+        />
       </div>
+
+      {/* ✅ SPINNER ONLY (ROTATES) */}
+      <div
+        className="h-16 w-16 animate-custom-spin rounded-full border-4 border-[#98AFC7] dark:border-white"
+        style={{ borderTopColor: 'transparent' }}
+        role="status"
+        aria-label="Loading"
+      />
     </div>
   )
 }


### PR DESCRIPTION
Resolves #4338

## Summary
Fixes an issue where the OWASP logo was rotating along with the loading spinner.

## Changes
- Separated spinner animation from logo
- Ensured logo remains static
- Spinner now rotates independently

## Impact
- Maintains OWASP branding guidelines
- Improves UI consistency