### PR TITLE
fix: resolve mobile sidebar bottom gap when scrolling

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -149,11 +149,11 @@ export default function Header({ isGitHubAuthEnabled }: { readonly isGitHubAuthE
       </div>
       <div
         className={cn(
-          'bg-owasp-blue fixed inset-y-0 left-0 z-50 w-64 transform shadow-md transition-transform dark:bg-slate-800',
+          'bg-owasp-blue fixed top-0 left-0 z-50 h-dvh w-64 transform shadow-md transition-transform dark:bg-slate-800',
           mobileMenuOpen ? 'translate-x-0' : '-translate-x-full'
         )}
       >
-        <div className="flex h-full flex-col justify-between gap-1 px-2 pt-2 pb-3">
+        <div className="flex h-full flex-col justify-between gap-1 overflow-y-auto px-2 pt-2 pb-3">
           {/* Logo */}
           <div className="flex flex-col justify-center gap-5">
             <Link


### PR DESCRIPTION
## Summary

Closes #4353

The mobile sidebar used `inset-y-0` which relies on viewport height (`100vh`). On mobile browsers with dynamic address bars (Chrome, Safari), `100vh` doesn't match the actual visible viewport, causing a gap at the bottom.

- Replaced `inset-y-0` with `top-0` + `h-dvh` (dynamic viewport height) so the sidebar correctly fills the visible area
- Added `overflow-y-auto` to the inner container so content scrolls properly if it exceeds viewport height

**Change:** 1 file (`Header.tsx`), 2 lines changed.

## Test plan

- [ ] Open the site on a mobile device (or Chrome DevTools mobile)
- [ ] Open the sidebar navigation menu
- [ ] Scroll down — verify no gap appears at the bottom of the sidebar
- [ ] Test on iOS Safari and Android Chrome where dynamic address bars are common

🤖 Generated with [Claude Code](https://claude.com/claude-code)