### PR TITLE
Strip italic, strikethrough and inline code in strip_markdown

### DIFF
--- a/backend/src/apps/slack/common/text.py
+++ b/backend/src/apps/slack/common/text.py
@@ -46,4 +46,18 @@ def strip_markdown(text: str) -> str:
         str: The text with markdown formatting removed.
 
     """
-    return SLACK_LINK_PATTERN.sub(r"\2 (\1)", text).replace("*", "")
+    text = SLACK_LINK_PATTERN.sub(r"\2 (\1)", text)
+
+    # Remove Slack formatting markers (bold, italic, strikethrough and code).
+    # Only strip a marker pair when it sits at a word boundary surrounded by
+    # spaces or sentence punctuation, so underscores that are part of words or
+    # URLs (e.g. snake_case or https://example.com/_docs_/) are left untouched.
+    markers = ["*", "_", "~", "`"]
+    for marker in markers:
+        escaped = re.escape(marker)
+        marker_pattern = re.compile(
+            rf"(?:^|(?<=[\s(])){escaped}(\S(?:.*?\S)?){escaped}(?:$|(?=[\s.,!?:;)]))"
+        )
+        text = marker_pattern.sub(r"\1", text)
+
+    return text

--- a/backend/tests/unit/apps/slack/utils_test.py
+++ b/backend/tests/unit/apps/slack/utils_test.py
@@ -78,6 +78,30 @@ class TestStripMarkdown:
                 "Multiple links: <https://example.com|First> and <https://example.org|Second>.",
                 "Multiple links: First (https://example.com) and Second (https://example.org).",
             ),
+            (
+                "This is _italic_ text.",
+                "This is italic text.",
+            ),
+            (
+                "This is ~strikethrough~ text.",
+                "This is strikethrough text.",
+            ),
+            (
+                "This is `code` text.",
+                "This is code text.",
+            ),
+            (
+                "Mix *bold*, _italic_, ~strike~ and `code`.",
+                "Mix bold, italic, strike and code.",
+            ),
+            (
+                "Keep snake_case and a <https://example.com/a_b_c|link> intact.",
+                "Keep snake_case and a link (https://example.com/a_b_c) intact.",
+            ),
+            (
+                "See <https://example.com/_docs_/intro|guide> here.",
+                "See guide (https://example.com/_docs_/intro) here.",
+            ),
         ],
     )
     def test_process_mrkdwn(self, input_text, expected_output):


### PR DESCRIPTION
## Proposed change

Resolves #4973

`strip_markdown()` only stripped bold (`*`) and rewrote links, so `_italic_`, `~strike~` and inline `` `code` `` markers leaked into the plain-text fallback. This extends it to strip those markers too.

Stripping is limited to paired markers wrapping non-space content, so underscores and similar characters that are part of words or URLs (e.g. `snake_case`) are left untouched. Added test cases for italic, strikethrough, inline code, a combined case, and a `snake_case` + URL regression check.

## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [ ] I used AI for code, documentation, tests, or communication related to this PR
