### PR TITLE
fix: ChapterMap cursor shows default on non-interactive areas

### DIFF
--- a/frontend/src/components/ChapterMap.tsx
+++ b/frontend/src/components/ChapterMap.tsx
@@ -196,7 +196,7 @@ const ChapterMap = ({
   return (
     <section
       aria-label="Chapter Map"
-      className="relative isolate z-0 overflow-hidden rounded-lg bg-slate-200 dark:bg-[#1a1a1a]"
+      className="relative isolate z-0 cursor-default overflow-hidden rounded-lg bg-slate-200 dark:bg-[#1a1a1a]"
       style={style}
       onPointerLeave={handlePointerLeave}
     >
@@ -204,7 +204,7 @@ const ChapterMap = ({
         center={[20, 0]}
         zoom={2}
         scrollWheelZoom={isMapActive}
-        style={{ height: '100%', width: '100%', outline: 'none', background: 'transparent' }}
+        style={{ height: '100%', width: '100%', outline: 'none', background: 'transparent', cursor: 'default' }}
         zoomControl={false}
         minZoom={1}
         maxZoom={18}


### PR DESCRIPTION
Fixes https://github.com/OWASP/Nest/issues/4419

The ChapterMap component displayed a pointer cursor across the entire map surface, including non-interactive areas. This fix adds:

- `cursor-default` Tailwind class to the outer `<section>` wrapper
- `cursor: default` to the `<MapContainer>` inline style

Interactive elements (popup buttons, unlock button) keep their explicit `cursor-pointer` classes, so they still show the pointer cursor as expected.