### PR TITLE
feat(a11y): add skip-to-main-content link for keyboard accessibility

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -74,10 +74,16 @@ export default function RootLayout({
         <Providers>
           <BreadcrumbRoot>
             <div className="flex min-h-screen flex-col">
+              <a
+                href="#main-content"
+                className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-[100] focus:rounded-md focus:bg-white focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-blue-700 focus:shadow-lg focus:outline-none"
+              >
+                Skip to main content
+              </a>
               <AutoScrollToTop />
               <Header isGitHubAuthEnabled={IS_GITHUB_AUTH_ENABLED} />
               <BreadCrumbsWrapper />
-              <main className="flex flex-1 flex-col justify-center">{children}</main>
+              <main id="main-content" className="flex flex-1 flex-col justify-center">{children}</main>
               <Footer />
               <ScrollToTop />
             </div>


### PR DESCRIPTION
## Summary

Closes #4435

Adds a visually-hidden "Skip to main content" link that satisfies WCAG 2.4.1 (Bypass Blocks - Level A):

- Link is placed before the Header in `layout.tsx`, hidden with `sr-only`
- Becomes visible and focused when a keyboard user presses Tab
- Styled with a white background + shadow so it's clearly visible when focused
- Added `id="main-content"` to the `<main>` element as the skip target

**Change:** 1 file, 7 lines added.

## Test plan

- [ ] Load any page and press Tab — the "Skip to main content" link should appear
- [ ] Press Enter on the link — focus should jump to the main content area
- [ ] Verify the link is not visible during normal mouse navigation
- [ ] Test with a screen reader (VoiceOver/NVDA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)