### PR TITLE
bypass poetry as dependency by running it inside nest-backend docker container . changes /bin/bash to /bin/sh to ensure it works on NixOS

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -97,7 +97,10 @@ dump-data: ## Write masked database dump to backend/data/nest.dump (no S3 upload
 	@CMD="python manage.py dump_data" $(MAKE) exec-backend-command-it
 
 upload-nest-dump: ## Upload backend/data/nest.dump to shared S3 (host AWS creds; poetry run)
-	@cd backend && poetry run python -m scripts.upload_nest_dump
+	@echo "updating data inside docker container 'nest-backend'"
+	@docker compose -f docker-compose/local/compose.yaml --project-name nest-local exec backend poetry run python -m scripts.upload_nest_dump
+	@echo "Check if it worked"
+	@ls -l backend/data
 
 enrich-data: ## Enrich data from external sources
 enrich-data: \

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -97,8 +97,8 @@ dump-data: ## Write masked database dump to backend/data/nest.dump (no S3 upload
 	@CMD="python manage.py dump_data" $(MAKE) exec-backend-command-it
 
 upload-nest-dump: ## Upload backend/data/nest.dump to shared S3 (host AWS creds; poetry run)
-	@echo "updating nest.dump"
-	@CMD="poetry run python -m scripts.update_nest_dump" $(MAKE) exec-backend-command
+	@echo "uploading nest.dump"
+	@CMD="poetry run python -m scripts.upload_nest_dump" $(MAKE) exec-backend-command
 
 enrich-data: ## Enrich data from external sources
 enrich-data: \

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -117,7 +117,13 @@ index-data: ## Index data for Algolia search
 	@CMD="python manage.py algolia_update_synonyms" $(MAKE) exec-backend-command
 
 fetch-nest-dump: ## Download backend/data/nest.dump from S3 if the remote copy changed
-	@cd backend && poetry run python -m scripts.fetch_nest_dump
+	# @cd backend && poetry run python -m scripts.fetch_nest_dump
+	@echo "changing permission of /backend/data"
+	@chmod 757 backend/data
+	@echo "fetching data inside docker container `nest-backend`"
+	@docker compose --project-name nest-local exec backend poetry run python -m scripts.fetch_nest_dump
+	@echo "Check if it worked"
+	@ls -l backend/data
 
 load-data: fetch-nest-dump ## Load initial data from fixtures
 	@echo "Loading Nest data"

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -117,11 +117,8 @@ index-data: ## Index data for Algolia search
 	@CMD="python manage.py algolia_update_synonyms" $(MAKE) exec-backend-command
 
 fetch-nest-dump: ## Download backend/data/nest.dump from S3 if the remote copy changed
-	# @cd backend && poetry run python -m scripts.fetch_nest_dump
-	@echo "changing permission of /backend/data"
-	@chmod 757 backend/data
-	@echo "fetching data inside docker container `nest-backend`"
-	@docker compose --project-name nest-local exec backend poetry run python -m scripts.fetch_nest_dump
+	@echo "fetching data inside docker container 'nest-backend'"
+	@docker compose -f docker-compose/local/compose.yaml --project-name nest-local exec backend poetry run python -m scripts.fetch_nest_dump
 	@echo "Check if it worked"
 	@ls -l backend/data
 

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -97,10 +97,8 @@ dump-data: ## Write masked database dump to backend/data/nest.dump (no S3 upload
 	@CMD="python manage.py dump_data" $(MAKE) exec-backend-command-it
 
 upload-nest-dump: ## Upload backend/data/nest.dump to shared S3 (host AWS creds; poetry run)
-	@echo "updating data inside docker container 'nest-backend'"
-	@docker compose -f docker-compose/local/compose.yaml --project-name nest-local exec backend poetry run python -m scripts.upload_nest_dump
-	@echo "Check if it worked"
-	@ls -l backend/data
+	@echo "updating nest.dump"
+	@CMD="poetry run python -m scripts.update_nest_dump" $(MAKE) exec-backend-command
 
 enrich-data: ## Enrich data from external sources
 enrich-data: \
@@ -120,10 +118,8 @@ index-data: ## Index data for Algolia search
 	@CMD="python manage.py algolia_update_synonyms" $(MAKE) exec-backend-command
 
 fetch-nest-dump: ## Download backend/data/nest.dump from S3 if the remote copy changed
-	@echo "fetching data inside docker container 'nest-backend'"
-	@docker compose -f docker-compose/local/compose.yaml --project-name nest-local exec backend poetry run python -m scripts.fetch_nest_dump
-	@echo "Check if it worked"
-	@ls -l backend/data
+	@echo "fetching nest.dump into nest-backend container"
+	@CMD="poetry run python -m scripts.fetch_nest_dump" $(MAKE) exec-backend-command
 
 load-data: fetch-nest-dump ## Load initial data from fixtures
 	@echo "Loading Nest data"

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -1,4 +1,4 @@
-SHELL := /bin/bash
+SHELL := /bin/sh
 
 .PHONY: sbom-frontend-image
 


### PR DESCRIPTION
## Proposed change

<!-- Don't forget to link your PR to an existing issue.-->
Resolves #4536 

<!-- Describe the big picture of your changes.-->
Add the PR description here.

- runs `fetch-nest-dump.py` and `update-nest-dump.py` inside `nest-backend` container 
- stores the `nest.dump` file in `backend/data` to be later used for storing/updating data in databases

## Checklist

- [X] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [X] **Required:** I verified that my code works as intended and resolves the issue as described
- [X] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [ ] I used AI for code, documentation, tests, or communication related to this PR
