### PR TITLE
Improve error handling for missing Algolia configuration

### DIFF
--- a/backend/apps/core/api/internal/algolia.py
+++ b/backend/apps/core/api/internal/algolia.py
@@ -37,6 +37,12 @@ def algolia_search(request: HttpRequest) -> JsonResponse | HttpResponseNotAllowe
             status=HTTPStatus.METHOD_NOT_ALLOWED,
         )
 
+    if not settings.ALGOLIA_APPLICATION_ID or not settings.ALGOLIA_WRITE_API_KEY:
+        return JsonResponse(
+            {"error": "Algolia is not configured. Please check your environment variables."},
+            status=HTTPStatus.SERVICE_UNAVAILABLE,
+        )
+
     try:
         data = json.loads(request.body)
 

--- a/frontend/src/server/fetchAlgoliaData.ts
+++ b/frontend/src/server/fetchAlgoliaData.ts
@@ -36,7 +36,9 @@ export const fetchAlgoliaData = async <T>(
     })
 
     if (!response.ok) {
-      throw new AppError(response.status, 'Search service error')
+      const errorData = await response.json().catch(() => null)
+      const message = errorData?.error || 'Search service error'
+      throw new AppError(response.status, message)
     }
 
     const results = await response.json()


### PR DESCRIPTION
## Summary
- Add explicit validation of `ALGOLIA_APPLICATION_ID` and `ALGOLIA_WRITE_API_KEY` in the search endpoint before attempting API calls
- Return a clear 503 response with message: "Algolia is not configured. Please check your environment variables." when env vars are missing
- Update frontend `fetchAlgoliaData` to parse and pass through specific backend error messages instead of always showing generic "Search service error"

This helps contributors setting up the project locally understand that the issue is a missing configuration, not a runtime bug.

Closes #4107

## Test plan
- [ ] Remove Algolia env vars and trigger a search — verify the specific error message is shown
- [ ] With valid Algolia env vars, verify search still works normally
- [ ] Verify backend returns 503 status when Algolia is not configured
- [ ] Verify frontend displays the backend's error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)