### PR TITLE
feat(frontend): display repository last updated date

### DIFF
--- a/frontend/__tests__/a11y/components/RepositoryCard.a11y.test.tsx
+++ b/frontend/__tests__/a11y/components/RepositoryCard.a11y.test.tsx
@@ -5,6 +5,7 @@ import { RepositoryCardProps } from 'types/project'
 import RepositoryCard from 'components/RepositoryCard'
 
 const createMockRepository = (index: number): RepositoryCardProps => ({
+  updatedAt: '2025-01-01T00:00:00.000Z',
   contributorsCount: 10 + index,
   forksCount: 5 + index,
   key: `repo-${index}`,

--- a/frontend/__tests__/unit/components/RepositoryCard.test.tsx
+++ b/frontend/__tests__/unit/components/RepositoryCard.test.tsx
@@ -48,6 +48,7 @@ describe('RepositoryCard', () => {
   })
 
   const createMockRepository = (index: number): RepositoryCardProps => ({
+    updatedAt: '2025-01-01T00:00:00.000Z',
     contributorsCount: 10 + index,
     forksCount: 5 + index,
     key: `repo-${index}`,
@@ -70,6 +71,12 @@ describe('RepositoryCard', () => {
     starsCount: 100 + index,
     subscribersCount: 20 + index,
     url: `https://github.com/org-${index}/repo-${index}`,
+  })
+
+  it('displays repository updated date when available', () => {
+    const repositories = [createMockRepository(0)]
+    render(<RepositoryCard repositories={repositories} />)
+    expect(screen.getByText(/Updated/i)).toBeInTheDocument()
   })
 
   it('renders without crashing with empty repositories', () => {

--- a/frontend/src/components/RepositoryCard.tsx
+++ b/frontend/src/components/RepositoryCard.tsx
@@ -86,6 +86,12 @@ const RepositoryItem = ({ details }: { details: RepositoryCardProps }) => {
           unit="Issue"
           value={details.openIssuesCount}
         />
+
+        {details.updatedAt && (
+          <div className="text-xs text-gray-500 dark:text-gray-400">
+            Updated {new Date(details.updatedAt).toLocaleDateString()}
+          </div>
+        )}
       </div>
     </div>
   )

--- a/frontend/src/server/queries/organizationQueries.ts
+++ b/frontend/src/server/queries/organizationQueries.ts
@@ -76,6 +76,7 @@ export const GET_ORGANIZATION_DATA = gql`
       url
     }
     repositories(organization: $login, limit: 12) {
+      updatedAt
       id
       contributorsCount
       forksCount

--- a/frontend/src/types/project.ts
+++ b/frontend/src/types/project.ts
@@ -63,6 +63,7 @@ export type RepositoryCardListProps = {
 }
 
 export type RepositoryCardProps = {
+  updatedAt?: string
   contributorsCount: number
   forksCount: number
   isArchived?: boolean


### PR DESCRIPTION
Closes #4912
## Summary

Display repository last updated information on repository cards.

### Changes

* Added `updatedAt` to the repositories GraphQL query.
* Added `updatedAt` to `RepositoryCardProps`.
* Displayed repository last updated date in `RepositoryCard`.
* Added unit test coverage.
* Updated accessibility test mocks.

### Testing

* Updated unit tests.
* Updated accessibility tests.

### Notes

I was unable to regenerate GraphQL generated files locally because `graphql-codegen` requires a running backend (`/csrf/` and `/graphql/` endpoints), which was not available in my local environment.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/OWASP/Nest/pull/4911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

