### PR TITLE
fix: correct cursor display on non-interactive ChapterMap areas

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -471,4 +471,13 @@ select:disabled,
 
 .leaflet-container {
   background: transparent !important;
+  cursor: default !important;
+}
+
+.leaflet-container a,
+.leaflet-container button,
+.leaflet-container [role='button'],
+.leaflet-container .popup-content,
+.leaflet-container .leaflet-interactive {
+  cursor: pointer !important;
 }


### PR DESCRIPTION
## Summary

Closes #4419

- The global CSS rule `[tabindex]:not([tabindex='-1']) { cursor: pointer }` was causing a pointer cursor across the entire map because Leaflet sets `tabindex="0"` on its container for accessibility
- Added a targeted CSS override: `cursor: default` on `.leaflet-container`, with `cursor: pointer` restored only on interactive elements (links, buttons, `[role='button']`, `.popup-content`, `.leaflet-interactive`)
- CSS-only fix — no component changes needed

## Test plan

- [ ] Navigate to a page with the ChapterMap component
- [ ] Verify the cursor shows as default (arrow) when hovering over non-interactive map areas
- [ ] Verify the cursor shows as pointer when hovering over map pins/markers
- [ ] Verify the cursor shows as pointer when hovering over popup content and buttons
- [ ] Test in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)