### PR TITLE
ci: add pre-commit ecosystem support for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -74,3 +74,17 @@ updates:
     schedule:
       interval: daily
     target-branch: main
+
+  - package-ecosystem: pre-commit   
+    cooldown:
+      default-days: 21
+    directories:
+      - /
+    groups:
+      version-updates:
+        applies-to: version-updates
+        patterns:
+          - '*'
+    schedule:
+      interval: daily
+    target-branch: main              

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -75,7 +75,7 @@ updates:
       interval: daily
     target-branch: main
 
-  - package-ecosystem: pre-commit   
+  - package-ecosystem: pre-commit
     cooldown:
       default-days: 21
     directories:
@@ -83,8 +83,9 @@ updates:
     groups:
       version-updates:
         applies-to: version-updates
+        group-by: dependency-name
         patterns:
           - '*'
     schedule:
       interval: daily
-    target-branch: main              
+    target-branch: main


### PR DESCRIPTION
Resolves #4523

Added `pre-commit` ecosystem entry to `.github/dependabot.yml` so that 
Dependabot automatically opens PRs when pre-commit hook versions are outdated, 
eliminating the need for manual version bumps.

Follows the same conventions as all existing ecosystem entries (cooldown, 
grouping, schedule, target-branch).

## Checklist
- [x] **Required:** I followed the contributing workflow
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [ ] I used AI for code, documentation, tests, or communication related to this PR