### PR TITLE
Update About tools entry to Terraform

### DIFF
--- a/e2e/pages/About.spec.ts
+++ b/e2e/pages/About.spec.ts
@@ -26,7 +26,6 @@ test.describe('About Page', () => {
 
   test('displays technologies & Tools', async ({ page }) => {
     const technologies = [
-      'Ansible',
       'Docker',
       'Jest',
       'Next.js',
@@ -34,6 +33,7 @@ test.describe('About Page', () => {
       'PostgreSQL',
       'Pytest',
       'Tailwind CSS',
+      'Terraform',
       'Typescript',
     ]
 

--- a/frontend/__tests__/a11y/pages/About.a11y.test.tsx
+++ b/frontend/__tests__/a11y/pages/About.a11y.test.tsx
@@ -111,9 +111,9 @@ jest.mock('utils/aboutData', () => ({
     {
       section: 'Tools',
       tools: {
-        ansible: {
-          icon: '/images/icons/ansible.svg',
-          url: 'https://www.ansible.com/',
+        terraform: {
+          icon: '/images/icons/terraform.svg',
+          url: 'https://www.terraform.io/',
         },
         gitHub: {
           icon: '/images/icons/github.svg',

--- a/frontend/__tests__/unit/pages/About.test.tsx
+++ b/frontend/__tests__/unit/pages/About.test.tsx
@@ -107,9 +107,9 @@ jest.mock('utils/aboutData', () => ({
     {
       section: 'Tools',
       tools: {
-        ansible: {
-          icon: '/images/icons/ansible.svg',
-          url: 'https://www.ansible.com/',
+        terraform: {
+          icon: '/images/icons/terraform.svg',
+          url: 'https://www.terraform.io/',
         },
         gitHub: {
           icon: '/images/icons/github.svg',
@@ -394,12 +394,12 @@ describe('About Component', () => {
     expect(screen.getByText('Tests')).toBeInTheDocument()
     expect(screen.getByText('Tools')).toBeInTheDocument()
 
-    expect(screen.getByText('Ansible')).toBeInTheDocument()
+    expect(screen.getByText('Terraform')).toBeInTheDocument()
     expect(screen.getByText('GitHub')).toBeInTheDocument()
     expect(screen.getByText('Next.js')).toBeInTheDocument()
 
-    const ansibleLink = screen.getByText('Ansible').closest('a')
-    expect(ansibleLink).toHaveAttribute('href', 'https://www.ansible.com/')
+    const terraformLink = screen.getByText('Terraform').closest('a')
+    expect(terraformLink).toHaveAttribute('href', 'https://www.terraform.io/')
 
     const githubLink = screen.getByText('GitHub').closest('a')
     expect(githubLink).toHaveAttribute('href', 'https://www.github.com/')
@@ -407,8 +407,8 @@ describe('About Component', () => {
     const reactLink = screen.getByText('Next.js').closest('a')
     expect(reactLink).toHaveAttribute('href', 'https://nextjs.org/')
 
-    const ansibleIconContainer = screen.getByText('Ansible').previousSibling
-    expect(ansibleIconContainer).toBeInTheDocument()
+    const terraformIconContainer = screen.getByText('Terraform').previousSibling
+    expect(terraformIconContainer).toBeInTheDocument()
 
     const githubIconContainer = screen.getByText('GitHub').previousSibling
     expect(githubIconContainer).toBeInTheDocument()

--- a/frontend/public/images/icons/terraform.svg
+++ b/frontend/public/images/icons/terraform.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128"><path fill="#7B42BC" d="M18 14l29 16.8v33.4L18 47.4V14zm34 19.6l29 16.8v33.4L52 67V33.6zM52 0l29 16.8v33.4L52 33.4V0zm34 53.2L115 70v33.4L86 86.6V53.2z"/></svg>

--- a/frontend/src/utils/aboutData.ts
+++ b/frontend/src/utils/aboutData.ts
@@ -227,9 +227,9 @@ export const technologies = [
   {
     section: 'Tools',
     tools: {
-      ansible: {
-        icon: '/images/icons/ansible.svg',
-        url: 'https://www.ansible.com/',
+      terraform: {
+        icon: '/images/icons/terraform.svg',
+        url: 'https://www.terraform.io/',
       },
       gitHub: {
         icon: '/images/icons/github.svg',


### PR DESCRIPTION
Closes #4745.

Summary:
- Replace the About page Tools entry for Ansible with Terraform.
- Add a Terraform SVG icon and link to terraform.io.
- Update the About unit, a11y, and e2e expectations for the Tools list.

Validation:
- pnpm install --frozen-lockfile --ignore-scripts (passed; local Node v22.16.0 emitted the repo engine warning for ^24.0.0)
- pnpm exec eslint src/utils/aboutData.ts __tests__/unit/pages/About.test.tsx __tests__/a11y/pages/About.a11y.test.tsx --config eslint.config.mjs --max-warnings=0
- NODE_OPTIONS='--experimental-vm-modules --no-warnings=DEP0040' pnpm exec jest __tests__/unit/pages/About.test.tsx --runInBand --coverage=false (24 passed)
- NODE_OPTIONS='--experimental-vm-modules --no-warnings=DEP0040' pnpm exec jest __tests__/a11y/pages/About.a11y.test.tsx --runInBand --coverage=false (6 passed)
- pnpm exec prettier --check src/utils/aboutData.ts __tests__/unit/pages/About.test.tsx __tests__/a11y/pages/About.a11y.test.tsx
- python3 -c 'import xml.etree.ElementTree as ET; ET.parse("frontend/public/images/icons/terraform.svg"); print("terraform svg ok")'
- git diff --check
- git diff --cached --check
- git diff --no-ext-diff | gitleaks stdin --no-banner --redact --exit-code 1
- git diff --cached --no-ext-diff | gitleaks stdin --no-banner --redact --exit-code 1