### PR TITLE
feat(member-snapshot): add total_platform_contributions property

### DIFF
--- a/backend/apps/owasp/api/internal/nodes/member_snapshot.py
+++ b/backend/apps/owasp/api/internal/nodes/member_snapshot.py
@@ -52,3 +52,8 @@ class MemberSnapshotNode(strawberry.relay.Node):
     def total_contributions(self, root: MemberSnapshot) -> int:
         """Resolve total contributions."""
         return root.total_contributions
+
+    @strawberry_django.field
+    def total_platform_contributions(self, root: MemberSnapshot) -> int:
+        """Resolve total contributions across all tracked platforms."""
+        return root.total_platform_contributions

--- a/backend/apps/owasp/models/member_snapshot.py
+++ b/backend/apps/owasp/models/member_snapshot.py
@@ -132,3 +132,12 @@ class MemberSnapshot(TimestampedModel):
     def total_contributions(self) -> int:
         """Return the total number of GitHub contributions in this snapshot."""
         return self.commits_count + self.pull_requests_count + self.issues_count
+
+    @property
+    def total_platform_contributions(self) -> int:
+        """Return the total number of contributions across all tracked platforms.
+
+        Combines GitHub contributions (commits, pull requests, issues) with
+        Slack messages to provide a unified cross-platform contribution count.
+        """
+        return self.total_contributions + self.messages_count

--- a/backend/tests/unit/apps/owasp/api/internal/nodes/member_snapshot_test.py
+++ b/backend/tests/unit/apps/owasp/api/internal/nodes/member_snapshot_test.py
@@ -26,6 +26,7 @@ class TestMemberSnapshotNode(GraphQLNodeBaseTest):
         assert "issues_count" in field_names
         assert "messages_count" in field_names
         assert "total_contributions" in field_names
+        assert "total_platform_contributions" in field_names
 
     def test_commits_count_resolver(self):
         """Test commits_count returns count from snapshot."""
@@ -87,3 +88,13 @@ class TestMemberSnapshotNode(GraphQLNodeBaseTest):
         result = field.base_resolver.wrapped_func(None, mock_snapshot)
 
         assert result == 80
+
+    def test_total_platform_contributions_resolver(self):
+        """Test total_platform_contributions returns cross-platform total from snapshot."""
+        mock_snapshot = Mock()
+        mock_snapshot.total_platform_contributions = 100
+
+        field = self._get_field_by_name("total_platform_contributions", MemberSnapshotNode)
+        result = field.base_resolver.wrapped_func(None, mock_snapshot)
+
+        assert result == 100

--- a/backend/tests/unit/apps/owasp/models/member_snapshot_test.py
+++ b/backend/tests/unit/apps/owasp/models/member_snapshot_test.py
@@ -57,6 +57,7 @@ class TestMemberSnapshotModel:
         assert hasattr(MemberSnapshot, "issues_count")
         assert hasattr(MemberSnapshot, "messages_count")
         assert hasattr(MemberSnapshot, "total_contributions")
+        assert hasattr(MemberSnapshot, "total_platform_contributions")
 
     def test_total_contributions_excludes_messages(self):
         """Test that total_contributions only includes GitHub contributions."""
@@ -285,3 +286,29 @@ class TestMemberSnapshotModel:
             result = snapshot.messages_count
         assert result == 15
         mock_manager.count.assert_called_once()
+
+    def test_total_platform_contributions_property(self):
+        """Test total_platform_contributions sums GitHub and Slack contributions."""
+        user = User(login="testuser")
+        snapshot = MemberSnapshot(
+            github_user=user,
+            start_at=datetime(2025, 1, 1, tzinfo=UTC),
+            end_at=datetime(2025, 1, 31, tzinfo=UTC),
+        )
+        snapshot.id = 1
+
+        with (
+            patch.object(
+                type(snapshot), "commits_count", new_callable=PropertyMock, return_value=10
+            ),
+            patch.object(
+                type(snapshot), "pull_requests_count", new_callable=PropertyMock, return_value=5
+            ),
+            patch.object(
+                type(snapshot), "issues_count", new_callable=PropertyMock, return_value=3
+            ),
+            patch.object(
+                type(snapshot), "messages_count", new_callable=PropertyMock, return_value=20
+            ),
+        ):
+            assert snapshot.total_platform_contributions == 38


### PR DESCRIPTION
Closes #4208

## What Does This PR Do

- Adds total_platform_contributions property to the MemberSnapshot model
- Combines GitHub contributions (commits, pull requests, issues) with Slack messages into a single unified count
- Exposes the new property via the MemberSnapshotNode GraphQL API
- Adds unit tests for the model property and the GraphQL resolver

## Root Cause

- MemberSnapshot.total_contributions only counts GitHub activity (commits + PRs + issues)
- Slack messages were already tracked in the messages M2M field with messages_count, but no unified cross-platform total existed
- This left a gap: no single field represented all tracked contribution sources

## Changes

- backend/apps/owasp/models/member_snapshot.py - new total_platform_contributions property
- backend/apps/owasp/api/internal/nodes/member_snapshot.py - new total_platform_contributions GraphQL resolver
- backend/tests/unit/apps/owasp/models/member_snapshot_test.py - test for new property and hasattr assertion
- backend/tests/unit/apps/owasp/api/internal/nodes/member_snapshot_test.py - test for new resolver and field presence

## Expected Impact

| Area | Before | After |
|---|---|---|
| Cross-platform total | No unified field | total_platform_contributions = GitHub + Slack |
| total_contributions | Unchanged (GitHub only) | Unchanged, no regression |
| GraphQL API | Only total_contributions exposed | Both fields available |
| DB schema | N/A | No migration needed (pure property) |

## Type of Change

- New feature (non-breaking addition)

## Checklist

- [x] Changes are additive, no existing behaviour modified
- [x] Unit tests added for model property and GraphQL resolver
- [x] No database migration required
- [x] Existing test_total_contributions_excludes_messages still passes