### PR TITLE
fix: add backdrop overlay and body scroll lock to mobile menu

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -46,10 +46,17 @@ export default function Header({ isGitHubAuthEnabled }: { readonly isGitHubAuthE
       }
     }
 
+    if (mobileMenuOpen) {
+      document.body.style.overflow = 'hidden'
+    } else {
+      document.body.style.overflow = ''
+    }
+
     globalThis.addEventListener('resize', handleResize)
     globalThis.addEventListener('click', handleOutsideClick)
 
     return () => {
+      document.body.style.overflow = ''
       globalThis.removeEventListener('resize', handleResize)
       globalThis.removeEventListener('click', handleOutsideClick)
     }
@@ -147,6 +154,13 @@ export default function Header({ isGitHubAuthEnabled }: { readonly isGitHubAuthE
           </div>
         </div>
       </div>
+      {mobileMenuOpen && (
+        <div
+          className="fixed inset-0 z-40 bg-black/50 transition-opacity lg:hidden"
+          onClick={() => setMobileMenuOpen(false)}
+          aria-hidden="true"
+        />
+      )}
       <div
         className={cn(
           'bg-owasp-blue fixed inset-y-0 left-0 z-50 w-64 transform shadow-md transition-transform dark:bg-slate-800',


### PR DESCRIPTION
## Summary

Closes #4423

- Added a semi-transparent black backdrop (`bg-black/50`) behind the mobile sidebar that closes the menu when clicked
- Added body scroll lock (`overflow: hidden`) when the mobile menu is open, cleaned up on close/unmount
- Backdrop is only rendered on mobile (`lg:hidden`) and uses `aria-hidden="true"`

**Change:** 1 file (`Header.tsx`), 14 lines added.

## Test plan

- [ ] Open the site on mobile or Chrome DevTools mobile view
- [ ] Open the side navigation menu
- [ ] Verify a dark backdrop overlay appears behind the sidebar
- [ ] Verify the background page cannot be scrolled while the menu is open
- [ ] Click the backdrop — menu should close
- [ ] Verify scroll is restored after closing the menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)