### PR TITLE
fix: replace numeric publishedAt test values with ISO strings

### DIFF
--- a/frontend/__tests__/a11y/components/RecentRelease.a11y.test.tsx
+++ b/frontend/__tests__/a11y/components/RecentRelease.a11y.test.tsx
@@ -6,7 +6,7 @@ import RecentReleases from 'components/RecentReleases'
 const mockReleases: Release[] = [
   {
     name: 'v1.0 The First Release',
-    publishedAt: Date.now(),
+    publishedAt: new Date().toISOString(),
     repositoryName: 'our-awesome-project',
     organizationName: 'our-org',
     tagName: 'v1.0',
@@ -26,7 +26,7 @@ const mockReleases: Release[] = [
   },
   {
     name: 'v2.0 The Second Release',
-    publishedAt: Date.now(),
+    publishedAt: new Date().toISOString(),
     repositoryName: 'another-cool-project',
     organizationName: 'our-org',
     tagName: 'v2.0',

--- a/frontend/__tests__/a11y/components/RecentReleases.a11y.test.tsx
+++ b/frontend/__tests__/a11y/components/RecentReleases.a11y.test.tsx
@@ -9,7 +9,7 @@ const mockReleases: ReleaseType[] = [
     id: '1',
     name: 'v1.0.0',
     tagName: 'v1.0.0',
-    publishedAt: Date.now(),
+    publishedAt: new Date().toISOString(),
     repositoryName: 'test-repo',
     organizationName: 'test-org',
     isPreRelease: false,

--- a/frontend/__tests__/a11y/components/Release.a11y.test.tsx
+++ b/frontend/__tests__/a11y/components/Release.a11y.test.tsx
@@ -6,7 +6,7 @@ import Release from 'components/Release'
 
 const release: ReleaseType = {
   name: 'v1.0 The First Release',
-  publishedAt: Date.now(),
+  publishedAt: new Date().toISOString(),
   repositoryName: 'our-awesome-project',
   organizationName: 'our-org',
   tagName: 'v1.0',

--- a/frontend/__tests__/unit/components/CardDetailsPage.test.tsx
+++ b/frontend/__tests__/unit/components/CardDetailsPage.test.tsx
@@ -759,7 +759,7 @@ describe('CardDetailsPage', () => {
       author: mockUser,
       isPreRelease: false,
       name: 'v1.0.0',
-      publishedAt: Date.now() - 604800000,
+      publishedAt: new Date(Date.now() - 604800000).toISOString(),
       repositoryName: 'test-repo',
       tagName: 'v1.0.0',
       url: 'https://github.com/test/repo/releases/tag/v1.0.0',

--- a/frontend/__tests__/unit/components/RecentRelease.test.tsx
+++ b/frontend/__tests__/unit/components/RecentRelease.test.tsx
@@ -64,7 +64,7 @@ jest.mock('next/image', () => ({
   },
 }))
 
-const now = Date.now()
+const now = new Date().toISOString()
 const mockReleases: Release[] = [
   {
     id: 'release-recent-1',

--- a/frontend/__tests__/unit/components/Release.test.tsx
+++ b/frontend/__tests__/unit/components/Release.test.tsx
@@ -68,7 +68,7 @@ jest.mock('next/image', () => ({
   },
 }))
 
-const now = Date.now()
+const now = new Date().toISOString()
 const mockReleases: ReleaseType[] = [
   {
     id: 'release-test-1',


### PR DESCRIPTION
## Proposed change

Resolves #4575

This PR fixes test mocks that assign `Date.now()` (number) to the `publishedAt` field, which is defined as a `string` in the Release type.

Changes made:
- Replaced `Date.now()` with `new Date().toISOString()` in release-related test data.
- Updated both unit and accessibility tests to ensure all mocked `publishedAt` values match the expected type.
- No production code, type definitions, or application logic were changed.

Modified files:
- frontend/__tests__/unit/components/Release.test.tsx
- frontend/__tests__/unit/components/RecentRelease.test.tsx
- frontend/__tests__/unit/components/CardDetailsPage.test.tsx
- frontend/__tests__/a11y/components/Release.a11y.test.tsx
- frontend/__tests__/a11y/components/RecentRelease.a11y.test.tsx
- frontend/__tests__/a11y/components/RecentReleases.a11y.test.tsx

### Verification

- Verified that all modified test mocks now use ISO string values for `publishedAt`.
- Confirmed the updated release-related unit tests pass locally.
- The remaining test failures are pre-existing timeout-related failures in unrelated test suites and are not affected by this change.

## Checklist

- [x] I followed the contributing workflow
- [x] I verified that my code works as intended and resolves the issue as described
- [x] I ran `make check-test` locally; all changes related to this fix passed validation
- [ ] I used AI for code, documentation, tests, or communication related to this PR
