### PR TITLE
Handle special-character-only search queries

### DIFF
--- a/backend/apps/core/api/internal/algolia.py
+++ b/backend/apps/core/api/internal/algolia.py
@@ -16,9 +16,10 @@ from apps.common.index import IndexBase
 from apps.common.utils import get_user_ip_address
 from apps.core.constants import CACHE_PREFIX
 from apps.core.utils.index import deep_camelize, get_params_for_index
-from apps.core.validators import validate_search_params
+from apps.core.validators import has_searchable_query, validate_search_params
 
 CACHE_TTL_IN_SECONDS = 3600  # 1 hour
+EMPTY_SEARCH_RESULTS = {"hits": [], "nbPages": 0}
 
 
 def algolia_search(request: HttpRequest) -> JsonResponse | HttpResponseNotAllowed:
@@ -51,6 +52,9 @@ def algolia_search(request: HttpRequest) -> JsonResponse | HttpResponseNotAllowe
         limit = data.get("hitsPerPage", 25)
         page = data.get("page", 1)
         query = data.get("query", "")
+
+        if query.strip() and not has_searchable_query(query):
+            return JsonResponse(EMPTY_SEARCH_RESULTS)
 
         cache_key = f"{CACHE_PREFIX}:{index_name}:{query}:{page}:{limit}"
         if facet_filters:

--- a/backend/apps/core/validators.py
+++ b/backend/apps/core/validators.py
@@ -5,6 +5,14 @@ import re
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_slug
 
+QUERY_PATTERN = re.compile(r"^[\w .-]*$")
+SEARCHABLE_QUERY_PATTERN = re.compile(r"\w")
+
+
+def has_searchable_query(query: str) -> bool:
+    """Return whether the query contains a searchable character."""
+    return bool(SEARCHABLE_QUERY_PATTERN.search(query))
+
 
 def validate_index_name(index_name: str) -> None:
     """Validate index name.
@@ -87,7 +95,7 @@ def validate_query(query: str) -> None:
         message = "query must be a string."
         raise ValidationError(message)
 
-    if not re.match(r"^[\w .-]*$", query):
+    if has_searchable_query(query) and not QUERY_PATTERN.match(query):
         message = (
             "Invalid query value provided. "
             "Only alphanumeric characters, hyphens, spaces, and underscores are allowed."

--- a/backend/tests/unit/apps/core/api/internal/algolia_test.py
+++ b/backend/tests/unit/apps/core/api/internal/algolia_test.py
@@ -271,6 +271,24 @@ class TestAlgoliaSearch:
             assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
             assert response_data["error"] == "An internal error occurred. Please try again later."
 
+    def test_algolia_search_returns_empty_results_for_non_searchable_query(self):
+        """Test that non-searchable queries return empty results without calling Algolia."""
+        with patch("apps.core.api.internal.algolia.get_search_results") as mock_get_search_results:
+            mock_request = self._build_request(
+                index_name="users",
+                query="% & * + ? / \\ \" ' ( ) [ ] =",
+                page=1,
+                hits_per_page=10,
+                facet_filters=[],
+            )
+
+            response = algolia_search(mock_request)
+            response_data = json.loads(response.content)
+
+            assert response.status_code == HTTPStatus.OK
+            assert response_data == {"hits": [], "nbPages": 0}
+            mock_get_search_results.assert_not_called()
+
     def test_algolia_search_handles_json_decode_error(self):
         """Test that JSONDecodeError is caught and proper error returned."""
         mock_request = Mock()

--- a/backend/tests/unit/apps/core/validators_test.py
+++ b/backend/tests/unit/apps/core/validators_test.py
@@ -100,6 +100,10 @@ class TestAlgoliaValidators:
     def test_valid_query(self, query):
         validate_query(query)
 
+    @pytest.mark.parametrize(("query"), ["@", "@@@ ### %%%%", "% & * + ? / \\ \" ' ( ) [ ] ="])
+    def test_non_searchable_query(self, query):
+        validate_query(query)
+
     # Facet filters tests
     @pytest.mark.parametrize(
         ("facet_filters", "error_message"),


### PR DESCRIPTION
## Proposed change

Resolves #4979

Special-character-only search queries currently fail backend query validation, causing the frontend to show a generic search service error. This change treats queries with no searchable characters as an empty result set before calling Algolia, while preserving the existing validation error for mixed text plus unsupported characters.

## Testing

- [x] `pytest --no-cov tests/unit/apps/core/api/internal/algolia_test.py tests/unit/apps/core/validators_test.py -q`
- [x] `uvx ruff==0.15.17 check apps/core/api/internal/algolia.py apps/core/validators.py tests/unit/apps/core/api/internal/algolia_test.py tests/unit/apps/core/validators_test.py`
- [x] `uvx ruff==0.15.17 format --check apps/core/api/internal/algolia.py apps/core/validators.py tests/unit/apps/core/api/internal/algolia_test.py tests/unit/apps/core/validators_test.py`
- [x] `python -m compileall -q apps/core/api/internal/algolia.py apps/core/validators.py tests/unit/apps/core/api/internal/algolia_test.py tests/unit/apps/core/validators_test.py`
- [x] `git diff --check`
- [x] `uvx pre-commit run --files backend/apps/core/api/internal/algolia.py backend/apps/core/validators.py backend/tests/unit/apps/core/api/internal/algolia_test.py backend/tests/unit/apps/core/validators_test.py`
- [ ] `make test-backend` (blocked locally: Docker daemon was unavailable at the configured OrbStack socket)

## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [ ] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [x] I used AI for code, documentation, tests, or communication related to this PR

AI assistance was used under my direction.