### PR TITLE
fix(infra): Use backend image tag for release version

### DIFF
--- a/infrastructure/live/main.tf
+++ b/infrastructure/live/main.tf
@@ -167,7 +167,7 @@ module "parameters" {
   django_db_port                = var.db_port
   django_db_user                = var.db_user
   django_redis_host             = module.cache.redis_primary_endpoint
-  django_release_version        = var.django_release_version
+  django_release_version        = var.backend_image_tag
   django_settings_module        = var.django_settings_module
   enable_additional_parameters  = var.enable_additional_parameters
   environment                   = var.environment


### PR DESCRIPTION
## Summary

The staging `/status` endpoint was incorrectly displaying "staging" as the version instead of the actual release version. This was caused by the `RELEASE_VERSION` setting in Django not being populated correctly. The fix involves updating the Terraform configuration to use the `backend_image_tag` variable, which contains the correct version string, to set the release version for the backend service. This ensures the version reported by the API matches the deployed container image.

## Changes

- **infrastructure/live/main.tf**: Updated the `parameters` module to use `var.backend_image_tag` for the `django_release_version`. This ensures the backend service receives the correct version, aligning it with the deployed Docker image tag and fixing the `/status` endpoint on staging.

## Related Issue

Closes #4481

