### PR TITLE
docs: add local testing steps to NestBot development guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -220,7 +220,7 @@ If you plan to fetch GitHub OWASP data locally, follow these additional steps:
 ❗ **Doing so will interfere with OWASP Nest functionality and trigger unnecessary notifications to Slack admins.**
 ❗ **Always use a different workspace (create your own if needed).**
 
-To setup NestBot development environment, follow these steps:
+To set up the NestBot development environment, follow these steps:
 
 1. **Set Up ngrok**:
 
@@ -262,20 +262,16 @@ To setup NestBot development environment, follow these steps:
      ```
 
 1. **Set up Slack application**:
-   - Configure your Slack application using [NestBot manifest file](https://github.com/OWASP/Nest/blob/main/backend/apps/slack/MANIFEST.yaml) (copy its contents and save it into `Features -- App Manifest`). You'll need to replace slash commands endpoint with your ngrok static domain path.
+   - Configure your Slack application using [NestBot manifest file](https://github.com/OWASP/Nest/blob/main/backend/apps/slack/MANIFEST.yaml) (copy its contents and save it into `Features -- App Manifest`). Replace production URLs with your ngrok base URL for slash commands, event subscriptions, and interactivity sections (`request_url`) so Slack can deliver events and actions to your machine.
    - Reinstall your Slack application after making the changes using `Settings -- Install App` section.
-   ### Testing NestBot Locally
 
-Once your environment is running, verify NestBot is working:
+##### Testing NestBot Locally
 
-1. Send a direct message to your bot in your test Slack workspace.
-2. Mention the bot in a channel using @NestBot.
-3. Check Django logs for incoming events:
+With `make run` and `ngrok start NestBot` running, smoke-test the integration—for example DM the bot, `@`-mention it in a channel, or post a normal channel message when your app subscribes to the `message.channels` bot event.
 
-   make logs
+To confirm Slack is reaching your machine, check the backend container logs.
 
-Note: Ensure ngrok is running before testing, as Slack requires
-a publicly accessible URL to deliver events to your local server.
+> **Note:** Keep ngrok running while you test. Slack must use a publicly accessible URL to reach your local server.
 
 #### Local Access to Internal Dashboards
 


### PR DESCRIPTION
Closes #4333

## Summary
Adds missing local testing instructions to the NestBot  Development section in CONTRIBUTING.md.

## Changes
- Added Testing NestBot Locally subsection
- Included make logs command for checking Django events

## Checklist
- [x] Documentation only change
- [x] No new dependencies added
- [x] Improves contributor onboarding experience

## STOP AND READ BEFORE SUBMITTING! REMOVE THIS PARAGRAPH BEFORE OPENING THE PR

Thank you for your interest in contributing to OWASP Nest!

Before starting any work, all external contributors **must first be assigned to an issue** in the repository.
This is a mandatory step in the OWASP Nest workflow and ensures that effort is coordinated, approved, and tracked properly.

**Exception:** OWASP leaders are not required to follow this rule —- just make sure your username is included in the [exception list](https://github.com/OWASP/Nest/blob/main/.github/workflows/check-pr-issue-skip-usernames.txt).

**If you were not assigned to the issue you are trying to resolve, stop right now and do NOT create this PR.**
Unassigned pull requests are automatically closed by our workflows — please don't waste your time.

If you want to be assigned on any available issue, comment on it and wait for confirmation from the maintainers or project leads.

## Proposed change

<!-- Don't forget to link your PR to an existing issue.-->
Resolves #(put the issue number here)

<!-- Describe the big picture of your changes.-->
Add the PR description here.

## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [x] I used AI for code, documentation, tests, or communication related to this PR
