### PR TITLE
feat: add ClusterFuzzLite QueryParser fuzz target

### DIFF
--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -eu
+
+python -m pip install \
+    atheris==3.0.0 \
+    pyparsing==3.3.2
+
+cp "$SRC/Nest/backend/tests/fuzz/fuzz_query_parser_test.py" \
+   "$OUT/fuzz_query_parser_test.py"
+
+cat > "$OUT/fuzz_query_parser" <<'RUNNER'
+#!/bin/bash
+
+cd "$(dirname "$0")"
+
+PYTHONPATH=/src/Nest/backend \
+exec python fuzz_query_parser_test.py "$@"
+RUNNER
+
+chmod +x "$OUT/fuzz_query_parser"

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: python

--- a/.github/workflows/clusterfuzzlite.yml
+++ b/.github/workflows/clusterfuzzlite.yml
@@ -1,0 +1,57 @@
+name: ClusterFuzzLite
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: 0 2 * * *
+  workflow_dispatch:
+
+concurrency:
+  cancel-in-progress: true
+  group: clusterfuzzlite-${{ github.ref }}
+
+permissions: {}
+
+jobs:
+  fuzzing:
+    name: ClusterFuzzLite
+    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
+
+    permissions:
+      contents: read
+      security-events: write
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Build fuzzers
+        uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1  # v1
+        with:
+          language: python
+
+      - name: Run fuzzers
+        uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1  # v1
+        with:
+          fuzz-seconds: 60
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          mode: code-change
+          output-sarif: true
+
+      - name: Upload SARIF to code scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa  # v4.36.0
+        with:
+          category: clusterfuzzlite
+          sarif_file: artifacts/fuzz-latest/fuzzing-report.sarif
+
+    timeout-minutes: 30

--- a/backend/tests/fuzz/fuzz_query_parser_test.py
+++ b/backend/tests/fuzz/fuzz_query_parser_test.py
@@ -1,0 +1,53 @@
+"""OWASP Nest QueryParser fuzz target for ClusterFuzzLite."""
+
+import sys
+
+import atheris
+
+with atheris.instrument_imports():
+    from apps.common.search.query_parser import QueryParser, QueryParserError
+
+# Representative production-like schema exercising multiple field types.
+FIELD_SCHEMA = {
+    "query": "string",
+    "language": "string",
+    "stars": "number",
+    "created": "date",
+    "archived": "boolean",
+}
+
+FIELDS = list(FIELD_SCHEMA.keys())
+
+
+def test_one_input(data: bytes) -> None:
+    """Fuzz QueryParser with arbitrary and structured Unicode input."""
+    fdp = atheris.FuzzedDataProvider(data)
+
+    parser = QueryParser(
+        field_schema=FIELD_SCHEMA,
+        case_sensitive=fdp.ConsumeBool(),
+        strict=fdp.ConsumeBool(),
+    )
+
+    if fdp.ConsumeBool():
+        query = fdp.ConsumeUnicodeNoSurrogates(512)
+    else:
+        field = fdp.PickValueInList(FIELDS)
+        value = fdp.ConsumeUnicodeNoSurrogates(128)
+        query = f"{field}:{value}"
+
+    try:
+        parser.parse(query)
+    except QueryParserError:
+        # Invalid queries are expected during fuzzing.
+        pass
+
+
+def main() -> None:
+    """Run the Atheris fuzz target."""
+    atheris.Setup(sys.argv, test_one_input)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/fuzz/fuzz_query_parser_test.py
+++ b/backend/tests/fuzz/fuzz_query_parser_test.py
@@ -19,7 +19,7 @@ FIELD_SCHEMA = {
 FIELDS = list(FIELD_SCHEMA.keys())
 
 
-def test_one_input(data: bytes) -> None:
+def TestOneInput(data: bytes) -> None:
     """Fuzz QueryParser with arbitrary and structured Unicode input."""
     fdp = atheris.FuzzedDataProvider(data)
 
@@ -45,7 +45,7 @@ def test_one_input(data: bytes) -> None:
 
 def main() -> None:
     """Run the Atheris fuzz target."""
-    atheris.Setup(sys.argv, test_one_input)
+    atheris.Setup(sys.argv, TestOneInput)
     atheris.Fuzz()
 
 


### PR DESCRIPTION
## Proposed change

Resolves #4934

This PR adds an initial **ClusterFuzzLite** integration to OWASP Nest to complement the existing Schemathesis-based fuzz testing and improve compatibility with the OpenSSF Scorecard **Fuzzing** check.

### Changes

* Added a **ClusterFuzzLite** GitHub Actions workflow for pull request fuzzing.
* Added the required `.clusterfuzzlite` configuration files.
* Added an **Atheris**-based fuzz target for `QueryParser` (`backend/tests/fuzz/fuzz_query_parser_test.py`).
* Added a build script for building and running the fuzz target within the ClusterFuzzLite environment.

### Why `QueryParser`?

`QueryParser` is a production component responsible for parsing structured search queries. It processes user-controlled input, exercises multiple parsing paths (field parsing, typed values, strict/non-strict parsing, and case sensitivity), and has minimal external dependencies, making it a suitable target for coverage-guided fuzzing.

### Existing fuzzing

This PR **does not replace** the existing Schemathesis REST and GraphQL fuzz tests. Instead, it introduces ClusterFuzzLite as an additional coverage-guided fuzzing layer while preserving the current API fuzzing approach.

### Motivation

The current Schemathesis-based fuzzing setup provides valuable API fuzz testing but is not recognized by the OpenSSF Scorecard's automated fuzzing check for Python projects. This change introduces a supported ClusterFuzzLite integration while maintaining the project's existing fuzzing strategy.

## Checklist

* [x] **Required:** I followed the contributing workflow
* [x] **Required:** I verified that my code works as intended and resolves the issue as described
* [ ] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
* [x] I used AI for code, documentation, tests, or communication related to this PR