### PR TITLE
ci: introduce actionlint pre-commit hook for GitHub Actions workflow file linting

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -2,3 +2,9 @@ config-variables:
   - AWS_AVAILABILITY_ZONES
   - AWS_REGION
   - DOMAIN_NAME
+
+paths:
+  .github/workflows/run-code-tests.yaml:
+    ignore:
+      # GraphQL fuzz tests are intentionally disabled.
+      - constant expression "false" in condition

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+config-variables:
+  - AWS_AVAILABILITY_ZONES
+  - AWS_REGION
+  - DOMAIN_NAME

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -127,6 +127,11 @@ repos:
       - id: trailing-whitespace
         exclude: pnpm-lock.yaml
 
+  - repo: https://github.com/rhysd/actionlint
+    rev: 914e7df21a07ef503a81201c76d2b11c789d3fca  # v1.7.12
+    hooks:
+      - id: actionlint
+
   - repo: https://github.com/terraform-docs/terraform-docs
     rev: 9d4455198941806aa02ec14369de030cda2c2b59  # v0.24.0
     hooks:


### PR DESCRIPTION
Resolves #4746 

## Proposed change
- Added actionlint as a pre-commit hook [(rhysd/actionlint v1.7.12)](https://github.com/rhysd/actionlint). Industry standard linter that understands Github action semantics. Runs via pre-commit and in CI through the existing pre-commit job. No new workflow or Makefile changes needed.
- Added config file for aciton lint `.github/actionlint.yaml` declares repository variables (`AWS_REGION`, `AWS_AVAILABILITY_ZONES`, `DOMAIN_NAME`) used across workflow files as a fail safe. Actionlint will catch typos that would pass all checks and only fail at runtime.
- Added a path-specific ignore rule for `.github/workflows/run-code-tests.yaml` in the actionlint config file to suppress the `constant expression "false" in condition` warning on the intentionally disabled GraphQL fuzz job. Changing it to a variable condition would alter the codebase's behavior and introduce an undeclared variable. Using an ignore rule is the correct fix.


## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [x] I used AI for code, documentation, tests, or communication related to this PR
