### PR TITLE
Remove unnecessay assertions

### DIFF
--- a/frontend/__tests__/unit/components/MetricsPDFButton.test.tsx
+++ b/frontend/__tests__/unit/components/MetricsPDFButton.test.tsx
@@ -38,7 +38,7 @@ describe('MetricsPDFButton', () => {
     const icon = screen.getByTestId('tooltip').querySelector('svg')
     expect(icon).toBeInTheDocument()
 
-    fireEvent.click(icon!)
+    fireEvent.click(icon)
 
     await waitFor(() => {
       expect(mockFetchMetricsPDF).toHaveBeenCalledWith('/api/metrics', 'metrics.pdf')
@@ -51,7 +51,7 @@ describe('MetricsPDFButton', () => {
     render(<MetricsPDFButton path="/custom/path" fileName="custom-file.pdf" />)
 
     const icon = screen.getByTestId('tooltip').querySelector('svg')
-    fireEvent.click(icon!)
+    fireEvent.click(icon)
 
     await waitFor(() => {
       expect(mockFetchMetricsPDF).toHaveBeenCalledWith('/custom/path', 'custom-file.pdf')

--- a/frontend/__tests__/unit/components/RepositoryCard.test.tsx
+++ b/frontend/__tests__/unit/components/RepositoryCard.test.tsx
@@ -354,7 +354,7 @@ describe('RepositoryCard', () => {
       render(<RepositoryCard repositories={repositories} />)
 
       const repositoryButton = screen.getByText('Repository 0').closest('button')
-      fireEvent.keyDown(repositoryButton!, { key: 'Enter' })
+      fireEvent.keyDown(repositoryButton, { key: 'Enter' })
 
       expect(mockPush).toHaveBeenCalledWith('/organizations/org-0/repositories/repo-0')
     })
@@ -365,7 +365,7 @@ describe('RepositoryCard', () => {
       render(<RepositoryCard repositories={repositories} />)
 
       const repositoryButton = screen.getByText('Repository 0').closest('button')
-      fireEvent.keyDown(repositoryButton!, { key: ' ' })
+      fireEvent.keyDown(repositoryButton, { key: ' ' })
 
       expect(mockPush).toHaveBeenCalledWith('/organizations/org-0/repositories/repo-0')
     })
@@ -376,9 +376,9 @@ describe('RepositoryCard', () => {
       render(<RepositoryCard repositories={repositories} />)
 
       const repositoryButton = screen.getByText('Repository 0').closest('button')
-      fireEvent.keyDown(repositoryButton!, { key: 'Tab' })
-      fireEvent.keyDown(repositoryButton!, { key: 'Escape' })
-      fireEvent.keyDown(repositoryButton!, { key: 'a' })
+      fireEvent.keyDown(repositoryButton, { key: 'Tab' })
+      fireEvent.keyDown(repositoryButton, { key: 'Escape' })
+      fireEvent.keyDown(repositoryButton, { key: 'a' })
 
       expect(mockPush).not.toHaveBeenCalled()
     })

--- a/frontend/__tests__/unit/components/UserMenu.test.tsx
+++ b/frontend/__tests__/unit/components/UserMenu.test.tsx
@@ -326,7 +326,7 @@ describe('UserMenu Component', () => {
       const dropdown = document.getElementById(dropdownId)
       expect(dropdown).toBeInTheDocument()
 
-      fireEvent.mouseDown(dropdown!)
+      fireEvent.mouseDown(dropdown)
 
       await waitFor(() => {
         expect(avatarButton).toHaveAttribute('aria-expanded', 'true')

--- a/frontend/__tests__/unit/components/UserMenu.test.tsx
+++ b/frontend/__tests__/unit/components/UserMenu.test.tsx
@@ -323,7 +323,7 @@ describe('UserMenu Component', () => {
       })
 
       const dropdownId = avatarButton.getAttribute('aria-controls')
-      const dropdown = document.getElementById(dropdownId!)
+      const dropdown = document.getElementById(dropdownId)
       expect(dropdown).toBeInTheDocument()
 
       fireEvent.mouseDown(dropdown!)

--- a/frontend/__tests__/unit/components/forms/shared/FormContainer.test.tsx
+++ b/frontend/__tests__/unit/components/forms/shared/FormContainer.test.tsx
@@ -32,7 +32,7 @@ describe('FormContainer', () => {
     const { container } = render(<FormContainer {...defaultProps} />)
     const form = container.querySelector('form')
 
-    fireEvent.submit(form!)
+    fireEvent.submit(form)
     expect(mockOnSubmit).toHaveBeenCalledTimes(1)
   })
 

--- a/frontend/__tests__/unit/pages/CreateProgram.test.tsx
+++ b/frontend/__tests__/unit/pages/CreateProgram.test.tsx
@@ -254,7 +254,7 @@ describe('CreateProgramPage (comprehensive tests)', () => {
       target: { value: '2025-12-31' },
     })
 
-    fireEvent.submit(screen.getByText('Save').closest('form')!)
+    fireEvent.submit(screen.getByText('Save').closest('form'))
 
     await waitFor(() => {
       expect(addToast).toHaveBeenCalledWith(

--- a/frontend/__tests__/unit/pages/Header.test.tsx
+++ b/frontend/__tests__/unit/pages/Header.test.tsx
@@ -405,7 +405,7 @@ describe('Header Component', () => {
       // Assert that mobileLogoLink is not null before clicking
       expect(mobileLogoLink).toBeDefined()
       await act(async () => {
-        fireEvent.click(mobileLogoLink!)
+        fireEvent.click(mobileLogoLink)
       })
       expect(isMobileMenuClosed()).toBe(true)
     })
@@ -430,7 +430,7 @@ describe('Header Component', () => {
 
       expect(desktopLogoLink).toBeDefined()
       await act(async () => {
-        fireEvent.click(desktopLogoLink!)
+        fireEvent.click(desktopLogoLink)
       })
       expect(isMobileMenuClosed()).toBe(true)
     })


### PR DESCRIPTION
## Description 

Resolve : #4557

This PR addresses SonarCloud rule `typescript:S4325` Redundant casts and non-null assertions should be avoided. So, Removed `unnecessary assertions (!)` where functions accept the original type.

## Example
```tsx
fireEvent.click(mobileLogoLink!)  // before
fireEvent.click(mobileLogoLink)   // after
```

## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran `make check-test` and `npm run lint` locally: all warnings addressed, tests passed
- [ ] I used AI for code, documentation, tests, or communication related to this PR
