### PR TITLE
fix(ai): resolve clarification agent tool conflict and empty response issues

### DIFF
--- a/backend/apps/ai/flows/assistant.py
+++ b/backend/apps/ai/flows/assistant.py
@@ -351,9 +351,11 @@ def process_query(  # noqa: PLR0911
                 )
                 return None
 
-            # Invoke Clarification Agent
+            # Invoke Clarification Agent (no tools needed - uses training knowledge)
             try:
-                clarification_result = execute_task(create_clarification_agent(), query)
+                clarification_result = execute_task(
+                    create_clarification_agent(), query, requires_tools=False
+                )
             except Exception:
                 logger.exception("Clarification agent failed, falling back to generic message")
                 return (
@@ -362,6 +364,15 @@ def process_query(  # noqa: PLR0911
                     "or wait for a response from one of the community members."
                 )
             else:
+                if not clarification_result:
+                    logger.warning(
+                        "Clarification agent returned empty result, using fallback"
+                    )
+                    return (
+                        "I'm unable to provide a confident answer to your question based on my "
+                        "current knowledge and available tools. Please try rephrasing your question "
+                        "or wait for a response from one of the community members."
+                    )
                 logger.info(
                     "Clarification agent returned",
                     extra={"clarification_preview": (clarification_result or "")[:200]},
@@ -397,6 +408,7 @@ def execute_task(
     task_description: str | None = None,
     *,
     is_channel_suggestion: bool = False,
+    requires_tools: bool = True,
 ) -> str:
     """Execute a task with an agent.
 
@@ -407,6 +419,8 @@ def execute_task(
         task_description: Optional task description to execute the task
         is_channel_suggestion: Whether this is a channel suggestion scenario
             from owasp-community channel
+        requires_tools: Whether tool-focused instructions should be injected.
+            Set to False for agents with no tools (e.g., clarification agent).
 
     Returns:
         Response string
@@ -417,22 +431,29 @@ def execute_task(
         raise ValueError(err_msg)
 
     if not task_description:
-        task_description = (
-            f"Answer this query: {query}\n\n"
-            "CRITICAL INSTRUCTIONS:\n"
-            "- You MUST use the provided tools to answer this question\n"
-            "- Do NOT rely on your training data or general knowledge\n"
-            "- If tools don't provide sufficient information, state that clearly\n"
-            "- Tool results are authoritative - use them exclusively\n"
-            "- Never guess or make assumptions based on general knowledge\n"
-            "- For RAG agent: ALWAYS call semantic_search tool first to retrieve relevant "
-            "context\n"
-            "- IMPORTANT: Do NOT retry the same tool call with the same input if it fails\n"
-            "- If a tool call fails or doesn't provide useful results, try a different "
-            "approach or tool\n"
-            "- If you've already tried a tool and it didn't work, do NOT call it again "
-            "with the same parameters"
-        )
+        if not requires_tools:
+            task_description = (
+                f"Answer this query concisely: {query}\n\n"
+                "Use your training knowledge to respond. "
+                "If you don't know the answer, state that clearly."
+            )
+        else:
+            task_description = (
+                f"Answer this query: {query}\n\n"
+                "CRITICAL INSTRUCTIONS:\n"
+                "- You MUST use the provided tools to answer this question\n"
+                "- Do NOT rely on your training data or general knowledge\n"
+                "- If tools don't provide sufficient information, state that clearly\n"
+                "- Tool results are authoritative - use them exclusively\n"
+                "- Never guess or make assumptions based on general knowledge\n"
+                "- For RAG agent: ALWAYS call semantic_search tool first to retrieve relevant "
+                "context\n"
+                "- IMPORTANT: Do NOT retry the same tool call with the same input if it fails\n"
+                "- If a tool call fails or doesn't provide useful results, try a different "
+                "approach or tool\n"
+                "- If you've already tried a tool and it didn't work, do NOT call it again "
+                "with the same parameters"
+            )
 
     if is_channel_suggestion:
         task_description += (

--- a/backend/tests/unit/apps/ai/flows/assistant_test.py
+++ b/backend/tests/unit/apps/ai/flows/assistant_test.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
-from apps.ai.flows.assistant import process_query
+from apps.ai.flows.assistant import CONFIDENCE_THRESHOLD, process_query
 
 
 class TestProcessQueryImageEnrichment:
@@ -107,7 +107,7 @@ def test_low_confidence_non_rag_triggers_clarification(
 ):
     """Low-confidence non-RAG routing should call Clarification Agent."""
     mock_analyze_query.return_value = {"is_simple": True, "sub_queries": []}
-    mock_route.return_value = {"intent": "project", "confidence": 0.5}
+    mock_route.return_value = {"intent": "project", "confidence": CONFIDENCE_THRESHOLD - 0.2}
     clarification_agent = MagicMock(name="clarification_agent")
     mock_create_clarify.return_value = clarification_agent
     mock_execute_task.return_value = "Clarify: which project?"
@@ -115,7 +115,9 @@ def test_low_confidence_non_rag_triggers_clarification(
     res = process_query("Ambiguous query", is_app_mention=True)
 
     mock_create_clarify.assert_called_once()
-    mock_execute_task.assert_called_once_with(clarification_agent, "Ambiguous query")
+    mock_execute_task.assert_called_once_with(
+        clarification_agent, "Ambiguous query", requires_tools=False
+    )
     assert res == "Clarify: which project?"
 
 
@@ -128,7 +130,7 @@ def test_low_confidence_rag_triggers_clarification_when_policy_removed(
 ):
     """Low-confidence RAG routing should also call Clarification Agent."""
     mock_analyze_query.return_value = {"is_simple": True, "sub_queries": []}
-    mock_route.return_value = {"intent": "rag", "confidence": 0.4}
+    mock_route.return_value = {"intent": "rag", "confidence": CONFIDENCE_THRESHOLD - 0.3}
     clarification_agent = MagicMock(name="clarification_agent")
     mock_create_clarify.return_value = clarification_agent
     mock_execute_task.return_value = "Clarify: please specify 'this'"
@@ -136,5 +138,7 @@ def test_low_confidence_rag_triggers_clarification_when_policy_removed(
     res = process_query("Is this covered by OWASP?", is_app_mention=True)
 
     mock_create_clarify.assert_called_once()
-    mock_execute_task.assert_called_once_with(clarification_agent, "Is this covered by OWASP?")
+    mock_execute_task.assert_called_once_with(
+        clarification_agent, "Is this covered by OWASP?", requires_tools=False
+    )
     assert res == "Clarify: please specify 'this'"


### PR DESCRIPTION
## Description

Fixes two blocking issues in the clarification agent flow (from PR #4357 review):

### 1. Tool conflict: agent has `tools=[]` but `execute_task` demands tool usage

The clarification agent is created with `tools=[]`, but `execute_task()` unconditionally injected "You MUST use the provided tools" / "Do NOT rely on your training data" instructions. This created a conflicting prompt that confused the LLM.

**Fix:** Added `requires_tools: bool = True` parameter to `execute_task()`. When `requires_tools=False`, the task description uses a simple knowledge-based prompt instead of tool-focused instructions. The clarification agent call now passes `requires_tools=False`.

### 2. Empty clarification result returned as blank response

If the clarification agent returned an empty/falsy result, it was returned directly to the user as a blank response.

**Fix:** Added a falsy check — if `clarification_result` is empty, it logs a warning and returns the generic fallback message instead.

### 3. Tests use hardcoded confidence values

Test assertions used hardcoded `0.5` / `0.4` instead of deriving from `CONFIDENCE_THRESHOLD`.

**Fix:** Replaced with `CONFIDENCE_THRESHOLD - 0.2` / `CONFIDENCE_THRESHOLD - 0.3`. Also updated assertions to match the new `requires_tools=False` kwarg.

## Changes

| File | Change |
|------|--------|
| `backend/apps/ai/flows/assistant.py` | Added `requires_tools` param to `execute_task`, empty-result guard on clarification agent |
| `backend/tests/unit/apps/ai/flows/assistant_test.py` | Use `CONFIDENCE_THRESHOLD` constants, update assertions for `requires_tools` |