### PR TITLE
fix: improve error handling in CalendarButton component

### DIFF
--- a/frontend/src/components/CalendarButton.tsx
+++ b/frontend/src/components/CalendarButton.tsx
@@ -41,8 +41,7 @@ export default function CalendarButton(props: Readonly<CalendarButtonProps>) {
         variant: 'solid',
       })
     } catch (err) {
-      // eslint-disable-next-line no-console
-      console.error('Failed to download ICS file:', err)
+      console.warn('Failed to download ICS file:', (err as Error)?.message)
       addToast({
         description: 'Failed to download ICS file',
         title: 'Download Failed',


### PR DESCRIPTION
## Summary

Closes #4399

- Replaced `console.error` with `console.warn` for download failure logging
- Removed the `// eslint-disable-next-line no-console` suppression comment
- Used `(err as Error)?.message` for safer, cleaner error output

## Test plan

- [ ] Trigger a download failure (e.g., by mocking `getIcsFileUrl` to throw)
- [ ] Verify `console.warn` is called with the error message string (not the full error object)
- [ ] Verify the toast notification still appears correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)