### PR TITLE
Add Playwright smoke tests for /community pages

### DIFF
--- a/frontend/__tests__/e2e/pages/Community.spec.ts
+++ b/frontend/__tests__/e2e/pages/Community.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Community Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/community', { timeout: 25000 })
+  })
+
+  test('renders main heading and description', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'OWASP Community' })).toBeVisible()
+    await expect(page.getByText('Explore the vibrant OWASP community')).toBeVisible()
+  })
+
+  test('renders explore resources section', async ({ page }) => {
+    await expect(page.getByText('Explore Resources')).toBeVisible()
+  })
+
+  test('renders ways to engage section', async ({ page }) => {
+    await expect(page.getByText('Ways to Engage')).toBeVisible()
+  })
+
+  test('renders call to action section', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Ready to Get Involved?' })).toBeVisible()
+  })
+
+  test('renders join slack link', async ({ page }) => {
+    await expect(page.getByRole('link', { name: 'Join Slack' })).toBeVisible()
+  })
+
+  test('renders navigation links to community sections', async ({ page }) => {
+    await expect(page.getByRole('link', { name: 'Chapters' }).first()).toBeVisible()
+    await expect(page.getByRole('link', { name: 'Members' }).first()).toBeVisible()
+    await expect(page.getByRole('link', { name: 'Organizations' }).first()).toBeVisible()
+  })
+
+  test('has no console errors', async ({ page }) => {
+    const errors: string[] = []
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        errors.push(msg.text())
+      }
+    })
+    await page.goto('/community', { timeout: 25000 })
+    expect(errors).toHaveLength(0)
+  })
+})
+
+test.describe('Community Snapshots Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/community/snapshots', { timeout: 25000 })
+  })
+
+  test('renders snapshots page without crashing', async ({ page }) => {
+    await expect(page.locator('body')).toBeVisible()
+  })
+})


### PR DESCRIPTION
## Summary
- Add e2e smoke specs for `/community` and `/community/snapshots` routes
- Tests verify: main heading, key sections (Explore Resources, Ways to Engage, call to action), navigation links, Join Slack link, and absence of console errors
- Follows existing test patterns in `__tests__/e2e/pages/`

Closes #4403

## Test plan
- [ ] Run `npx playwright test Community.spec.ts` and verify all tests pass
- [ ] Verify test file follows the project's existing e2e test conventions
- [ ] Confirm tests cover the main heading, landmark sections, and no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)