### PR TITLE
Add backdrop overlay and body scroll lock to mobile menu

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -55,6 +55,19 @@ export default function Header({ isGitHubAuthEnabled }: { readonly isGitHubAuthE
     }
   }, [mobileMenuOpen])
 
+  // Lock body scroll when mobile menu is open
+  useEffect(() => {
+    if (mobileMenuOpen) {
+      document.body.style.overflow = 'hidden'
+    } else {
+      document.body.style.overflow = ''
+    }
+
+    return () => {
+      document.body.style.overflow = ''
+    }
+  }, [mobileMenuOpen])
+
   return (
     <header className="bg-owasp-blue fixed inset-x-0 top-0 z-50 w-full shadow-md dark:bg-slate-800">
       <div className="flex h-16 w-full items-center px-4 max-lg:justify-between" id="navbar-sticky">
@@ -147,6 +160,15 @@ export default function Header({ isGitHubAuthEnabled }: { readonly isGitHubAuthE
           </div>
         </div>
       </div>
+      {/* Backdrop overlay */}
+      {mobileMenuOpen && (
+        <div
+          className="fixed inset-0 z-40 bg-black/50 transition-opacity lg:hidden"
+          onClick={() => setMobileMenuOpen(false)}
+          aria-hidden="true"
+        />
+      )}
+      {/* Mobile menu sidebar */}
       <div
         className={cn(
           'bg-owasp-blue fixed inset-y-0 left-0 z-50 w-64 transform shadow-md transition-transform dark:bg-slate-800',


### PR DESCRIPTION
## Description

This PR fixes the mobile navigation menu UX issues by adding a backdrop overlay and body scroll lock functionality.

## Changes Made

- **Added backdrop overlay**: A semi-transparent black overlay (`bg-black/50`) now appears behind the mobile menu when open, providing better visual focus
- **Implemented body scroll lock**: Background content no longer scrolls when the mobile menu is active, preventing confusing scroll behavior
- **Enhanced click-outside-to-close**: Users can now click the backdrop to dismiss the menu, improving usability
- **Improved mobile UX**: The menu now provides a focused, modal-like experience on mobile devices

## Technical Implementation

1. Added a new `useEffect` hook to manage body scroll locking:
   - Sets `overflow: hidden` on `document.body` when menu opens
   - Restores normal scrolling when menu closes
   - Properly cleans up on component unmount

2. Added backdrop overlay element:
   - Positioned with `fixed inset-0` to cover entire viewport
   - Z-index of 40 (menu sidebar is 50) to layer correctly
   - Only visible on mobile with `lg:hidden` class
   - Includes `onClick` handler to close menu

3. Maintained all existing functionality:
   - Resize handler still works
   - Outside click detection preserved
   - Menu animations unchanged

## Testing

- [x] Code follows project style guidelines
- [x] No TypeScript errors or linting issues
- [x] Changes are minimal and focused on the issue
- [x] Existing functionality preserved

## Fixes

Closes #4423

## Screenshots/Demo

_Please test on mobile or responsive view to see:_
- Backdrop overlay appears when menu opens
- Background content doesn't scroll when menu is open
- Clicking backdrop closes the menu
- Menu animations work smoothly

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
