### PR TITLE
Add mentroship modules data sync cron job

### DIFF
--- a/infrastructure/modules/tasks/README.md
+++ b/infrastructure/modules/tasks/README.md
@@ -18,6 +18,7 @@
 | ---- | ------ | ------- |
 | <a name="module_index_data_task"></a> [index\_data\_task](#module\_index\_data\_task) | ./modules/task | n/a |
 | <a name="module_load_data_task"></a> [load\_data\_task](#module\_load\_data\_task) | ./modules/task | n/a |
+| <a name="module_mentorship_sync_modules_data"></a> [mentorship\_sync\_modules\_data](#module\_mentorship\_sync\_modules\_data) | ./modules/task | n/a |
 | <a name="module_migrate_task"></a> [migrate\_task](#module\_migrate\_task) | ./modules/task | n/a |
 | <a name="module_owasp_update_project_health_metrics_task"></a> [owasp\_update\_project\_health\_metrics\_task](#module\_owasp\_update\_project\_health\_metrics\_task) | ./modules/task | n/a |
 | <a name="module_owasp_update_project_health_scores_task"></a> [owasp\_update\_project\_health\_scores\_task](#module\_owasp\_update\_project\_health\_scores\_task) | ./modules/task | n/a |
@@ -65,6 +66,8 @@
 | <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | The ARN of the KMS key. | `string` | n/a | yes |
 | <a name="input_load_data_task_cpu"></a> [load\_data\_task\_cpu](#input\_load\_data\_task\_cpu) | The CPU for the load-data task. | `string` | `"512"` | no |
 | <a name="input_load_data_task_memory"></a> [load\_data\_task\_memory](#input\_load\_data\_task\_memory) | The memory for the load-data task. | `string` | `"4096"` | no |
+| <a name="input_mentorship_sync_modules_data_task_cpu"></a> [mentorship\_sync\_modules\_data\_task\_cpu](#input\_mentorship\_sync\_modules\_data\_task\_cpu) | The CPU for the mentorship-sync-modules-data task. | `string` | `"256"` | no |
+| <a name="input_mentorship_sync_modules_data_task_memory"></a> [mentorship\_sync\_modules\_data\_task\_memory](#input\_mentorship\_sync\_modules\_data\_task\_memory) | The memory for the mentorship-sync-modules-data task. | `string` | `"1024"` | no |
 | <a name="input_migrate_task_cpu"></a> [migrate\_task\_cpu](#input\_migrate\_task\_cpu) | The CPU for the migrate task. | `string` | `"256"` | no |
 | <a name="input_migrate_task_memory"></a> [migrate\_task\_memory](#input\_migrate\_task\_memory) | The memory for the migrate task. | `string` | `"1024"` | no |
 | <a name="input_project_name"></a> [project\_name](#input\_project\_name) | The name of the project. | `string` | n/a | yes |

--- a/infrastructure/modules/tasks/main.tf
+++ b/infrastructure/modules/tasks/main.tf
@@ -12,6 +12,7 @@ terraform {
 data "aws_caller_identity" "current" {}
 
 locals {
+  mentorship_sync_modules_data_schedule_expression  = var.enable_cron_tasks ? "cron(30 06 * * ? *)" : null
   slack_sync_data_schedule_expression               = var.enable_cron_tasks ? "cron(0 */6 ? * MON-FRI *)" : null
   sync_data_schedule_expression                     = var.enable_cron_tasks ? "cron(17 05 * * ? *)" : null
   update_project_health_metrics_schedule_expression = var.enable_cron_tasks ? "cron(17 17 * * ? *)" : null
@@ -327,6 +328,38 @@ module "owasp_update_project_health_scores_task" {
   security_group_ids           = [var.ecs_sg_id]
   subnet_ids                   = var.subnet_ids
   task_name                    = "owasp-update-project-health-scores"
+  use_fargate_spot             = var.use_fargate_spot
+}
+
+module "mentorship_sync_modules_data" {
+  source = "./modules/task"
+
+  assign_public_ip = var.assign_public_ip
+  aws_region       = var.aws_region
+  command = [
+    "/bin/sh",
+    "-c",
+    <<-EOT
+    set -e
+    EXEC_MODE=direct make mentorship-sync-module-issues
+    EXEC_MODE=direct make github-update-pull-requests
+    EOT
+  ]
+  common_tags                  = var.common_tags
+  container_parameters_arns    = var.container_parameters_arns
+  cpu                          = var.mentorship_sync_modules_data_task_cpu
+  ecs_cluster_arn              = aws_ecs_cluster.main.arn
+  ecs_tasks_execution_role_arn = aws_iam_role.ecs_tasks_execution_role.arn
+  environment                  = var.environment
+  event_bridge_role_arn        = aws_iam_role.event_bridge_role.arn
+  image_url                    = "${var.ecr_repository_url}:${var.image_tag}"
+  kms_key_arn                  = var.kms_key_arn
+  memory                       = var.mentorship_sync_modules_data_task_memory
+  project_name                 = var.project_name
+  schedule_expression          = local.mentorship_sync_modules_data_schedule_expression
+  security_group_ids           = [var.ecs_sg_id]
+  subnet_ids                   = var.subnet_ids
+  task_name                    = "mentorship-sync-modules-data"
   use_fargate_spot             = var.use_fargate_spot
 }
 

--- a/infrastructure/modules/tasks/tests/tasks.tftest.hcl
+++ b/infrastructure/modules/tasks/tests/tasks.tftest.hcl
@@ -25,6 +25,11 @@ run "test_cron_tasks_disabled_removes_schedules" {
   }
 
   assert {
+    condition     = local.mentorship_sync_modules_data_schedule_expression == null
+    error_message = "mentorship_sync_modules_data_schedule_expression must be null when enable_cron_tasks is false."
+  }
+
+  assert {
     condition     = local.sync_data_schedule_expression == null
     error_message = "sync_data_schedule_expression must be null when enable_cron_tasks is false."
   }
@@ -45,6 +50,11 @@ run "test_cron_tasks_enabled_creates_schedules" {
 
   variables {
     enable_cron_tasks = true
+  }
+
+  assert {
+    condition     = local.mentorship_sync_modules_data_schedule_expression == "cron(30 06 * * ? *)"
+    error_message = "mentorship_sync_modules_data_schedule_expression must be set when enable_cron_tasks is true."
   }
 
   assert {

--- a/infrastructure/modules/tasks/variables.tf
+++ b/infrastructure/modules/tasks/variables.tf
@@ -90,6 +90,18 @@ variable "load_data_task_memory" {
   default     = "4096"
 }
 
+variable "mentorship_sync_modules_data_task_cpu" {
+  description = "The CPU for the mentorship-sync-modules-data task."
+  type        = string
+  default     = "256"
+}
+
+variable "mentorship_sync_modules_data_task_memory" {
+  description = "The memory for the mentorship-sync-modules-data task."
+  type        = string
+  default     = "1024"
+}
+
 variable "migrate_task_cpu" {
   description = "The CPU for the migrate task."
   type        = string


### PR DESCRIPTION
Add a cron job to sync issues and pull requests from mentorship modules.

## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [x] I used AI for code, documentation, tests, or communication related to this PR
