### PR TITLE
feat(candidate-claim): add key field, rename title to name, add GraphQL layer

### DIFF
--- a/backend/apps/owasp/admin/board_candidate_claim.py
+++ b/backend/apps/owasp/admin/board_candidate_claim.py
@@ -7,11 +7,11 @@ from apps.owasp.models.board_candidate_claim import BoardCandidateClaim
 from .mixins import GenericEntityAdminMixin
 
 
-class BoardCandidateClaimAdmin(admin.ModelAdmin, GenericEntityAdminMixin):
+class BoardCandidateClaimAdmin(GenericEntityAdminMixin, admin.ModelAdmin):
     """Admin for BoardCandidateClaim model."""
 
     list_filter = ("status",)
-    search_fields = ("title",)
+    search_fields = ("name",)
 
 
 admin.site.register(BoardCandidateClaim, BoardCandidateClaimAdmin)

--- a/backend/apps/owasp/admin/board_candidate_claim_evidence.py
+++ b/backend/apps/owasp/admin/board_candidate_claim_evidence.py
@@ -7,11 +7,11 @@ from apps.owasp.models.board_candidate_claim_evidence import BoardCandidateClaim
 from .mixins import GenericEntityAdminMixin
 
 
-class BoardCandidateClaimEvidenceAdmin(admin.ModelAdmin, GenericEntityAdminMixin):
+class BoardCandidateClaimEvidenceAdmin(GenericEntityAdminMixin, admin.ModelAdmin):
     """Admin for BoardCandidateClaimEvidence model."""
 
     list_filter = ("is_removed",)
-    search_fields = ("title",)
+    search_fields = ("name",)
 
 
 admin.site.register(BoardCandidateClaimEvidence, BoardCandidateClaimEvidenceAdmin)

--- a/backend/apps/owasp/api/internal/nodes/board_candidate_claim.py
+++ b/backend/apps/owasp/api/internal/nodes/board_candidate_claim.py
@@ -1,0 +1,24 @@
+"""OWASP app Board Candidate Claim GraphQL node."""
+
+import strawberry
+import strawberry_django
+
+from apps.owasp.models.board_candidate_claim import BoardCandidateClaim
+
+
+@strawberry_django.type(
+    BoardCandidateClaim,
+    fields=[
+        "created_at",
+        "description",
+        "is_locked",
+        "key",
+        "name",
+        "status",
+        "updated_at",
+        "withdrawn_at",
+        "withdrawn_reason",
+    ],
+)
+class BoardCandidateClaimNode(strawberry.relay.Node):
+    """Board Candidate Claim node."""

--- a/backend/apps/owasp/api/internal/nodes/board_candidate_claim_evidence.py
+++ b/backend/apps/owasp/api/internal/nodes/board_candidate_claim_evidence.py
@@ -1,0 +1,26 @@
+"""OWASP app Board Candidate Claim Evidence GraphQL node."""
+
+import strawberry
+import strawberry_django
+
+from apps.owasp.models.board_candidate_claim_evidence import BoardCandidateClaimEvidence
+
+
+@strawberry_django.type(
+    BoardCandidateClaimEvidence,
+    fields=[
+        "created_at",
+        "description",
+        "file_name",
+        "file_size",
+        "is_removed",
+        "key",
+        "name",
+        "removed_at",
+        "removed_reason",
+        "source_url",
+        "updated_at",
+    ],
+)
+class BoardCandidateClaimEvidenceNode(strawberry.relay.Node):
+    """Board Candidate Claim Evidence node."""

--- a/backend/apps/owasp/api/internal/queries/__init__.py
+++ b/backend/apps/owasp/api/internal/queries/__init__.py
@@ -1,5 +1,6 @@
 """OWASP GraphQL queries."""
 
+from .board_candidate_claim import BoardCandidateClaimQuery
 from .board_of_directors import BoardOfDirectorsQuery
 from .chapter import ChapterQuery
 from .committee import CommitteeQuery
@@ -14,6 +15,7 @@ from .stats import StatsQuery
 
 
 class OwaspQuery(
+    BoardCandidateClaimQuery,
     BoardOfDirectorsQuery,
     ChapterQuery,
     CommitteeQuery,

--- a/backend/apps/owasp/api/internal/queries/board_candidate_claim.py
+++ b/backend/apps/owasp/api/internal/queries/board_candidate_claim.py
@@ -1,0 +1,47 @@
+"""OWASP Board Candidate Claim GraphQL queries."""
+
+import strawberry
+import strawberry_django
+
+from apps.common.utils import normalize_limit
+from apps.owasp.api.internal.nodes.board_candidate_claim import BoardCandidateClaimNode
+from apps.owasp.models.board_candidate_claim import BoardCandidateClaim
+
+MAX_LIMIT = 100
+
+
+@strawberry.type
+class BoardCandidateClaimQuery:
+    """GraphQL queries for BoardCandidateClaim model."""
+
+    @strawberry_django.field
+    def board_candidate_claim(self, key: str) -> BoardCandidateClaimNode | None:
+        """Resolve Board Candidate Claim by key.
+
+        Args:
+            key: The unique claim key.
+
+        Returns:
+            BoardCandidateClaimNode or None if not found.
+
+        """
+        try:
+            return BoardCandidateClaim.objects.get(key=key)
+        except BoardCandidateClaim.DoesNotExist:
+            return None
+
+    @strawberry_django.field
+    def board_candidate_claims(self, limit: int = 10) -> list[BoardCandidateClaimNode]:
+        """Resolve multiple Board Candidate Claims.
+
+        Args:
+            limit: Maximum number of claims to return.
+
+        Returns:
+            List of BoardCandidateClaimNode objects.
+
+        """
+        if (normalized_limit := normalize_limit(limit, MAX_LIMIT)) is None:
+            return []
+
+        return BoardCandidateClaim.objects.order_by("-created_at")[:normalized_limit]

--- a/backend/apps/owasp/migrations/0074_boardcandidateclaim_key_name_and_more.py
+++ b/backend/apps/owasp/migrations/0074_boardcandidateclaim_key_name_and_more.py
@@ -1,0 +1,36 @@
+# Generated manually
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    """Add key and rename title to name for claim models."""
+
+    dependencies = [
+        ("owasp", "0073_boardcandidateclaim_boardcandidateclaimevidence_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="boardcandidateclaim",
+            name="key",
+            field=models.CharField(default="", max_length=100, unique=True, verbose_name="Key"),
+            preserve_default=False,
+        ),
+        migrations.RenameField(
+            model_name="boardcandidateclaim",
+            old_name="title",
+            new_name="name",
+        ),
+        migrations.AddField(
+            model_name="boardcandidateclaimevidence",
+            name="key",
+            field=models.CharField(default="", max_length=100, unique=True, verbose_name="Key"),
+            preserve_default=False,
+        ),
+        migrations.RenameField(
+            model_name="boardcandidateclaimevidence",
+            old_name="title",
+            new_name="name",
+        ),
+    ]

--- a/backend/apps/owasp/models/board_candidate_claim.py
+++ b/backend/apps/owasp/models/board_candidate_claim.py
@@ -37,7 +37,7 @@ class BoardCandidateClaim(TimestampedModel):
     VALID_TRANSITIONS = {
         Status.DRAFT: {Status.SUBMITTED, Status.DISCARDED},
         Status.SUBMITTED: {Status.APPROVED, Status.REJECTED, Status.WITHDRAWN},
-        Status.APPROVED: {Status.WITHDRAWN},
+        Status.APPROVED: set(),
         Status.REJECTED: set(),
         Status.DISCARDED: set(),
         Status.WITHDRAWN: set(),
@@ -54,19 +54,20 @@ class BoardCandidateClaim(TimestampedModel):
         help_text="Indicates if the claim is locked",
         verbose_name="Is locked",
     )
+    key = models.CharField(max_length=100, unique=True, verbose_name="Key")
+    name = models.CharField(max_length=1000, verbose_name="Name")
     status = models.CharField(
         choices=Status.choices,
         default=Status.DRAFT,
         max_length=20,
         verbose_name="Claim status",
     )
-    title = models.CharField(max_length=1000, verbose_name="Title")
     withdrawn_at = models.DateTimeField(blank=True, null=True)
     withdrawn_reason = models.TextField(blank=True)
 
     def __str__(self):
         """Return a string representation of the a Board Candidate Claim."""
-        return f"{self.title}"
+        return f"{self.name}"
 
     def clean(self) -> None:
         """Validate claim."""
@@ -83,6 +84,10 @@ class BoardCandidateClaim(TimestampedModel):
 
         if not existing_claim:
             error_message = "Claim does not exist."
+            raise ValidationError(error_message)
+
+        if existing_claim.is_locked:
+            error_message = "Cannot update a locked claim."
             raise ValidationError(error_message)
 
         if self.status != existing_claim.status and self.status not in self.VALID_TRANSITIONS.get(
@@ -102,8 +107,7 @@ class BoardCandidateClaim(TimestampedModel):
             raise ValidationError(error_message)
 
         if (
-            self.status != self.Status.WITHDRAWN
-            and existing_claim.status != self.Status.DRAFT
+            existing_claim.status != self.Status.DRAFT
             and any(
                 f.attname != "status"
                 for f in self._meta.fields

--- a/backend/apps/owasp/models/board_candidate_claim_evidence.py
+++ b/backend/apps/owasp/models/board_candidate_claim_evidence.py
@@ -41,14 +41,15 @@ class BoardCandidateClaimEvidence(TimestampedModel):
         help_text="Indicates if the file is removed",
         verbose_name="Is removed",
     )
+    key = models.CharField(max_length=100, unique=True, verbose_name="Key")
+    name = models.CharField(max_length=1000, verbose_name="Name")
     removed_at = models.DateTimeField(blank=True, null=True)
     removed_reason = models.TextField(blank=True)
-    title = models.CharField(max_length=1000, verbose_name="Title")
     source_url = models.TextField(blank=True, verbose_name="Source URL")
 
     def __str__(self):
         """Return a string representation of the a Board Candidate Claim Evidence."""
-        return f"{self.title}"
+        return f"{self.name}"
 
     def clean(self) -> None:
         """Validate evidence."""

--- a/backend/tests/unit/apps/owasp/admin/board_candidate_claim_evidence_test.py
+++ b/backend/tests/unit/apps/owasp/admin/board_candidate_claim_evidence_test.py
@@ -21,7 +21,7 @@ class TestBoardCandidateClaimEvidenceAdmin:
         """Test search_fields."""
         admin_instance = BoardCandidateClaimEvidenceAdmin(BoardCandidateClaimEvidence, AdminSite())
 
-        assert admin_instance.search_fields == ("title",)
+        assert admin_instance.search_fields == ("name",)
 
     def test_inherits_generic_entity_admin_mixin(self):
         """Test admin inherits from GenericEntityAdminMixin."""

--- a/backend/tests/unit/apps/owasp/admin/board_candidate_claim_test.py
+++ b/backend/tests/unit/apps/owasp/admin/board_candidate_claim_test.py
@@ -18,10 +18,10 @@ class TestBoardCandidateClaimAdmin:
         assert admin_instance.list_filter == ("status",)
 
     def test_search_fields(self):
-        """Test search_fields includes title."""
+        """Test search_fields includes name."""
         admin_instance = BoardCandidateClaimAdmin(BoardCandidateClaim, AdminSite())
 
-        assert admin_instance.search_fields == ("title",)
+        assert admin_instance.search_fields == ("name",)
 
     def test_inherits_generic_entity_admin_mixin(self):
         """Test admin inherits from GenericEntityAdminMixin."""

--- a/backend/tests/unit/apps/owasp/models/board_candidate_claim_evidence_test.py
+++ b/backend/tests/unit/apps/owasp/models/board_candidate_claim_evidence_test.py
@@ -12,10 +12,10 @@ class TestBoardCandidateClaimEvidenceModel:
     """Tests for BoardCandidateClaimEvidence model."""
 
     def test_str_representation(self):
-        """Test __str__ returns the evidence title."""
-        evidence = BoardCandidateClaimEvidence(title="Test Evidence Title")
+        """Test __str__ returns the evidence name."""
+        evidence = BoardCandidateClaimEvidence(key="test-evidence", name="Test Evidence Name")
 
-        assert str(evidence) == "Test Evidence Title"
+        assert str(evidence) == "Test Evidence Name"
 
     def test_meta_options(self):
         """Test model meta options."""
@@ -82,11 +82,18 @@ class TestBoardCandidateClaimEvidenceModel:
 
         assert field.blank
 
-    def test_title_max_length(self):
-        """Test title field max_length."""
-        field = BoardCandidateClaimEvidence._meta.get_field("title")
+    def test_name_max_length(self):
+        """Test name field max_length."""
+        field = BoardCandidateClaimEvidence._meta.get_field("name")
 
         assert field.max_length == 1000
+
+    def test_key_field_unique(self):
+        """Test key field is unique."""
+        field = BoardCandidateClaimEvidence._meta.get_field("key")
+
+        assert field.unique
+        assert field.max_length == 100
 
     def test_source_url_field_blank(self):
         """Test source_url field allows blank."""
@@ -97,7 +104,7 @@ class TestBoardCandidateClaimEvidenceModel:
     def test_clean_locked_claim_raises_validation_error(self):
         """Test that clean raises ValidationError when claim is locked."""
         evidence = BoardCandidateClaimEvidence(
-            title="Test Evidence", source_url="https://example.com"
+            key="test-evidence", name="Test Evidence", source_url="https://example.com"
         )
         evidence.claim_id = 1
 
@@ -114,7 +121,7 @@ class TestBoardCandidateClaimEvidenceModel:
     def test_clean_unlocked_claim_with_source_url_passes(self):
         """Test that clean passes for unlocked claim with source_url."""
         evidence = BoardCandidateClaimEvidence(
-            title="Test Evidence", source_url="https://example.com"
+            key="test-evidence", name="Test Evidence", source_url="https://example.com"
         )
         evidence.claim_id = 1
 
@@ -126,7 +133,9 @@ class TestBoardCandidateClaimEvidenceModel:
 
     def test_clean_no_file_and_no_source_url_raises_validation_error(self):
         """Test that clean raises ValidationError when neither file nor source_url."""
-        evidence = BoardCandidateClaimEvidence(title="Test Evidence", source_url="")
+        evidence = BoardCandidateClaimEvidence(
+            key="test-evidence", name="Test Evidence", source_url=""
+        )
         evidence.claim_id = 1
         evidence.file = None
 
@@ -145,7 +154,7 @@ class TestBoardCandidateClaimEvidenceModel:
         mock_file.size = 12345
         mock_file.__bool__ = Mock(return_value=True)
 
-        evidence = BoardCandidateClaimEvidence(title="Test Evidence")
+        evidence = BoardCandidateClaimEvidence(key="test-evidence", name="Test Evidence")
         evidence.claim_id = 1
         evidence.file = mock_file
         evidence.file_name = ""
@@ -167,7 +176,7 @@ class TestBoardCandidateClaimEvidenceModel:
         mock_file.size = 12345
         mock_file.__bool__ = Mock(return_value=True)
 
-        evidence = BoardCandidateClaimEvidence(title="Test Evidence")
+        evidence = BoardCandidateClaimEvidence(key="test-evidence", name="Test Evidence")
         evidence.claim_id = 1
         evidence.file = mock_file
         evidence.file_name = "custom_name.pdf"
@@ -185,7 +194,7 @@ class TestBoardCandidateClaimEvidenceModel:
     def test_clean_without_claim_id_skips_locked_check(self):
         """Test that clean skips locked check when claim_id is not set."""
         evidence = BoardCandidateClaimEvidence(
-            title="Test Evidence", source_url="https://example.com"
+            key="test-evidence", name="Test Evidence", source_url="https://example.com"
         )
         evidence.claim_id = None
 
@@ -195,7 +204,7 @@ class TestBoardCandidateClaimEvidenceModel:
     @patch("apps.owasp.models.board_candidate_claim_evidence.TimestampedModel.save")
     def test_save_calls_full_clean(self, mock_super_save, mock_full_clean):
         """Test that save calls full_clean before saving."""
-        evidence = BoardCandidateClaimEvidence(title="Test Evidence")
+        evidence = BoardCandidateClaimEvidence(key="test-evidence", name="Test Evidence")
 
         evidence.save()
 

--- a/backend/tests/unit/apps/owasp/models/board_candidate_claim_test.py
+++ b/backend/tests/unit/apps/owasp/models/board_candidate_claim_test.py
@@ -12,10 +12,10 @@ class TestBoardCandidateClaimModel:
     """Tests for BoardCandidateClaim model."""
 
     def test_str_representation(self):
-        """Test __str__ returns the claim title."""
-        claim = BoardCandidateClaim(title="Test Claim Title")
+        """Test __str__ returns the claim name."""
+        claim = BoardCandidateClaim(key="test-claim", name="Test Claim Name")
 
-        assert str(claim) == "Test Claim Title"
+        assert str(claim) == "Test Claim Name"
 
     def test_meta_options(self):
         """Test model meta options."""
@@ -86,11 +86,18 @@ class TestBoardCandidateClaimModel:
 
         assert field.blank
 
-    def test_title_max_length(self):
-        """Test title field max_length."""
-        field = BoardCandidateClaim._meta.get_field("title")
+    def test_name_max_length(self):
+        """Test name field max_length."""
+        field = BoardCandidateClaim._meta.get_field("name")
 
         assert field.max_length == 1000
+
+    def test_key_field_unique(self):
+        """Test key field is unique."""
+        field = BoardCandidateClaim._meta.get_field("key")
+
+        assert field.unique
+        assert field.max_length == 100
 
     def test_description_default_empty(self):
         """Test description field defaults to empty string."""
@@ -100,7 +107,9 @@ class TestBoardCandidateClaimModel:
 
     def test_clean_new_claim_passes(self):
         """Test that clean passes for new draft claims without pk."""
-        claim = BoardCandidateClaim(title="New Claim", status=BoardCandidateClaim.Status.DRAFT)
+        claim = BoardCandidateClaim(
+            key="new-claim", name="New Claim", status=BoardCandidateClaim.Status.DRAFT
+        )
         claim.pk = None
 
         claim.clean()
@@ -117,7 +126,7 @@ class TestBoardCandidateClaimModel:
     )
     def test_clean_new_claim_non_draft_raises(self, status):
         """Test that clean raises ValidationError when creating a non-draft claim."""
-        claim = BoardCandidateClaim(title="New Claim", status=status)
+        claim = BoardCandidateClaim(key="new-claim", name="New Claim", status=status)
         claim.pk = None
 
         with pytest.raises(ValidationError) as exc_info:
@@ -130,13 +139,40 @@ class TestBoardCandidateClaimModel:
         """Test that clean raises ValidationError when claim with pk does not exist in DB."""
         mock_objects.filter.return_value.first.return_value = None
 
-        claim = BoardCandidateClaim(title="Ghost Claim", status=BoardCandidateClaim.Status.DRAFT)
+        claim = BoardCandidateClaim(
+            key="ghost-claim", name="Ghost Claim", status=BoardCandidateClaim.Status.DRAFT
+        )
         claim.pk = 999
 
         with pytest.raises(ValidationError) as exc_info:
             claim.clean()
 
         assert str(exc_info.value.messages[0]) == "Claim does not exist."
+
+    @patch("apps.owasp.models.board_candidate_claim.BoardCandidateClaim.objects")
+    def test_clean_locked_claim_raises(self, mock_objects):
+        """Test that clean raises for any update on a locked claim."""
+        existing = BoardCandidateClaim(
+            key="locked-claim",
+            name="Locked Claim",
+            status=BoardCandidateClaim.Status.APPROVED,
+            is_locked=True,
+        )
+        existing.pk = 1
+        mock_objects.filter.return_value.first.return_value = existing
+
+        claim = BoardCandidateClaim(
+            key="locked-claim",
+            name="Locked Claim",
+            status=BoardCandidateClaim.Status.WITHDRAWN,
+        )
+        claim.is_locked = True
+        claim.pk = 1
+
+        with pytest.raises(ValidationError) as exc_info:
+            claim.clean()
+
+        assert str(exc_info.value.messages[0]) == "Cannot update a locked claim."
 
     @pytest.mark.parametrize(
         ("from_status", "to_status"),
@@ -146,23 +182,24 @@ class TestBoardCandidateClaimModel:
             (BoardCandidateClaim.Status.SUBMITTED, BoardCandidateClaim.Status.APPROVED),
             (BoardCandidateClaim.Status.SUBMITTED, BoardCandidateClaim.Status.REJECTED),
             (BoardCandidateClaim.Status.SUBMITTED, BoardCandidateClaim.Status.WITHDRAWN),
-            (BoardCandidateClaim.Status.APPROVED, BoardCandidateClaim.Status.WITHDRAWN),
         ],
     )
     @patch("apps.owasp.models.board_candidate_claim.BoardCandidateClaim.objects")
     def test_clean_valid_transition_passes(self, mock_objects, from_status, to_status):
         """Test that clean passes for valid status transitions."""
         existing = BoardCandidateClaim(
-            title="Original Title",
+            key="existing-claim",
+            name="Original Name",
             description="Original Description",
             status=from_status,
-            is_locked=from_status in BoardCandidateClaim.FINALIZED_STATUSES,
+            is_locked=False,
         )
         existing.pk = 1
         mock_objects.filter.return_value.first.return_value = existing
 
         claim = BoardCandidateClaim(
-            title=existing.title,
+            key=existing.key,
+            name=existing.name,
             description=existing.description,
             status=to_status,
         )
@@ -188,6 +225,7 @@ class TestBoardCandidateClaimModel:
             (BoardCandidateClaim.Status.APPROVED, BoardCandidateClaim.Status.SUBMITTED),
             (BoardCandidateClaim.Status.APPROVED, BoardCandidateClaim.Status.REJECTED),
             (BoardCandidateClaim.Status.APPROVED, BoardCandidateClaim.Status.DISCARDED),
+            (BoardCandidateClaim.Status.APPROVED, BoardCandidateClaim.Status.WITHDRAWN),
             (BoardCandidateClaim.Status.REJECTED, BoardCandidateClaim.Status.DRAFT),
             (BoardCandidateClaim.Status.REJECTED, BoardCandidateClaim.Status.SUBMITTED),
             (BoardCandidateClaim.Status.REJECTED, BoardCandidateClaim.Status.APPROVED),
@@ -209,16 +247,18 @@ class TestBoardCandidateClaimModel:
     def test_clean_invalid_transition_raises(self, mock_objects, from_status, to_status):
         """Test that clean raises for invalid status transitions."""
         existing = BoardCandidateClaim(
-            title="Original Title",
+            key="existing-claim",
+            name="Original Name",
             description="Original Description",
             status=from_status,
-            is_locked=from_status in BoardCandidateClaim.FINALIZED_STATUSES,
+            is_locked=False,
         )
         existing.pk = 1
         mock_objects.filter.return_value.first.return_value = existing
 
         claim = BoardCandidateClaim(
-            title=existing.title,
+            key=existing.key,
+            name=existing.name,
             description=existing.description,
             status=to_status,
         )
@@ -239,7 +279,8 @@ class TestBoardCandidateClaimModel:
     ):
         """Test that clean raises when changing disallowed fields during withdrawal."""
         existing = BoardCandidateClaim(
-            title="Original Title",
+            key="existing-claim",
+            name="Original Name",
             description="Original Description",
             status=BoardCandidateClaim.Status.SUBMITTED,
             is_locked=False,
@@ -248,7 +289,8 @@ class TestBoardCandidateClaimModel:
         mock_objects.filter.return_value.first.return_value = existing
 
         claim = BoardCandidateClaim(
-            title="Updated Title",
+            key="new-key",
+            name=existing.name,
             description=existing.description,
             status=BoardCandidateClaim.Status.WITHDRAWN,
         )
@@ -264,7 +306,8 @@ class TestBoardCandidateClaimModel:
     def test_clean_non_draft_claim_disallows_field_updates(self, mock_objects):
         """Test that non-draft claims cannot update non-status fields."""
         existing = BoardCandidateClaim(
-            title="Original Title",
+            key="existing-claim",
+            name="Original Name",
             description="Original Description",
             status=BoardCandidateClaim.Status.SUBMITTED,
             is_locked=False,
@@ -273,7 +316,8 @@ class TestBoardCandidateClaimModel:
         mock_objects.filter.return_value.first.return_value = existing
 
         claim = BoardCandidateClaim(
-            title="Updated Title",
+            key="new-key",
+            name=existing.name,
             description=existing.description,
             status=BoardCandidateClaim.Status.SUBMITTED,
         )
@@ -289,7 +333,8 @@ class TestBoardCandidateClaimModel:
     def test_clean_non_draft_claim_allows_status_update_only(self, mock_objects):
         """Test that non-draft claims can change status when fields are unchanged."""
         existing = BoardCandidateClaim(
-            title="Original Title",
+            key="existing-claim",
+            name="Original Name",
             description="Original Description",
             status=BoardCandidateClaim.Status.SUBMITTED,
             is_locked=False,
@@ -298,7 +343,8 @@ class TestBoardCandidateClaimModel:
         mock_objects.filter.return_value.first.return_value = existing
 
         claim = BoardCandidateClaim(
-            title=existing.title,
+            key=existing.key,
+            name=existing.name,
             description=existing.description,
             status=BoardCandidateClaim.Status.APPROVED,
         )
@@ -311,7 +357,9 @@ class TestBoardCandidateClaimModel:
     @patch("apps.owasp.models.board_candidate_claim.TimestampedModel.save")
     def test_save_calls_full_clean(self, mock_super_save, mock_full_clean):
         """Test that save calls full_clean before saving."""
-        claim = BoardCandidateClaim(title="Test Claim", status=BoardCandidateClaim.Status.DRAFT)
+        claim = BoardCandidateClaim(
+            key="test-claim", name="Test Claim", status=BoardCandidateClaim.Status.DRAFT
+        )
 
         claim.save()
 
@@ -331,7 +379,7 @@ class TestBoardCandidateClaimModel:
     @patch("apps.owasp.models.board_candidate_claim.TimestampedModel.save")
     def test_save_locks_claim_on_finalized_status(self, mock_super_save, mock_full_clean, status):
         """Test that save sets is_locked=True for finalized statuses."""
-        claim = BoardCandidateClaim(title="Test Claim", status=status)
+        claim = BoardCandidateClaim(key="test-claim", name="Test Claim", status=status)
         claim.is_locked = False
 
         claim.save()
@@ -351,7 +399,7 @@ class TestBoardCandidateClaimModel:
         self, mock_super_save, mock_full_clean, status
     ):
         """Test that save does not set is_locked=True for non-finalized statuses."""
-        claim = BoardCandidateClaim(title="Test Claim", status=status)
+        claim = BoardCandidateClaim(key="test-claim", name="Test Claim", status=status)
         claim.is_locked = False
 
         claim.save()


### PR DESCRIPTION
Fixes #4883

**Changes made:**

1. **PR #4743 discussion** — Locked claims are now fully frozen (no WITHDRAWN from APPROVED). Added early guard in clean() rejecting any update to locked claims.

2. **Add key field** — Added `key = CharField(max_length=100, unique=True)` to both models.

3. **Rename title to name** — Renamed for consistency.

4. **GraphQL layer** — Nodes and queries with single-node resolver.

5. **Admin fixes** — MRO order fixed, search_fields updated.

6. **Migration 0074** — Schema changes.

7. **Tests** — Updated for renames and new behavior.