### PR TITLE
Fix ChapterMap cursor on non-interactive map areas

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -471,4 +471,16 @@ select:disabled,
 
 .leaflet-container {
   background: transparent !important;
+  cursor: default !important;
+}
+
+.leaflet-container a,
+.leaflet-container button,
+.leaflet-container [role='button'] {
+  cursor: pointer !important;
+}
+
+.leaflet-container.leaflet-drag-target {
+  cursor: move !important;
+  cursor: grabbing !important;
 }


### PR DESCRIPTION
## Summary
- Reset cursor to `default` on `.leaflet-container` to prevent the pointer cursor from appearing across the entire map surface
- Only apply `cursor: pointer` to actual interactive elements (links, buttons, `[role='button']`) within the map
- Add `cursor: grabbing` for active drag operations

The root cause was the global CSS rule applying `cursor: pointer` to broad selectors like `[tabindex]:not([tabindex='-1'])`, which matched the Leaflet map container.

Closes #4419

## Test plan
- [ ] Navigate to a page with the ChapterMap component
- [ ] Verify cursor shows as default arrow when hovering over non-interactive map areas
- [ ] Verify cursor shows as pointer when hovering over map pins and popup links
- [ ] Verify cursor changes to grabbing when dragging the map

🤖 Generated with [Claude Code](https://claude.com/claude-code)