### PR TITLE
fix: add XFrameOptionsMiddleware to prevent clickjacking

### DIFF
--- a/backend/settings/base.py
+++ b/backend/settings/base.py
@@ -100,6 +100,7 @@ class Base(Configuration):
         "apps.common.middlewares.block_null_characters.BlockNullCharactersMiddleware",
         "django.contrib.auth.middleware.AuthenticationMiddleware",
         "django.contrib.messages.middleware.MessageMiddleware",
+        "django.middleware.clickjacking.XFrameOptionsMiddleware",
     ]
 
     ROOT_URLCONF = "settings.urls"

--- a/frontend/src/components/ChapterMap.tsx
+++ b/frontend/src/components/ChapterMap.tsx
@@ -196,7 +196,7 @@ const ChapterMap = ({
   return (
     <section
       aria-label="Chapter Map"
-      className="relative isolate z-0 overflow-hidden rounded-lg bg-slate-200 dark:bg-[#1a1a1a]"
+      className="relative isolate z-0 cursor-default overflow-hidden rounded-lg bg-slate-200 dark:bg-[#1a1a1a]"
       style={style}
       onPointerLeave={handlePointerLeave}
     >
@@ -204,7 +204,7 @@ const ChapterMap = ({
         center={[20, 0]}
         zoom={2}
         scrollWheelZoom={isMapActive}
-        style={{ height: '100%', width: '100%', outline: 'none', background: 'transparent' }}
+        style={{ height: '100%', width: '100%', outline: 'none', background: 'transparent', cursor: 'default' }}
         zoomControl={false}
         minZoom={1}
         maxZoom={18}


### PR DESCRIPTION
Fixes #4879

**Describe the issue**
The Django  is not included in the  list in . This means no  header is set on responses, leaving the application vulnerable to clickjacking attacks.

**Impact**
An attacker could embed Nest pages in an iframe on a malicious site and trick users into performing unintended actions (clickjacking).

**Fix**
Added  to the MIDDLEWARE list. Django enables  by default when this middleware is active.