### PR TITLE
Unexpected await of non promise

### DIFF
--- a/frontend/__tests__/unit/pages/ProgramDetailsMentorship.test.tsx
+++ b/frontend/__tests__/unit/pages/ProgramDetailsMentorship.test.tsx
@@ -319,7 +319,7 @@ describe('ProgramDetailsPage', () => {
     })
 
     if (capturedSetStatus) {
-      await capturedSetStatus(ProgramStatusEnum.Published)
+      capturedSetStatus(ProgramStatusEnum.Published)
     }
 
     await waitFor(() => {
@@ -358,7 +358,7 @@ describe('ProgramDetailsPage', () => {
     })
 
     if (capturedSetStatus) {
-      await capturedSetStatus(ProgramStatusEnum.Published)
+      capturedSetStatus(ProgramStatusEnum.Published)
     }
 
     await waitFor(() => {


### PR DESCRIPTION
## Description
Resolve : #4507

This PR addresses SonarCloud rule `typescript:S4123`. There was Unexpected `await` of a non-Promise (non-"Thenable") value.
So, removed unexpected await from capturedSetStatus since it is a synchronous function and does not return a Promise.


## File Changed :

frontend/__tests__/unit/pages/ProgramDetailsMentorship.test.tsx

## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [ ] I used AI for code, documentation, tests, or communication related to this PR