### PR TITLE
Pin .pre-commit-config.yaml hook versions to immutable SHAs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/AleksaC/hadolint-py
-    rev: v2.14.0
+    rev: 458cb25edf664682e3e856a53a2f9af33e068297
     hooks:
       - id: hadolint
         args:
@@ -8,7 +8,7 @@ repos:
         name: hadolint
 
   - repo: https://github.com/EbodShojaei/bake
-    rev: v1.4.6
+    rev: a39df91c8e2c8ee584f81ff8d7d00f137a5fc160
     hooks:
       - id: mbake-format
         args:
@@ -21,7 +21,7 @@ repos:
         exclude: ^backend/
 
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.38.0
+    rev: cba56bcde1fdd01c1deb3f945e69764c291a6530
     hooks:
       - id: yamllint
         args:
@@ -31,7 +31,7 @@ repos:
         exclude: pnpm-lock.yaml
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.105.0
+    rev: d0e12caebb2ab0ee8bf98181c8bfe9702bca103d
     hooks:
       - id: terraform_fmt
         files: ^infrastructure/.*\.(tf|tftest\.hcl)$
@@ -41,7 +41,7 @@ repos:
           - --args=--config=__GIT_WORKING_DIR__/infrastructure/.tflint.hcl
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.8
+    rev: aca6d4c8045a504e2812ea4bedff1d0a09e437bc
     hooks:
       - id: ruff-check
         args:
@@ -49,7 +49,7 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/djlint/djLint
-    rev: v1.36.4
+    rev: 9112cb64851c95a7802358af285d21ad8b7f6437
     hooks:
       - id: djlint-reformat-django
         files: templates/.*.html
@@ -58,7 +58,7 @@ repos:
           - html
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.48.0
+    rev: e72a3ca1632f0b11a07d171449fe447a7ff6795e
     hooks:
       - id: markdownlint
         args:
@@ -66,7 +66,7 @@ repos:
         files: \.md$
 
   - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
-    rev: 0.2.3
+    rev: 8d1b9cadaf854cb25bb0b0f5870e1cc66a083d6b
     hooks:
       - id: yamlfmt
         args:
@@ -77,7 +77,7 @@ repos:
         exclude: (pnpm-lock.yaml|\.yamllint)
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.20.0
+    rev: 8e5c80792e2ec0c87804d8ef915bf35e2caea6da
     hooks:
       - id: mypy
         additional_dependencies:
@@ -91,7 +91,7 @@ repos:
           - backend/pyproject.toml
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c
     hooks:
       - id: check-ast
       - id: check-builtin-literals
@@ -123,6 +123,6 @@ repos:
         exclude: pnpm-lock.yaml
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: v2.21.0
+    rev: 6e10264313f53d6247a8b1b984f5b5ccf50ba539
     hooks:
       - id: pyproject-fmt


### PR DESCRIPTION
## Summary

Pins all 11 pre-commit hooks in `.pre-commit-config.yaml` to their immutable commit SHAs instead of version tags, as requested in #4527.

## Changes

| Hook | Tag | SHA |
|------|-----|-----|
| hadolint-py | v2.14.0 | `458cb25e` |
| bake | v1.4.6 | `a39df91c` |
| yamllint | v1.38.0 | `cba56bcd` |
| pre-commit-terraform | v1.105.0 | `d0e12cae` |
| ruff-pre-commit | v0.15.8 | `aca6d4c8` |
| djLint | v1.36.4 | `9112cb64` |
| markdownlint-cli | v0.48.0 | `e72a3ca1` |
| pre-commit-hook-yamlfmt | 0.2.3 | `8d1b9cad` |
| mirrors-mypy | v1.20.0 | `8e5c8079` |
| pre-commit-hooks | v6.0.0 | `3e8a8703` |
| pyproject-fmt | v2.21.0 | `6e102643` |

## Verification

Each SHA was resolved by querying the Git ref API for the corresponding tag. All SHAs are 40-character commit hashes matching the intended tagged releases.

Closes #4527