### PR TITLE
Stabilize chapter E2E tests by blocking map tiles

### DIFF
--- a/e2e/pages/Chapters.spec.ts
+++ b/e2e/pages/Chapters.spec.ts
@@ -4,6 +4,8 @@ import { test, expect } from '@playwright/test'
 
 test.describe('Chapters Page', () => {
   test.beforeEach(async ({ page }) => {
+    await page.route('https://*.tile.openstreetmap.org/**', (route) => route.abort())
+
     await page.route('**/idx/', async (route) => {
       await route.fulfill({
         status: 200,


### PR DESCRIPTION
## Proposed change

Resolves #4932 

The chapter tests may time out while loading external map tiles. This change blocks those requests because the tests do not depend on them.

**Assumption : removing the external resources should make the test resolve in less time by not waiting on third-party resources that are not part of the assertion.**

## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/
  CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [x] I used AI for code, documentation, tests, or communication related to this PR