### PR TITLE
fix:replace some github api badge with static ones

### DIFF
--- a/.github/workflows/update-badges.yaml
+++ b/.github/workflows/update-badges.yaml
@@ -5,24 +5,38 @@ on:
     - cron: 0 */6 * * *
   workflow_dispatch:
 
+concurrency:
+  group: update-readme-badges
+  cancel-in-progress: false
+
 jobs:
   update-badges:
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Fetch latest badge values
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           echo "STARS=$(gh api repos/OWASP/Nest --jq .stargazers_count)" >> $GITHUB_ENV
+
+          contributors_json="$(gh api repos/OWASP/Nest/stats/contributors)"
+          if echo "$contributors_json" | jq -e 'type == "array"' >/dev/null; then
+            contributors_count="$(echo "$contributors_json" | jq '[.[] | select(.total > 0)] | length')"
+          else
+            contributors_count=0
+          fi
+          echo "CONTRIBUTORS=$contributors_count" >> $GITHUB_ENV
+
           echo "FORKS=$(gh api repos/OWASP/Nest --jq .forks_count)" >> $GITHUB_ENV
           echo "ISSUES=$(gh api 'search/issues?q=repo:OWASP/Nest+type:issue+state:open' --jq .total_count)" >> $GITHUB_ENV
           echo "PRS=$(gh api 'search/issues?q=repo:OWASP/Nest+type:pr+state:open' --jq .total_count)" >> $GITHUB_ENV
           echo "CONTRIBUTORS=$(gh api repos/OWASP/Nest/stats/contributors --jq '[.[] | select(.total > 0)] | length')" >> $GITHUB_ENV
-          echo "LAST_COMMIT=$(gh api repos/OWASP/Nest/commits/main --jq '.commit.committer.date[:10]')" >> $GITHUB_ENV
+          raw_last_commit="$(gh api repos/OWASP/Nest/commits/main --jq '.commit.committer.date[:10]')"
+          echo "LAST_COMMIT=${raw_last_commit//-/--}" >> $GITHUB_ENV
 
       - name: Update README.md with new values
         run: |

--- a/.github/workflows/update-badges.yaml
+++ b/.github/workflows/update-badges.yaml
@@ -1,0 +1,44 @@
+name: Update README badges
+
+on:
+  schedule:
+    - cron: 0 */6 * * *
+  workflow_dispatch:
+
+jobs:
+  update-badges:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fetch latest badge values
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "STARS=$(gh api repos/OWASP/Nest --jq .stargazers_count)" >> $GITHUB_ENV
+          echo "FORKS=$(gh api repos/OWASP/Nest --jq .forks_count)" >> $GITHUB_ENV
+          echo "ISSUES=$(gh api 'search/issues?q=repo:OWASP/Nest+type:issue+state:open' --jq .total_count)" >> $GITHUB_ENV
+          echo "PRS=$(gh api 'search/issues?q=repo:OWASP/Nest+type:pr+state:open' --jq .total_count)" >> $GITHUB_ENV
+          echo "CONTRIBUTORS=$(gh api repos/OWASP/Nest/stats/contributors --jq '[.[] | select(.total > 0)] | length')" >> $GITHUB_ENV
+          echo "LAST_COMMIT=$(gh api repos/OWASP/Nest/commits/main --jq '.commit.committer.date[:10]')" >> $GITHUB_ENV
+
+      - name: Update README.md with new values
+        run: |
+          sed -i 's|https://img.shields.io/badge/Stars-[0-9]*-blue|https://img.shields.io/badge/Stars-'"$STARS"'-blue|g' README.md
+          sed -i 's|https://img.shields.io/badge/Forks-[0-9]*-blue|https://img.shields.io/badge/Forks-'"$FORKS"'-blue|g' README.md
+          sed -i 's|https://img.shields.io/badge/Contributors-[0-9]*-blue|https://img.shields.io/badge/Contributors-'"$CONTRIBUTORS"'-blue|g' README.md
+          sed -i 's|https://img.shields.io/badge/Last%20commit-[^"< ]*-blue|https://img.shields.io/badge/Last%20commit-'"$LAST_COMMIT"'-blue|g' README.md
+          sed -i 's|https://img.shields.io/badge/Issues-[0-9]*-blue|https://img.shields.io/badge/Issues-'"$ISSUES"'-blue|g' README.md
+          sed -i 's|https://img.shields.io/badge/Pull%20Requests-[0-9]*-blue|https://img.shields.io/badge/Pull%20Requests-'"$PRS"'-blue|g' README.md
+
+      - name: Commit if changed
+        run: |
+          if ! git diff --quiet README.md; then
+            git config user.name 'github-actions[bot]'
+            git config user.email 'github-actions[bot]@users.noreply.github.com'
+            git add README.md
+            git commit -m 'Update README badges'
+            git push
+          fi

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 [![OWASP](https://img.shields.io/badge/production-blue?&label=level&style=for-the-badge)](https://owasp.org/www-project-nest/) [![OWASP](https://img.shields.io/badge/Code-blue?label=type&style=for-the-badge)](https://owasp.org/www-project-nest/) [![License](https://img.shields.io/badge/license-%20MIT-blue?style=for-the-badge)](https://github.com/OWASP/Nest/blob/main/LICENSE) [![project-nest](https://img.shields.io/badge/%23project--nest-blue?label=slack&logoColor=white&style=for-the-badge)](https://owasp.slack.com/archives/project-nest)
 
-[![Forks](https://img.shields.io/github/forks/owasp/nest?style=for-the-badge&label=Forks)](https://github.com/OWASP/Nest/network/members) [![Stars](https://img.shields.io/github/stars/owasp/nest?style=for-the-badge&label=Stars)](https://github.com/OWASP/Nest/stargazers) [![Contributors](https://img.shields.io/github/contributors/owasp/nest?style=for-the-badge&label=Contributors&color=blue)](https://github.com/OWASP/Nest/graphs/contributors) [![Last Commit](https://img.shields.io/github/last-commit/owasp/nest/main?color=blue&style=for-the-badge&label=Last%20commit)](https://github.com/OWASP/Nest/commits/main/)
+[![Forks](https://img.shields.io/badge/Forks-644-blue?style=for-the-badge)](https://github.com/OWASP/Nest/network/members) [![Stars](https://img.shields.io/badge/Stars-409-blue?style=for-the-badge)](https://github.com/OWASP/Nest/stargazers) [![Contributors](https://img.shields.io/badge/Contributors-100-blue?style=for-the-badge)](https://github.com/OWASP/Nest/graphs/contributors) [![Last Commit](https://img.shields.io/badge/Last%20commit-2026--06--15-blue?style=for-the-badge)](https://github.com/OWASP/Nest/commits/main/)
 
 [![CI](https://img.shields.io/github/actions/workflow/status/owasp/nest/ci.yaml?branch=main&color=blue&label=CI&style=for-the-badge)](https://github.com/owasp/nest/actions/workflows/ci.yaml?query=branch%3Amain) [![CI/CD](https://img.shields.io/github/actions/workflow/status/owasp/nest/ci-cd-staging.yaml?branch=main&color=blue&label=CI%2FCD&style=for-the-badge)](https://github.com/owasp/nest/actions/workflows/ci-cd-staging.yaml?query=branch%3Amain) [![CodeQL](https://img.shields.io/github/actions/workflow/status/owasp/nest/code-ql.yaml?branch=main&color=blue&label=CodeQL&style=for-the-badge)](https://github.com/owasp/nest/actions/workflows/code-ql.yaml?query=branch%3Amain)
 
-[![Issues](https://img.shields.io/github/issues/owasp/nest?color=blue&style=for-the-badge&label=Issues)](https://github.com/OWASP/Nest/issues) [![Pull Requests](https://img.shields.io/github/issues-pr/owasp/nest?color=blue&style=for-the-badge&label=Pull%20Requests)](https://github.com/OWASP/Nest/pulls)
+[![Issues](https://img.shields.io/badge/Issues-320-blue?style=for-the-badge)](https://github.com/OWASP/Nest/issues) [![Pull Requests](https://img.shields.io/badge/Pull%20Requests-75-blue?style=for-the-badge)](https://github.com/OWASP/Nest/pulls)
 
 [![DeepWiki](https://img.shields.io/badge/docs-deep%20wiki-blue?style=for-the-badge)](https://deepwiki.com/OWASP/Nest) [![ReadTheDocs](https://img.shields.io/badge/docs-read%20the%20docs-blue?style=for-the-badge)](https://owasp-nest.readthedocs.io/latest/)
 
@@ -26,6 +26,7 @@
 </div>
 
 <!-- --8<-- [start:docs] -->
+
 **OWASP Nest** is a comprehensive, community-first platform built to enhance collaboration and contribution across the OWASP community. The application serves as a central hub for exploring OWASP projects and ways to contribute to them, empowering contributors to find opportunities that align with their interests and expertise.
 
 Key features of the platform include:
@@ -42,7 +43,7 @@ OWASP Nest promotes collaboration, making it easier for both new and experienced
 OWASP Nest is led by a dedicated team committed to fostering collaboration and supporting contributors. The leadership team ensures the platform aligns with OWASP's mission, continually improving its features to serve the community better.
 Current Leaders:
 
-- [Arkadii Yakovets](https://github.com/arkid15r/)  -- CCSP, CISSP, CSSLP
+- [Arkadii Yakovets](https://github.com/arkid15r/) -- CCSP, CISSP, CSSLP
 - [Kate Golovanova](https://github.com/kasya/) -- CC
 - [Starr Brown](https://github.com/mamicidal/) -- CISSP
 


### PR DESCRIPTION
## Proposed change

<!-- Don't forget to link your PR to an existing issue.-->
Resolves #4933 

<!-- Describe the big picture of your changes.-->
Add the PR description here.

This pr 
- replaces some dynamic badge ( fork,issue,pr,recent commit,stars and contributors) with static urls 
- uses github action after every 6 hours to update these badges ( Thought 6hrs should be good enough to not have stale stats )
- workflow uses `gh` and `jq` to fetch stats and then uses `sed` to update the README.md with latest stats

## Checklist

- [X] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [X] **Required:** I verified that my code works as intended and resolves the issue as described
- [X] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [X] I used AI for code, documentation, tests, or communication related to this PR
