### PR TITLE
feat(e2e): add Playwright smoke test for /community page

### DIFF
--- a/frontend/__tests__/e2e/pages/Community.spec.ts
+++ b/frontend/__tests__/e2e/pages/Community.spec.ts
@@ -1,0 +1,44 @@
+import { expectBreadCrumbsToBeVisible } from '@e2e/helpers/expects'
+import { test, expect } from '@playwright/test'
+
+test.describe('Community Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/community', { timeout: 25000 })
+  })
+
+  test('renders main heading and description', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'OWASP Community' })).toBeVisible()
+    await expect(
+      page.getByText('Explore the vibrant OWASP community', { exact: false })
+    ).toBeVisible()
+  })
+
+  test('renders explore resources section', async ({ page }) => {
+    await expect(page.getByText('Explore Resources')).toBeVisible()
+    await expect(page.getByRole('link', { name: /Chapters/i })).toBeVisible()
+    await expect(page.getByRole('link', { name: /Members/i })).toBeVisible()
+    await expect(page.getByRole('link', { name: /Organizations/i })).toBeVisible()
+  })
+
+  test('renders ways to engage section', async ({ page }) => {
+    await expect(page.getByText('Ways to Engage')).toBeVisible()
+  })
+
+  test('renders join slack section', async ({ page }) => {
+    const joinSlackLink = page.getByRole('link', { name: 'Join Slack' })
+    await expect(joinSlackLink).toBeVisible()
+    await expect(joinSlackLink).toHaveAttribute('href', 'https://owasp.org/slack/invite')
+    await expect(joinSlackLink).toHaveAttribute('target', '_blank')
+  })
+
+  test('renders call to action section', async ({ page }) => {
+    await expect(
+      page.getByRole('heading', { name: 'Ready to Get Involved?' })
+    ).toBeVisible()
+    await expect(page.getByRole('link', { name: 'contributing to a project' })).toBeVisible()
+  })
+
+  test('breadcrumb renders correct segments on /community', async ({ page }) => {
+    await expectBreadCrumbsToBeVisible(page, ['Home', 'Community'])
+  })
+})


### PR DESCRIPTION
## Summary

Closes #4403

- Adds a Playwright e2e smoke test for the `/community` route
- Follows existing test patterns in `__tests__/e2e/pages/` (e.g., `About.spec.ts`)
- Tests cover: main heading, Explore Resources links, Ways to Engage section, Join Slack CTA (href + target), call to action section, and breadcrumb navigation

## Test plan

- [ ] Run `npx playwright test Community.spec.ts` against a local dev server
- [ ] Verify all assertions pass on both Desktop Chrome and Mobile Safari (per `playwright.config.ts`)
- [ ] Confirm no console errors during page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)