### PR TITLE
feat(github): add recent repository fields

### DIFF
--- a/backend/apps/github/api/internal/nodes/repository.py
+++ b/backend/apps/github/api/internal/nodes/repository.py
@@ -46,6 +46,16 @@ class RepositoryNode(strawberry.relay.Node):
     organization: OrganizationNode | None = strawberry_django.field()
 
     @strawberry_django.field(prefetch_related=["issues"])
+    def recent_issues(self, root: Repository) -> list[IssueNode]:
+        """Resolve recent issues."""
+        return root.issues.order_by("-created_at")[:RECENT_ISSUES_LIMIT]
+
+    @strawberry_django.field(prefetch_related=["releases"])
+    def recent_releases(self, root: Repository) -> list[ReleaseNode]:
+        """Resolve recent releases."""
+        return root.published_releases.order_by("-published_at")[:RECENT_RELEASES_LIMIT]
+
+    @strawberry_django.field(prefetch_related=["issues"])
     def issues(self, root: Repository) -> list[IssueNode]:
         """Resolve recent issues."""
         # TODO(arkid15r): rename this to recent_issues.

--- a/backend/tests/unit/apps/github/api/internal/nodes/repository_test.py
+++ b/backend/tests/unit/apps/github/api/internal/nodes/repository_test.py
@@ -34,7 +34,9 @@ class TestRepositoryNode(GraphQLNodeBaseTest):
             "open_issues_count",
             "organization",
             "project",
+            "recent_issues",
             "recent_milestones",
+            "recent_releases",
             "releases",
             "size",
             "stars_count",
@@ -48,6 +50,11 @@ class TestRepositoryNode(GraphQLNodeBaseTest):
 
     def test_resolve_issues(self):
         field = self._get_field_by_name("issues", RepositoryNode)
+        assert field is not None
+        assert field.type.of_type is IssueNode
+
+    def test_resolve_recent_issues(self):
+        field = self._get_field_by_name( "recent_issues", RepositoryNode )
         assert field is not None
         assert field.type.of_type is IssueNode
 
@@ -76,6 +83,11 @@ class TestRepositoryNode(GraphQLNodeBaseTest):
         assert field is not None
         assert field.type.of_type is ReleaseNode
 
+    def test_resolve_recent_releases(self):
+        field = self._get_field_by_name( "recent_releases", RepositoryNode )
+        assert field is not None
+        assert field.type.of_type is ReleaseNode
+
     def test_resolve_top_contributors(self):
         field = self._get_field_by_name("top_contributors", RepositoryNode)
         assert field is not None
@@ -101,6 +113,17 @@ class TestRepositoryNode(GraphQLNodeBaseTest):
         field = self._get_field_by_name("issues", RepositoryNode)
         field.base_resolver.wrapped_func(None, mock_repository)
         mock_issues.order_by.assert_called_with("-created_at")
+
+    def test_recent_issues_method(self):
+        """Test recent_issues method resolution."""
+        mock_repository = Mock()
+        mock_issues = Mock()
+        mock_issues.order_by.return_value.__getitem__ = Mock( return_value=[] )
+        mock_repository.issues = mock_issues
+
+        field = self._get_field_by_name( "recent_issues", RepositoryNode )
+        field.base_resolver.wrapped_func( None, mock_repository )
+        mock_issues.order_by.assert_called_with( "-created_at" )
 
     def test_recent_milestones_with_invalid_limit(self):
         """Test recent_milestones returns empty list for invalid limit."""
@@ -161,6 +184,18 @@ class TestRepositoryNode(GraphQLNodeBaseTest):
         resolver = field.base_resolver.wrapped_func
         resolver(None, mock_repository)
         mock_releases.order_by.assert_called_with("-published_at")
+
+    def test_recent_releases_method(self):
+        """Test recent_releases method resolution."""
+        mock_repository = Mock()
+        mock_releases = Mock()
+        mock_releases.order_by.return_value.__getitem__ = Mock( return_value=[] )
+        mock_repository.published_releases = mock_releases
+
+        field = self._get_field_by_name( "recent_releases", RepositoryNode )
+        resolver = field.base_resolver.wrapped_func
+        resolver( None, mock_repository )
+        mock_releases.order_by.assert_called_with( "-published_at" )
 
     def test_top_contributors_method(self):
         """Test top_contributors method resolution."""


### PR DESCRIPTION
Closes #4895
## Proposed change

Adds explicit `recent_issues` and `recent_releases` fields to `RepositoryNode`.

The existing `issues` and `releases` fields currently return only a limited subset of records, which may be confusing to GraphQL consumers because their names imply complete collections.

This change introduces clearly named fields that reflect the existing behavior while preserving backward compatibility.

## Changes

* Add `recent_issues` field to `RepositoryNode`
* Add `recent_releases` field to `RepositoryNode`
* Add unit tests for both fields
* Expose the new fields in GraphQL schema metadata

## Testing

* Added unit tests covering field exposure
* Added resolver tests for recent issues
* Added resolver tests for recent releases


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/OWASP/Nest/pull/4907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

