### PR TITLE
chore(deps): migrate pnpm to v11

### DIFF
--- a/cspell/custom-dict.txt
+++ b/cspell/custom-dict.txt
@@ -227,6 +227,7 @@ trivyignores
 tsc
 unassigning
 unhover
+unrs
 usefixtures
 vcodec
 webgoat

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -9,6 +9,8 @@ ENV APK_CACHE_DIR="/app/.cache/apk" \
     COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
     FORCE_COLOR=1 \
     NPM_CONFIG_CACHE="/app/.npm" \
+    PNPM_CONFIG_FETCH_RETRIES=5 \
+    PNPM_CONFIG_FETCH_TIMEOUT=30000 \
     PNPM_HOME="/pnpm"
 
 ARG ENV_FILE=.env
@@ -29,9 +31,9 @@ WORKDIR /app
 COPY --chmod=444 package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     corepack install && corepack enable pnpm && \
-    pnpm install --frozen-lockfile --ignore-scripts
+    pnpm install --frozen-lockfile
 
-COPY --chmod=444 .pnpmrc next.config.ts postcss.config.js tailwind.config.mjs tsconfig.json ./
+COPY --chmod=444 next.config.ts postcss.config.js tailwind.config.mjs tsconfig.json ./
 COPY --chmod=444 ${ENV_FILE} ./.env
 COPY --chmod=555 public public
 COPY --chmod=555 src src

--- a/docker/frontend/Dockerfile.a11y-tests
+++ b/docker/frontend/Dockerfile.a11y-tests
@@ -5,8 +5,8 @@ ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
     NPM_CONFIG_CACHE="/app/.npm" \
     PNPM_HOME="/pnpm"
 
-ENV NPM_CONFIG_RETRY=5 \
-    NPM_CONFIG_TIMEOUT=30000 \
+ENV PNPM_CONFIG_FETCH_RETRIES=5 \
+    PNPM_CONFIG_FETCH_TIMEOUT=30000 \
     PATH="$PNPM_HOME:$PATH"
 
 WORKDIR /app
@@ -14,13 +14,13 @@ WORKDIR /app
 COPY --chmod=444 --chown=root:root package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     corepack install && corepack enable pnpm && \
-    pnpm install --frozen-lockfile --ignore-scripts && \
+    pnpm install --frozen-lockfile && \
     chown node:node /app
 
 COPY __tests__/a11y __tests__/a11y
 COPY __tests__/mockData __tests__/mockData
 COPY __tests__/jest.setup.ts __tests__/jest.setup.ts
-COPY .pnpmrc jest.config.ts tsconfig.json ./
+COPY jest.config.ts tsconfig.json ./
 COPY public public
 COPY src src
 

--- a/docker/frontend/Dockerfile.local
+++ b/docker/frontend/Dockerfile.local
@@ -8,8 +8,8 @@ ENV APK_CACHE_DIR="/home/owasp/.cache/apk-frontend-builder" \
     NPM_CONFIG_CACHE="/home/owasp/.npm" \
     PNPM_HOME="/pnpm"
 
-ENV NPM_CONFIG_RETRY=5 \
-    NPM_CONFIG_TIMEOUT=30000 \
+ENV PNPM_CONFIG_FETCH_RETRIES=5 \
+    PNPM_CONFIG_FETCH_TIMEOUT=30000 \
     PATH="$PNPM_HOME:$PATH"
 
 RUN mkdir -p ${APK_CACHE_DIR} && \
@@ -26,7 +26,7 @@ WORKDIR /home/owasp
 COPY --chmod=444 --chown=root:root package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     corepack install && corepack enable pnpm && \
-    pnpm install --frozen-lockfile --ignore-scripts
+    pnpm install --frozen-lockfile
 
 FROM node:24.16-alpine3.23@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14
 

--- a/docker/frontend/Dockerfile.unit-tests
+++ b/docker/frontend/Dockerfile.unit-tests
@@ -5,8 +5,8 @@ ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
     NPM_CONFIG_CACHE="/app/.npm" \
     PNPM_HOME="/pnpm"
 
-ENV NPM_CONFIG_RETRY=5 \
-    NPM_CONFIG_TIMEOUT=30000 \
+ENV PNPM_CONFIG_FETCH_RETRIES=5 \
+    PNPM_CONFIG_FETCH_TIMEOUT=30000 \
     PATH="$PNPM_HOME:$PATH"
 
 WORKDIR /app
@@ -14,14 +14,14 @@ WORKDIR /app
 COPY --chmod=444 --chown=root:root package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     corepack install && corepack enable pnpm && \
-    pnpm install --frozen-lockfile --ignore-scripts && \
+    pnpm install --frozen-lockfile && \
     chown node:node /app
 
 COPY __tests__/unit __tests__/unit
 COPY __tests__/mockData __tests__/mockData
 COPY __tests__/jest.setup.ts __tests__/jest.setup.ts
 COPY __tests__/tsconfig.json __tests__/tsconfig.json
-COPY .pnpmrc jest.config.ts tsconfig.json ./
+COPY jest.config.ts tsconfig.json ./
 COPY public public
 COPY src src
 

--- a/frontend/.pnpmrc
+++ b/frontend/.pnpmrc
@@ -1,3 +1,0 @@
-legacy-peer-deps=true
-public-hoist-pattern[]=*import-in-the-middle*
-save-exact=true

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -123,19 +123,7 @@
   "engines": {
     "node": "^24.0.0"
   },
-  "packageManager": "pnpm@10.33.3",
-  "pnpm": {
-    "overrides": {
-      "brace-expansion@5": "5.0.6",
-      "fast-uri": "3.1.2",
-      "glob": "^11.1.0",
-      "postcss": "8.5.10",
-      "protobufjs": "7.5.8",
-      "serialize-javascript": "^7.0.3",
-      "test-exclude": "^7.0.1",
-      "ws@8": "8.20.1"
-    }
-  },
+  "packageManager": "pnpm@11.5.0+sha512.dbfcc4f81cf48597afd4bc391ffdf12c11f1a9fb83a395bfa6b0a2d9cc2fd8ffebafdb1ccbd529632153f793904c2615b7f09fe1a345473fd1c35845172a8eb1",
   "prettier": {
     "arrowParens": "always",
     "endOfLine": "lf",

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,3 +1,27 @@
+allowBuilds:
+  '@heroui/shared-utils': true
+  '@sentry/cli': true
+  '@swc/core': true
+  core-js: true
+  protobufjs: true
+  sharp: true
+  unrs-resolver: true
+
+overrides:
+  brace-expansion@5: 5.0.6
+  fast-uri: 3.1.2
+  glob: 11.1.0
+  postcss: 8.5.10
+  protobufjs: 7.5.8
+  serialize-javascript: 7.0.5
+  test-exclude: 7.0.2
+  ws@8: 8.20.1
+
+publicHoistPattern:
+  - '*import-in-the-middle*'
+
+saveExact: true
+
 # 21 days (in minutes)
 minimumReleaseAge: 30240
 minimumReleaseAgeExclude:


### PR DESCRIPTION
Resolves #4747

## Proposed change
- Updated `packageManager` to `pnpm@11.5.0` in `frontend/package.json`
- Removed `pnpm` field from `package.json` overrides migrated to `pnpm-workspace.yaml`
- Deleted `frontend/.pnpmrc` settings moved to `pnpm-workspace.yaml`
- Added `allowBuilds` config in `pnpm-workspace.yaml` for pnpm v11's stricter build script policy
- Replaced `NPM_CONFIG_RETRY`/`NPM_CONFIG_TIMEOUT` with `PNPM_CONFIG_FETCH_RETRIES`/`PNPM_CONFIG_FETCH_TIMEOUT` in all frontend Dockerfiles
- Removed `.pnpmrc` from Docker COPY instructions
- Added `unrs` to cSpell dictionary

## Verification
- `pnpm install` runs cleanly with no warnings
- Production build passes (`pnpm run build`)
- `make check-test` passes locally
 
<img width="1035" height="803" alt="image" src="https://github.com/user-attachments/assets/22356a5e-0e69-4472-aa29-b565816a7730" />


## Checklist
- [X] I followed the contributing workflow
- [X] I verified that my code works as intended and resolves the issue as described
- [X] I ran `make check-test` locally: all warnings addressed, tests passed
- [X] I used AI for code, documentation, tests, or communication related to this PR