### PR TITLE
Improve header search discoverability and local search resilience

### DIFF
--- a/frontend/src/app/chapters/page.tsx
+++ b/frontend/src/app/chapters/page.tsx
@@ -50,22 +50,27 @@ const ChaptersPage = () => {
 
   useEffect(() => {
     const fetchData = async () => {
-      const searchParams = {
-        indexName: 'chapters',
-        query: '',
-        currentPage,
-        hitsPerPage: currentPage === 1 ? 1000 : 25,
+      try {
+        const searchParams = {
+          indexName: 'chapters',
+          query: '',
+          currentPage,
+          hitsPerPage: currentPage === 1 ? 1000 : 25,
+        }
+        const data: AlgoliaResponse<Chapter> = await fetchAlgoliaData(
+          searchParams.indexName,
+          searchParams.query,
+          searchParams.currentPage,
+          searchParams.hitsPerPage,
+          selectedCountry ? [`idx_country:${selectedCountry}`] : [],
+          { throwOnError: false }
+        )
+        setGeoLocData(data.hits)
+      } catch {
+        setGeoLocData([])
       }
-      const data: AlgoliaResponse<Chapter> = await fetchAlgoliaData(
-        searchParams.indexName,
-        searchParams.query,
-        searchParams.currentPage,
-        searchParams.hitsPerPage,
-        selectedCountry ? [`idx_country:${selectedCountry}`] : []
-      )
-      setGeoLocData(data.hits)
     }
-    fetchData()
+    void fetchData()
   }, [currentPage, selectedCountry])
 
   const handleCountryChange = (country: string) => {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -74,21 +74,27 @@ export default function Home() {
 
   useEffect(() => {
     const fetchData = async () => {
-      const searchParams = {
-        indexName: 'chapters',
-        query: '',
-        currentPage: 1,
-        hitsPerPage: 1000,
+      try {
+        const searchParams = {
+          indexName: 'chapters',
+          query: '',
+          currentPage: 1,
+          hitsPerPage: 1000,
+        }
+        const data: AlgoliaResponse<Chapter> = await fetchAlgoliaData(
+          searchParams.indexName,
+          searchParams.query,
+          searchParams.currentPage,
+          searchParams.hitsPerPage,
+          [],
+          { throwOnError: false }
+        )
+        setGeoLocData(data.hits)
+      } catch {
+        setGeoLocData([])
       }
-      const data: AlgoliaResponse<Chapter> = await fetchAlgoliaData(
-        searchParams.indexName,
-        searchParams.query,
-        searchParams.currentPage,
-        searchParams.hitsPerPage
-      )
-      setGeoLocData(data.hits)
     }
-    fetchData()
+    void fetchData()
   }, [])
 
   if (isLoading || !graphQLData || !geoLocData) {

--- a/frontend/src/components/GlobalSearch.tsx
+++ b/frontend/src/components/GlobalSearch.tsx
@@ -392,16 +392,19 @@ export default function GlobalSearch() {
       <button
         type="button"
         onClick={() => setIsOpen(true)}
-        className="flex items-center gap-2 rounded-lg border border-slate-600/30 bg-transparent px-2.5 py-2 text-sm text-slate-600 transition-colors hover:border-slate-500/50 hover:bg-slate-200/50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-500 sm:w-60 sm:px-4 dark:border-slate-600/50 dark:bg-transparent dark:text-slate-300 dark:hover:border-slate-500/50 dark:hover:bg-slate-600/30 dark:hover:text-slate-100 dark:focus-visible:outline-slate-400"
+        className="flex items-center gap-2 rounded-lg border border-slate-500/40 bg-slate-100/70 px-3 py-2 text-sm text-slate-700 transition-colors hover:border-slate-500/70 hover:bg-slate-200/80 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-500 sm:w-72 sm:px-4 dark:border-slate-500/60 dark:bg-slate-700/40 dark:text-slate-200 dark:hover:border-slate-400/80 dark:hover:bg-slate-600/40 dark:hover:text-slate-50 dark:focus-visible:outline-slate-400"
         aria-label="Open search"
       >
         <FaSearch className="h-4 w-4 shrink-0" />
+        <span className="text-left sm:hidden">Search</span>
         <span className="hidden flex-1 text-left sm:inline">
-          Type{' '}
+          Search projects, issues, chapters
+        </span>
+        <span className="hidden items-center text-left text-slate-500 sm:inline-flex dark:text-slate-400">
           <kbd className="mx-1 rounded border border-slate-500/30 bg-transparent px-1.5 py-0.5 text-xs dark:border-slate-500/50 dark:bg-transparent">
             /
           </kbd>{' '}
-          to search
+          <span className="text-xs">shortcut</span>
         </span>
       </button>
 

--- a/frontend/src/server/fetchAlgoliaData.ts
+++ b/frontend/src/server/fetchAlgoliaData.ts
@@ -3,13 +3,20 @@ import type { AlgoliaResponse } from 'types/algolia'
 import { IDX_URL } from 'utils/env.client'
 import { getCsrfToken } from 'utils/utility'
 
+interface FetchAlgoliaDataOptions {
+  throwOnError?: boolean
+}
+
 export const fetchAlgoliaData = async <T>(
   indexName: string,
   query = '',
   currentPage = 0,
   hitsPerPage = 25,
-  facetFilters: string[] = []
+  facetFilters: string[] = [],
+  options: FetchAlgoliaDataOptions = {}
 ): Promise<AlgoliaResponse<T>> => {
+  const { throwOnError = true } = options
+
   try {
     if (['projects', 'chapters'].includes(indexName)) {
       facetFilters.push('idx_is_active:true')
@@ -36,6 +43,9 @@ export const fetchAlgoliaData = async <T>(
     })
 
     if (!response.ok) {
+      if (!throwOnError) {
+        return { hits: [], totalPages: 0 }
+      }
       throw new AppError(response.status, 'Search service error')
     }
 
@@ -51,6 +61,10 @@ export const fetchAlgoliaData = async <T>(
       return { hits: [], totalPages: 0 }
     }
   } catch (error) {
+    if (!throwOnError) {
+      return { hits: [], totalPages: 0 }
+    }
+
     if (error instanceof AppError) {
       throw error
     }


### PR DESCRIPTION
## Summary
This PR improves the discoverability of the global header search and prevents optional Algolia failures from breaking local development.

## Changes
- make the header search trigger more visible on mobile and desktop
- update the search trigger copy to better communicate what users can search
- make optional Algolia-backed chapter map requests fail gracefully on the home and chapters pages
- return an empty result set instead of throwing for non-critical local search failures

## Why
- improves first-click UX for new contributors
- makes the header search easier to notice, especially on mobile
- prevents local runtime crashes when Algolia search is unavailable

## Verification
- `docker exec nest-frontend pnpm test:unit -- --runInBand __tests__/unit/components/GlobalSearch.test.tsx __tests__/unit/components/Header.test.tsx`
  - both suites passed
  - repo-level coverage thresholds still make the command exit non-zero on partial test runs
- verified locally:
  - `http://localhost:3000/` -> 200
  - `http://localhost:3000/chapters` -> 200