### PR TITLE
fix(ChapterMap): correct cursor display on non-interactive areas

### DIFF
--- a/frontend/__tests__/unit/components/ChapterMap.test.tsx
+++ b/frontend/__tests__/unit/components/ChapterMap.test.tsx
@@ -466,6 +466,26 @@ describe('ChapterMap Refactored Tests', () => {
     })
   })
 
+  describe('Cursor Behavior', () => {
+    it('has cursor-default class on the section wrapper', () => {
+      const { container } = render(<ChapterMap {...defaultProps} />)
+      const section = container.querySelector('section')
+      expect(section).toHaveClass('cursor-default')
+    })
+
+    it('has chapter-map class on the section wrapper', () => {
+      const { container } = render(<ChapterMap {...defaultProps} />)
+      const section = container.querySelector('section')
+      expect(section).toHaveClass('chapter-map')
+    })
+
+    it('has cursor: default inline style on the map container', () => {
+      const { container } = render(<ChapterMap {...defaultProps} />)
+      const mapDiv = container.querySelector('#chapter-map')
+      expect(mapDiv).toHaveStyle('cursor: default')
+    })
+  })
+
   describe('Edge Cases', () => {
     it('handles case when map is not ready yet', () => {
       mockMapInstance = null

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -471,4 +471,14 @@ select:disabled,
 
 .leaflet-container {
   background: transparent !important;
+  cursor: default !important;
+}
+
+.leaflet-interactive {
+  cursor: default !important;
+}
+
+.leaflet-marker-icon,
+.leaflet-marker-shadow {
+  cursor: pointer !important;
 }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -469,16 +469,16 @@ select:disabled,
   }
 }
 
-.leaflet-container {
+.chapter-map .leaflet-container {
   background: transparent !important;
   cursor: default !important;
 }
 
-.leaflet-interactive {
+.chapter-map .leaflet-interactive {
   cursor: default !important;
 }
 
-.leaflet-marker-icon,
-.leaflet-marker-shadow {
+.chapter-map .leaflet-marker-icon,
+.chapter-map .leaflet-marker-shadow {
   cursor: pointer !important;
 }

--- a/frontend/src/components/ChapterMap.tsx
+++ b/frontend/src/components/ChapterMap.tsx
@@ -196,7 +196,7 @@ const ChapterMap = ({
   return (
     <section
       aria-label="Chapter Map"
-      className="relative isolate z-0 cursor-default overflow-hidden rounded-lg bg-slate-200 dark:bg-[#1a1a1a]"
+      className="chapter-map relative isolate z-0 cursor-default overflow-hidden rounded-lg bg-slate-200 dark:bg-[#1a1a1a]"
       style={style}
       onPointerLeave={handlePointerLeave}
     >

--- a/frontend/src/components/ChapterMap.tsx
+++ b/frontend/src/components/ChapterMap.tsx
@@ -196,7 +196,7 @@ const ChapterMap = ({
   return (
     <section
       aria-label="Chapter Map"
-      className="relative isolate z-0 overflow-hidden rounded-lg bg-slate-200 dark:bg-[#1a1a1a]"
+      className="relative isolate z-0 cursor-default overflow-hidden rounded-lg bg-slate-200 dark:bg-[#1a1a1a]"
       style={style}
       onPointerLeave={handlePointerLeave}
     >
@@ -204,7 +204,7 @@ const ChapterMap = ({
         center={[20, 0]}
         zoom={2}
         scrollWheelZoom={isMapActive}
-        style={{ height: '100%', width: '100%', outline: 'none', background: 'transparent' }}
+        style={{ height: '100%', width: '100%', outline: 'none', background: 'transparent', cursor: 'default' }}
         zoomControl={false}
         minZoom={1}
         maxZoom={18}

--- a/frontend/src/components/ChapterMap.tsx
+++ b/frontend/src/components/ChapterMap.tsx
@@ -204,7 +204,13 @@ const ChapterMap = ({
         center={[20, 0]}
         zoom={2}
         scrollWheelZoom={isMapActive}
-        style={{ height: '100%', width: '100%', outline: 'none', background: 'transparent', cursor: 'default' }}
+        style={{
+          height: '100%',
+          width: '100%',
+          outline: 'none',
+          background: 'transparent',
+          cursor: 'default',
+        }}
         zoomControl={false}
         minZoom={1}
         maxZoom={18}


### PR DESCRIPTION
Fixes #4419

**Problem:** The ChapterMap component displayed a pointer cursor across the entire map surface, including non-interactive areas like map tiles. This misled users into thinking all areas are clickable when only markers/pins are interactive.

**Changes made:**

1. `frontend/src/components/ChapterMap.tsx`:
   - Added `cursor-default` Tailwind class to the section wrapper
   - Added `cursor: default` inline style to the MapContainer

2. `frontend/src/app/globals.css`:
   - Set `cursor: default !important` on `.leaflet-container` to prevent Leaflet-internal cursor overrides
   - Set `cursor: default !important` on `.leaflet-interactive` to prevent Leaflet's default `cursor: pointer` on interactive overlays
   - Set `cursor: pointer !important` on `.leaflet-marker-icon` and `.leaflet-marker-shadow` to ensure markers/pins still show the pointer cursor

**Result:**
- Default arrow cursor on non-interactive map areas (tiles, background)
- Pointer cursor only on interactive elements (marker pins, popup buttons)