### PR TITLE
fix: improve error handling for missing Algolia configuration

### DIFF
--- a/backend/apps/core/api/internal/algolia.py
+++ b/backend/apps/core/api/internal/algolia.py
@@ -37,6 +37,18 @@ def algolia_search(request: HttpRequest) -> JsonResponse | HttpResponseNotAllowe
             status=HTTPStatus.METHOD_NOT_ALLOWED,
         )
 
+    if not getattr(settings, "ALGOLIA_APPLICATION_ID", None) or not getattr(
+        settings, "ALGOLIA_WRITE_API_KEY", None
+    ):
+        return JsonResponse(
+            {
+                "error": "Algolia is not configured. "
+                "Please set ALGOLIA_APPLICATION_ID and ALGOLIA_WRITE_API_KEY "
+                "environment variables."
+            },
+            status=HTTPStatus.SERVICE_UNAVAILABLE,
+        )
+
     try:
         data = json.loads(request.body)
 


### PR DESCRIPTION
## Summary

Closes #4107

When Algolia environment variables (`ALGOLIA_APPLICATION_ID`, `ALGOLIA_WRITE_API_KEY`) are missing or set to `None`, the backend previously threw a generic "An internal error occurred" message, which was confusing for developers setting up the project locally.

**Fix:** Added an explicit check at the top of `algolia_search()` that returns a clear 503 response: *"Algolia is not configured. Please set ALGOLIA_APPLICATION_ID and ALGOLIA_WRITE_API_KEY environment variables."*

**Change:** 1 file (`backend/apps/core/api/internal/algolia.py`), 12 lines added.

## Test plan

- [ ] Start the backend without Algolia env vars configured
- [ ] Make a POST request to the search endpoint
- [ ] Verify the response is 503 with the specific configuration error message
- [ ] Configure valid Algolia credentials and verify search works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)