### PR TITLE
fix: prevent tooltip collision for contributors across multiple projects

### DIFF
--- a/frontend/src/components/ContributorList.tsx
+++ b/frontend/src/components/ContributorList.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+
+export interface Contributor {
+  id: string | number;
+  login: string;
+  avatar_url: string;
+  html_url: string;
+  name?: string;
+}
+
+export interface ContributorListProps {
+  projectId: string | number;
+  contributors: Contributor[];
+}
+
+const ContributorList: React.FC<ContributorListProps> = ({ projectId, contributors }) => {
+  if (!contributors || contributors.length === 0) {
+    return null;
+  }
+
+  return (
+    <ul className="flex flex-wrap items-center gap-2 m-0 p-0 list-none">
+      {contributors.map((contributor, index) => {
+        // Fix for Issue #1065: Tooltip Collision for Contributors Across Multiple Projects
+        // Strategy: Extend the unique key for contributor tooltips to include the project identifier
+        const tooltipId = `tooltip-${projectId}-contributor-${contributor.id}-${index}`;
+        const displayName = contributor.name || contributor.login;
+
+        return (
+          <li key={tooltipId} className="relative group">
+            <a
+              href={contributor.html_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="block focus:outline-none focus:ring-2 focus:ring-blue-500 rounded-full"
+              data-tooltip-id={tooltipId}
+              aria-describedby={tooltipId}
+            >
+              <img
+                src={contributor.avatar_url}
+                alt={`${displayName}'s avatar`}
+                className="w-8 h-8 rounded-full border border-gray-200 object-cover hover:border-blue-500 transition-colors"
+                loading="lazy"
+              />
+            </a>
+            {/* Tooltip element */}
+            <div
+              id={tooltipId}
+              role="tooltip"
+              className="invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100 transition-opacity absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-2 py-1 bg-gray-800 text-white text-xs rounded whitespace-nowrap z-50 pointer-events-none"
+            >
+              {displayName}
+              {/* Tooltip arrow */}
+              <div className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-gray-800"></div>
+            </div>
+          </li>
+        );
+      })}
+    </ul>
+  );
+};
+
+export default ContributorList;

--- a/frontend/src/components/Contributors.tsx
+++ b/frontend/src/components/Contributors.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+
+export interface Contributor {
+  id?: string | number;
+  login?: string;
+  name?: string;
+  avatar_url?: string;
+  html_url?: string;
+  profile_url?: string;
+}
+
+export interface ContributorsProps {
+  contributors: Contributor[];
+  projectId: string | number;
+}
+
+const Contributors: React.FC<ContributorsProps> = ({ contributors, projectId }) => {
+  if (!contributors || !Array.isArray(contributors) || contributors.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {contributors.map((contributor, index) => {
+        // Strategy: Extend the unique key for contributor tooltips to include the project identifier
+        // to prevent collisions when the same contributor appears in multiple projects on the same page.
+        const identifier = contributor.id || contributor.login || index;
+        const uniqueKey = `project-${projectId}-contributor-${identifier}-pos-${index}`;
+        const tooltipId = `tooltip-${uniqueKey}`;
+        
+        const displayName = contributor.name || contributor.login || 'Contributor';
+        const profileUrl = contributor.html_url || contributor.profile_url || '#';
+
+        return (
+          <div key={uniqueKey} className="relative group flex items-center justify-center">
+            <a
+              href={profileUrl}
+              target={profileUrl !== '#' ? '_blank' : undefined}
+              rel={profileUrl !== '#' ? 'noopener noreferrer' : undefined}
+              className="inline-block transition-transform hover:scale-110 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded-full"
+              aria-describedby={tooltipId}
+            >
+              {contributor.avatar_url ? (
+                <img
+                  src={contributor.avatar_url}
+                  alt={displayName}
+                  className="w-8 h-8 rounded-full border border-gray-200 shadow-sm object-cover bg-white"
+                  loading="lazy"
+                />
+              ) : (
+                <div className="w-8 h-8 rounded-full bg-gray-200 border border-gray-300 shadow-sm flex items-center justify-center text-gray-700 text-xs font-semibold">
+                  {displayName.charAt(0).toUpperCase()}
+                </div>
+              )}
+            </a>
+            
+            {/* Tooltip */}
+            <div
+              id={tooltipId}
+              role="tooltip"
+              className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none z-50 px-2.5 py-1 text-xs font-medium text-white bg-gray-900 rounded-md shadow-sm whitespace-nowrap"
+            >
+              {displayName}
+              <div className="absolute top-full left-1/2 transform -translate-x-1/2 -mt-px border-4 border-transparent border-t-gray-900"></div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default Contributors;


### PR DESCRIPTION
Closes #1065

## Summary
Extend the unique key for contributor tooltips to include the project identifier to prevent collisions when the same contributor appears in multiple projects on the same page.

## Changes
- `frontend/src/components/Contributors.tsx`
- `frontend/src/components/ContributorList.tsx`