### PR TITLE
fix(slack): eliminate duplicate QuestionDetector classification in AI reply flow

### DIFF
--- a/backend/apps/slack/common/handlers/ai.py
+++ b/backend/apps/slack/common/handlers/ai.py
@@ -29,19 +29,22 @@ def get_blocks(query: str) -> list[dict]:
     return get_error_blocks()
 
 
-def process_ai_query(query: str) -> str | None:
+def process_ai_query(query: str, skip_question_check: bool = False) -> str | None:
     """Process the AI query using the agentic RAG agent.
 
     Args:
         query (str): The user's question.
+        skip_question_check (bool): Skip QuestionDetector classification when the
+            caller has already validated the question is OWASP-related.
 
     Returns:
         str | None: The AI response or None if error occurred.
 
     """
-    question_detector = QuestionDetector()
-    if not question_detector.is_owasp_question(text=query):
-        return get_default_response()
+    if not skip_question_check:
+        question_detector = QuestionDetector()
+        if not question_detector.is_owasp_question(text=query):
+            return get_default_response()
 
     agent = AgenticRAGAgent()
     result = agent.run(query=query)

--- a/backend/apps/slack/services/message_auto_reply.py
+++ b/backend/apps/slack/services/message_auto_reply.py
@@ -6,7 +6,8 @@ from django_rq import job
 from slack_sdk.errors import SlackApiError
 
 from apps.slack.apps import SlackConfig
-from apps.slack.common.handlers.ai import get_blocks, process_ai_query
+from apps.slack.blocks import markdown
+from apps.slack.common.handlers.ai import process_ai_query
 from apps.slack.models import Message
 
 logger = logging.getLogger(__name__)
@@ -41,13 +42,15 @@ def generate_ai_reply_if_unanswered(message_id: int):
     except SlackApiError:
         logger.exception("Error checking for replies for message")
 
-    ai_response_text = process_ai_query(query=message.text)
+    # The message was already validated as an OWASP question in MessagePosted.handle_event
+    # before the job was enqueued, so skip the QuestionDetector re-check here.
+    ai_response_text = process_ai_query(query=message.text, skip_question_check=True)
     if not ai_response_text:
         return
 
     client.chat_postMessage(
         channel=message.conversation.slack_channel_id,
-        blocks=get_blocks(ai_response_text),
+        blocks=[markdown(ai_response_text)],
         text=ai_response_text,
         thread_ts=message.slack_message_id,
     )

--- a/backend/tests/unit/apps/slack/common/handlers/ai_test.py
+++ b/backend/tests/unit/apps/slack/common/handlers/ai_test.py
@@ -149,6 +149,26 @@ class TestAiHandler:
         mock_question_detector.is_owasp_question.assert_called_once_with(text=query)
         assert result == get_default_response()
 
+    @patch("apps.slack.common.handlers.ai.AgenticRAGAgent")
+    @patch("apps.slack.common.handlers.ai.QuestionDetector")
+    def test_process_ai_query_skips_question_check_when_flagged(
+        self, mock_question_detector_class, mock_agent_class
+    ):
+        """Test that QuestionDetector is not instantiated when skip_question_check=True."""
+        query = "What is OWASP?"
+        expected_response = "OWASP is a security organization..."
+
+        mock_agent = Mock()
+        mock_agent.run.return_value = {"answer": expected_response}
+        mock_agent_class.return_value = mock_agent
+
+        result = process_ai_query(query, skip_question_check=True)
+
+        mock_question_detector_class.assert_not_called()
+        mock_agent_class.assert_called_once()
+        mock_agent.run.assert_called_once_with(query=query)
+        assert result == expected_response
+
     @patch("apps.slack.common.handlers.ai.markdown")
     def test_get_error_blocks(self, mock_markdown):
         """Test error blocks generation."""

--- a/backend/tests/unit/apps/slack/services/message_auto_reply_test.py
+++ b/backend/tests/unit/apps/slack/services/message_auto_reply_test.py
@@ -45,27 +45,24 @@ class TestMessageAutoReply:
     @patch.object(SlackConfig, "app")
     @patch("apps.slack.services.message_auto_reply.Message.objects.get")
     @patch("apps.slack.services.message_auto_reply.process_ai_query")
-    @patch("apps.slack.services.message_auto_reply.get_blocks")
+    @patch("apps.slack.services.message_auto_reply.markdown")
     def test_generate_ai_reply_success(
         self,
-        mock_get_blocks,
+        mock_markdown,
         mock_process_ai_query,
         mock_message_get,
         mock_app,
         mock_message,
     ):
         """Test successful AI reply generation."""
+        ai_response = "OWASP is a security organization..."
+        expected_block = {
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": ai_response},
+        }
         mock_message_get.return_value = mock_message
-        mock_process_ai_query.return_value = "OWASP is a security organization..."
-        mock_get_blocks.return_value = [
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": "OWASP is a security organization...",
-                },
-            }
-        ]
+        mock_process_ai_query.return_value = ai_response
+        mock_markdown.return_value = expected_block
         mock_client = Mock()
         mock_app.client = mock_client
         mock_client.conversations_replies.return_value = {"messages": [{"reply_count": 0}]}
@@ -77,20 +74,14 @@ class TestMessageAutoReply:
             ts=mock_message.slack_message_id,
             limit=1,
         )
-        mock_process_ai_query.assert_called_once_with(query=mock_message.text)
-        mock_get_blocks.assert_called_once_with("OWASP is a security organization...")
+        mock_process_ai_query.assert_called_once_with(
+            query=mock_message.text, skip_question_check=True
+        )
+        mock_markdown.assert_called_once_with(ai_response)
         mock_client.chat_postMessage.assert_called_once_with(
             channel=mock_message.conversation.slack_channel_id,
-            blocks=[
-                {
-                    "type": "section",
-                    "text": {
-                        "type": "mrkdwn",
-                        "text": "OWASP is a security organization...",
-                    },
-                }
-            ],
-            text="OWASP is a security organization...",
+            blocks=[expected_block],
+            text=ai_response,
             thread_ts=mock_message.slack_message_id,
         )
 
@@ -146,37 +137,32 @@ class TestMessageAutoReply:
     @patch.object(SlackConfig, "app")
     @patch("apps.slack.services.message_auto_reply.Message.objects.get")
     @patch("apps.slack.services.message_auto_reply.process_ai_query")
-    @patch("apps.slack.services.message_auto_reply.get_blocks")
+    @patch("apps.slack.services.message_auto_reply.markdown")
     @patch("apps.slack.services.message_auto_reply.logger")
     def test_generate_ai_reply_slack_api_error(
         self,
         mock_logger,
-        mock_get_blocks,
+        mock_markdown,
         mock_process_ai_query,
         mock_message_get,
         mock_app,
         mock_message,
     ):
         """Test when Slack API error occurs while checking replies."""
+        ai_response = "OWASP is a security organization..."
         mock_message_get.return_value = mock_message
         mock_client = Mock()
         mock_app.client = mock_client
         mock_client.conversations_replies.side_effect = SlackApiError("API Error", response=Mock())
-        mock_process_ai_query.return_value = "OWASP is a security organization..."
-        mock_get_blocks.return_value = [
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": "OWASP is a security organization...",
-                },
-            }
-        ]
+        mock_process_ai_query.return_value = ai_response
+        mock_markdown.return_value = {"type": "section", "text": {"type": "mrkdwn", "text": ai_response}}
 
         generate_ai_reply_if_unanswered(mock_message.id)
 
         mock_logger.exception.assert_called_once_with("Error checking for replies for message")
-        mock_process_ai_query.assert_called_once()
+        mock_process_ai_query.assert_called_once_with(
+            query=mock_message.text, skip_question_check=True
+        )
         mock_client.chat_postMessage.assert_called_once()
 
     @patch.object(SlackConfig, "app")
@@ -220,3 +206,26 @@ class TestMessageAutoReply:
         generate_ai_reply_if_unanswered(mock_message.id)
 
         mock_client.chat_postMessage.assert_not_called()
+
+    @patch.object(SlackConfig, "app")
+    @patch("apps.slack.services.message_auto_reply.Message.objects.get")
+    @patch("apps.slack.services.message_auto_reply.process_ai_query")
+    def test_generate_ai_reply_skips_question_check(
+        self,
+        mock_process_ai_query,
+        mock_message_get,
+        mock_app,
+        mock_message,
+    ):
+        """Test that QuestionDetector is not re-run — skip_question_check=True is passed."""
+        mock_message_get.return_value = mock_message
+        mock_client = Mock()
+        mock_app.client = mock_client
+        mock_client.conversations_replies.return_value = {"messages": [{"reply_count": 0}]}
+        mock_process_ai_query.return_value = None
+
+        generate_ai_reply_if_unanswered(mock_message.id)
+
+        mock_process_ai_query.assert_called_once_with(
+            query=mock_message.text, skip_question_check=True
+        )


### PR DESCRIPTION
## Summary

Fixes #4870.

`process_ai_query()` was instantiating and running `QuestionDetector.is_owasp_question()` a second time even though `MessagePosted.handle_event()` had already confirmed the message is OWASP-related before the job was enqueued. This wasted compute and added latency to every AI reply.

A second bug was also present: `generate_ai_reply_if_unanswered()` passed the AI *response text* to `get_blocks()`, which is designed to accept the original *query* — causing the AI model to run a third time on its own output.

## Changes

- Add `skip_question_check: bool = False` parameter to `process_ai_query()`. When `True`, the `QuestionDetector` instantiation and classification step is skipped entirely.
- Pass `skip_question_check=True` from `generate_ai_reply_if_unanswered()` since the message was pre-validated at enqueue time.
- Replace `get_blocks(ai_response_text)` with `markdown(ai_response_text)` directly in `message_auto_reply.py` to format the response without re-running the AI model.
- Update tests: assert `skip_question_check=True` is passed, `QuestionDetector` is not instantiated in the pre-validated path, and `markdown()` is used for block formatting.
- Add `test_process_ai_query_skips_question_check_when_flagged` to `ai_test.py`.

## Test plan

- [ ] All existing unit tests pass
- [ ] `test_generate_ai_reply_skips_question_check` confirms `QuestionDetector` is not re-run
- [ ] `test_process_ai_query_skips_question_check_when_flagged` confirms the new parameter works

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/OWASP/Nest/pull/4908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

