### PR TITLE
Fix pointer cursor on non-interactive map areas in ChapterMap

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -471,4 +471,5 @@ select:disabled,
 
 .leaflet-container {
   background: transparent !important;
+  cursor: default;
 }


### PR DESCRIPTION
## Summary

Fixes the ChapterMap component displaying a pointer cursor across the entire map surface, including non-interactive areas.

### Problem
The `.leaflet-container` was inheriting a pointer cursor, making users think all areas of the map are clickable when only specific elements like markers/pins are interactive.

### Fix
Added `cursor: default` to the `.leaflet-container` CSS rule in `globals.css`. This ensures the default arrow cursor is shown on the map surface, while interactive elements (markers, popups, buttons) retain their pointer cursor.

### Changes
- Added `cursor: default` to the existing `.leaflet-container` style rule in `frontend/src/app/globals.css` (1 line change)

### Testing
- Verified that the map surface shows the default cursor
- Markers and popup buttons still show the pointer cursor
- Map dragging still works with appropriate grab/move cursors

If anyone needs help testing or wants to verify this fix, feel free to reach out!

Closes #4419