### PR TITLE
Prevent duplicate crewai workflow execution

### DIFF
--- a/backend/apps/slack/common/handlers/ai.py
+++ b/backend/apps/slack/common/handlers/ai.py
@@ -45,11 +45,8 @@ def get_response_blocks(response: str | None) -> list[dict]:
         list: A list of Slack blocks representing the AI response.
 
     """
-    if response:
-        # Format the AI response for Slack (remove code blocks, fix markdown)
-        formatted_response = format_ai_response_for_slack(response)
-        return [markdown(formatted_response)]
-    return get_error_blocks()
+    # Format the AI response for Slack (remove code blocks, fix markdown)
+    return [markdown(format_ai_response_for_slack(response))] if response else get_error_blocks()
 
 
 def process_ai_query(

--- a/backend/apps/slack/common/handlers/ai.py
+++ b/backend/apps/slack/common/handlers/ai.py
@@ -32,10 +32,22 @@ def get_blocks(
     ai_response = process_ai_query(
         query.strip(), images=images, channel_id=channel_id, is_app_mention=is_app_mention
     )
+    return get_response_blocks(ai_response)
 
-    if ai_response:
+
+def get_response_blocks(response: str | None) -> list[dict]:
+    """Get Slack blocks for an already generated AI response.
+
+    Args:
+        response (str | None): The AI's generated response.
+
+    Returns:
+        list: A list of Slack blocks representing the AI response.
+
+    """
+    if response:
         # Format the AI response for Slack (remove code blocks, fix markdown)
-        formatted_response = format_ai_response_for_slack(ai_response)
+        formatted_response = format_ai_response_for_slack(response)
         return [markdown(formatted_response)]
     return get_error_blocks()
 

--- a/backend/apps/slack/services/message_auto_reply.py
+++ b/backend/apps/slack/services/message_auto_reply.py
@@ -6,7 +6,7 @@ from django_rq import job
 from slack_sdk.errors import SlackApiError
 
 from apps.slack.apps import SlackConfig
-from apps.slack.common.handlers.ai import get_blocks, process_ai_query
+from apps.slack.common.handlers.ai import get_response_blocks, process_ai_query
 from apps.slack.models import Message
 
 logger = logging.getLogger(__name__)
@@ -70,7 +70,7 @@ def generate_ai_reply_if_unanswered(message_id: int):
 
     client.chat_postMessage(
         channel=channel_id,
-        blocks=get_blocks(ai_response_text, channel_id=channel_id),
+        blocks=get_response_blocks(ai_response_text),
         text=ai_response_text,
         thread_ts=message.slack_message_id,
     )

--- a/backend/tests/unit/apps/slack/common/handlers/ai_test.py
+++ b/backend/tests/unit/apps/slack/common/handlers/ai_test.py
@@ -6,6 +6,7 @@ from apps.slack.common.handlers.ai import (
     get_blocks,
     get_default_response,
     get_error_blocks,
+    get_response_blocks,
     process_ai_query,
 )
 
@@ -198,3 +199,30 @@ class TestAiHandler:
 
         mock_markdown.assert_called_once_with(expected_error_message)
         assert result == [expected_block]
+
+    @patch("apps.slack.common.handlers.ai.format_ai_response_for_slack")
+    @patch("apps.slack.common.handlers.ai.markdown")
+    def test_get_response_blocks_success(self, mock_markdown, mock_format_ai_response):
+        """Test get_response_blocks with successful response."""
+        response = "Successful response"
+        formatted = "Formatted response"
+        expected_block = {"type": "section", "text": {"type": "mrkdwn", "text": formatted}}
+
+        mock_format_ai_response.return_value = formatted
+        mock_markdown.return_value = expected_block
+
+        result = get_response_blocks(response)
+
+        mock_format_ai_response.assert_called_once_with(response)
+        mock_markdown.assert_called_once_with(formatted)
+        assert result == [expected_block]
+
+    @patch("apps.slack.common.handlers.ai.get_error_blocks")
+    def test_get_response_blocks_empty(self, mock_get_error_blocks):
+        """Test get_response_blocks with empty response returns error blocks."""
+        error_blocks = [{"type": "section", "text": {"type": "mrkdwn", "text": "Error"}}]
+        mock_get_error_blocks.return_value = error_blocks
+
+        assert get_response_blocks("") == error_blocks
+        assert get_response_blocks(None) == error_blocks
+        assert mock_get_error_blocks.call_count == 2

--- a/backend/tests/unit/apps/slack/services/message_auto_reply_test.py
+++ b/backend/tests/unit/apps/slack/services/message_auto_reply_test.py
@@ -45,10 +45,10 @@ class TestMessageAutoReply:
     @patch.object(SlackConfig, "app")
     @patch("apps.slack.services.message_auto_reply.Message.objects.get")
     @patch("apps.slack.services.message_auto_reply.process_ai_query")
-    @patch("apps.slack.services.message_auto_reply.get_blocks")
+    @patch("apps.slack.services.message_auto_reply.get_response_blocks")
     def test_generate_ai_reply_success(
         self,
-        mock_get_blocks,
+        mock_get_response_blocks,
         mock_process_ai_query,
         mock_message_get,
         mock_app,
@@ -57,7 +57,7 @@ class TestMessageAutoReply:
         """Test successful AI reply generation."""
         mock_message_get.return_value = mock_message
         mock_process_ai_query.return_value = "OWASP is a security organization..."
-        mock_get_blocks.return_value = [
+        mock_get_response_blocks.return_value = [
             {
                 "type": "section",
                 "text": {
@@ -80,10 +80,7 @@ class TestMessageAutoReply:
         mock_process_ai_query.assert_called_once_with(
             query=mock_message.text, channel_id=mock_message.conversation.slack_channel_id
         )
-        mock_get_blocks.assert_called_once_with(
-            "OWASP is a security organization...",
-            channel_id=mock_message.conversation.slack_channel_id,
-        )
+        mock_get_response_blocks.assert_called_once_with("OWASP is a security organization...")
         mock_client.chat_postMessage.assert_called_once_with(
             channel=mock_message.conversation.slack_channel_id,
             blocks=[
@@ -151,12 +148,12 @@ class TestMessageAutoReply:
     @patch.object(SlackConfig, "app")
     @patch("apps.slack.services.message_auto_reply.Message.objects.get")
     @patch("apps.slack.services.message_auto_reply.process_ai_query")
-    @patch("apps.slack.services.message_auto_reply.get_blocks")
+    @patch("apps.slack.services.message_auto_reply.get_response_blocks")
     @patch("apps.slack.services.message_auto_reply.logger")
     def test_generate_ai_reply_slack_api_error(
         self,
         mock_logger,
-        mock_get_blocks,
+        mock_get_response_blocks,
         mock_process_ai_query,
         mock_message_get,
         mock_app,
@@ -168,7 +165,7 @@ class TestMessageAutoReply:
         mock_app.client = mock_client
         mock_client.conversations_replies.side_effect = SlackApiError("API Error", response=Mock())
         mock_process_ai_query.return_value = "OWASP is a security organization..."
-        mock_get_blocks.return_value = [
+        mock_get_response_blocks.return_value = [
             {
                 "type": "section",
                 "text": {


### PR DESCRIPTION
## Proposed change

Resolves #4778

### Description of changes

This PR fixes a critical logic issue in the Slack background auto-reply workflow that caused the CrewAI multi-agent pipeline to execute twice for every unanswered Slack message.

#### Root Cause

The background worker first generated a response using `process_ai_query()`. However, while constructing Slack blocks, it passed the generated AI response into `get_blocks()`. Since `get_blocks()` internally calls `process_ai_query()`, the system incorrectly treated the already-generated response as a new query and executed the full CrewAI workflow a second time.

#### Changes Made

* Added a new helper function `get_response_blocks(response: str | None)` to format already-generated AI responses into Slack markdown blocks without triggering query processing again.
* Updated `get_blocks()` to delegate formatting to `get_response_blocks()` after query execution.
* Updated the Slack background auto-reply task to use `get_response_blocks()` directly for precomputed responses.
* Added unit tests for the new formatting helper and updated existing tests/mocks to validate the corrected execution flow.

### Impact

* Prevents duplicate execution of the CrewAI workflow.
* Reduces unnecessary LLM/API usage and background reply latency.
* Avoids accidental clarification/fallback responses generated from re-processing AI output.
* Improves reliability and correctness of automated Slack replies.

## Checklist

* [x] Required: I followed the contributing workflow
* [x] Required: I verified that my code works as intended and resolves the issue as described
* [x] Required: I ran `make check-test` locally: all warnings addressed, tests passed
* [x] I used AI for code, documentation, tests, or communication related to this PR
