### PR TITLE
fix(graphql): rename RepositoryNode issues/releases to recent_issues/recent_releases

### DIFF
--- a/backend/apps/github/api/internal/nodes/repository.py
+++ b/backend/apps/github/api/internal/nodes/repository.py
@@ -46,9 +46,8 @@ class RepositoryNode(strawberry.relay.Node):
     organization: OrganizationNode | None = strawberry_django.field()
 
     @strawberry_django.field(prefetch_related=["issues"])
-    def issues(self, root: Repository) -> list[IssueNode]:
+    def recent_issues(self, root: Repository) -> list[IssueNode]:
         """Resolve recent issues."""
-        # TODO(arkid15r): rename this to recent_issues.
         return root.issues.order_by("-created_at")[:RECENT_ISSUES_LIMIT]
 
     @strawberry_django.field
@@ -77,9 +76,8 @@ class RepositoryNode(strawberry.relay.Node):
         return root.recent_milestones.order_by("-created_at")[:normalized_limit]
 
     @strawberry_django.field(prefetch_related=["releases"])
-    def releases(self, root: Repository) -> list[ReleaseNode]:
+    def recent_releases(self, root: Repository) -> list[ReleaseNode]:
         """Resolve recent releases."""
-        # TODO(arkid15r): rename this to recent_releases.
         return root.published_releases.order_by("-published_at")[:RECENT_RELEASES_LIMIT]
 
     @strawberry_django.field

--- a/backend/tests/unit/apps/github/api/internal/nodes/repository_test.py
+++ b/backend/tests/unit/apps/github/api/internal/nodes/repository_test.py
@@ -25,7 +25,7 @@ class TestRepositoryNode(GraphQLNodeBaseTest):
             "description",
             "forks_count",
             "is_archived",
-            "issues",
+            "recent_issues",
             "key",
             "languages",
             "latest_release",
@@ -35,7 +35,7 @@ class TestRepositoryNode(GraphQLNodeBaseTest):
             "organization",
             "project",
             "recent_milestones",
-            "releases",
+            "recent_releases",
             "size",
             "stars_count",
             "subscribers_count",
@@ -46,8 +46,8 @@ class TestRepositoryNode(GraphQLNodeBaseTest):
         }
         assert expected_field_names.issubset(field_names)
 
-    def test_resolve_issues(self):
-        field = self._get_field_by_name("issues", RepositoryNode)
+    def test_resolve_recent_issues(self):
+        field = self._get_field_by_name("recent_issues", RepositoryNode)
         assert field is not None
         assert field.type.of_type is IssueNode
 
@@ -71,8 +71,8 @@ class TestRepositoryNode(GraphQLNodeBaseTest):
         assert field is not None
         assert field.type.of_type is MilestoneNode
 
-    def test_resolve_releases(self):
-        field = self._get_field_by_name("releases", RepositoryNode)
+    def test_resolve_recent_releases(self):
+        field = self._get_field_by_name("recent_releases", RepositoryNode)
         assert field is not None
         assert field.type.of_type is ReleaseNode
 
@@ -91,14 +91,14 @@ class TestRepositoryNode(GraphQLNodeBaseTest):
         assert field is not None
         assert field.type is str
 
-    def test_issues_method(self):
-        """Test issues method resolution."""
+    def test_recent_issues_method(self):
+        """Test recent_issues method resolution."""
         mock_repository = Mock()
         mock_issues = Mock()
         mock_issues.order_by.return_value.__getitem__ = Mock(return_value=[])
         mock_repository.issues = mock_issues
 
-        field = self._get_field_by_name("issues", RepositoryNode)
+        field = self._get_field_by_name("recent_issues", RepositoryNode)
         field.base_resolver.wrapped_func(None, mock_repository)
         mock_issues.order_by.assert_called_with("-created_at")
 

--- a/frontend/src/app/organizations/[organizationKey]/repositories/[repositoryKey]/page.tsx
+++ b/frontend/src/app/organizations/[organizationKey]/repositories/[repositoryKey]/page.tsx
@@ -35,7 +35,7 @@ const RepositoryDetailsPage = () => {
   const repository = data?.repository
   const topContributors = data?.topContributors ?? []
   const recentPullRequests = data?.recentPullRequests
-  const recentIssues = repository?.issues?.map((issue) => ({
+  const recentIssues = repository?.recentIssues?.map((issue) => ({
     ...issue,
     author: issue.author ?? undefined,
   }))
@@ -135,7 +135,7 @@ const RepositoryDetailsPage = () => {
         recentIssues={recentIssues ?? []}
         recentMilestones={repository.recentMilestones ?? []}
         pullRequests={recentPullRequests ?? []}
-        recentReleases={repository.releases ?? []}
+        recentReleases={repository.recentReleases ?? []}
         showAvatar={true}
       />
 

--- a/frontend/src/server/queries/repositoryQueries.ts
+++ b/frontend/src/server/queries/repositoryQueries.ts
@@ -11,7 +11,7 @@ export const GET_REPOSITORY_DATA = gql`
       forksCount
       isArchived
       key
-      issues {
+      recentIssues {
         id
         author {
           id
@@ -39,7 +39,7 @@ export const GET_REPOSITORY_DATA = gql`
         key
         name
       }
-      releases {
+      recentReleases {
         id
         author {
           id


### PR DESCRIPTION
## Summary

Fixes #4895.

The `RepositoryNode` GraphQL type exposed `issues` and `releases` fields that returned only the 5 most recent items (`RECENT_ISSUES_LIMIT = 5`, `RECENT_RELEASES_LIMIT = 5`). The field names implied complete collections to API consumers, while the resolver code itself had TODO comments noting the rename was needed.

## Changes

- Rename `issues()` resolver to `recent_issues()` in `RepositoryNode`
- Rename `releases()` resolver to `recent_releases()` in `RepositoryNode`
- Remove the TODO comments that flagged this inconsistency
- Update `GET_REPOSITORY_DATA` query in `repositoryQueries.ts` to request `recentIssues` and `recentReleases`
- Update the repository detail page (`page.tsx`) to use the renamed fields from the query response
- Update `repository_test.py`: rename test methods and the expected field name set

**Note:** Run `yarn codegen` in the `frontend` directory after merging to regenerate the TypeScript types from the updated GraphQL schema.

## Test plan

- [ ] Backend unit tests pass (renamed resolver methods, updated expected field names)
- [ ] Frontend page renders repository issues and releases correctly
- [ ] `yarn codegen` completes without errors after merging

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/OWASP/Nest/pull/4909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

