### PR TITLE
fix(ui): prevent OWASP logo from rotating with spinner

### DIFF
--- a/frontend/src/components/LoadingSpinner.tsx
+++ b/frontend/src/components/LoadingSpinner.tsx
@@ -12,10 +12,11 @@ const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({ imageUrl }) => {
 
   return (
     <div className="flex min-h-[60vh] items-center justify-center">
-      <div
-        className="animate-custom-spin relative h-16 w-16 rounded-full border-4 border-[#98AFC7] dark:border-white"
-        style={{ borderTopColor: 'transparent' }}
-      >
+      <div className="relative h-16 w-16">
+        <div
+          className="animate-custom-spin absolute inset-0 rounded-full border-4 border-[#98AFC7] dark:border-white"
+          style={{ borderTopColor: 'transparent' }}
+        />
         <div className="absolute inset-0 flex items-center justify-center">
           <div className="animate-fade-in-out">
             <Image


### PR DESCRIPTION
## Summary

Closes #4338

The OWASP logo was rotating together with the spinner ring because both were inside the same `animate-custom-spin` div. Per OWASP branding guidelines, the logo should not be altered in appearance.

**Fix:** Restructured `LoadingSpinner.tsx` so the spinning border ring and the static logo are sibling elements instead of parent-child. The ring uses absolute positioning and spins independently, while the logo remains centered and static (only fading in/out as before).

**Change:** 1 file, ~5 lines changed — pure structural adjustment, no new dependencies or CSS.

## Test plan

- [ ] Navigate to any page that shows the loading spinner
- [ ] Verify the border ring rotates while the OWASP logo stays static
- [ ] Verify the fade-in-out animation on the logo still works
- [ ] Test in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)