### PR TITLE
Prototype: shared GraphQL input validation layer

### DIFF
--- a/backend/apps/common/graphql/__init__.py
+++ b/backend/apps/common/graphql/__init__.py
@@ -1,0 +1,1 @@
+"""Shared GraphQL validation utilities."""

--- a/backend/apps/common/graphql/validators.py
+++ b/backend/apps/common/graphql/validators.py
@@ -1,0 +1,134 @@
+"""Shared input validators for GraphQL mutations.
+
+These validators centralize checks that recur across mutations (date ranges,
+duplicate keys, required-together fields) so resolvers don't reimplement
+the same logic with slightly different error messages or calling conventions.
+
+All validators raise django.core.exceptions.ValidationError on failure,
+matching the existing convention in apps/mentorship/api/internal/mutations.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from django.core.exceptions import ValidationError
+from django.utils import timezone
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+
+def ensure_aware(value: datetime) -> datetime:
+    """Return a timezone-aware version of a datetime, making it aware if needed."""
+    return timezone.make_aware(value) if timezone.is_naive(value) else value
+
+
+def validate_date_range(
+    started_at: datetime | None,
+    ended_at: datetime | None,
+    *,
+    required: bool = True,
+) -> tuple[datetime, datetime] | tuple[None, None]:
+    """Validate that ended_at is after started_at, normalizing both to aware datetimes.
+
+    Args:
+        started_at: Start of the range.
+        ended_at: End of the range.
+        required: If True, raises when either value is missing.
+
+    Returns:
+        A tuple of (started_at, ended_at) normalized to timezone-aware datetimes,
+        or (None, None) if both are missing and required=False.
+
+    Raises:
+        ValidationError: If required fields are missing or ended_at <= started_at.
+
+    """
+    if started_at is None or ended_at is None:
+        if required:
+            msg = "Both start and end dates are required."
+            raise ValidationError(msg)
+        return None, None
+
+    started_at = ensure_aware(started_at)
+    ended_at = ensure_aware(ended_at)
+
+    if ended_at <= started_at:
+        msg = "End date must be after start date."
+        raise ValidationError(msg)
+
+    return started_at, ended_at
+
+
+def validate_date_range_within_bounds(
+    started_at: datetime,
+    ended_at: datetime,
+    *,
+    bounds_started_at: datetime,
+    bounds_ended_at: datetime,
+    subject_label: str = "",
+    bounds_label: str = "the parent",
+) -> None:
+    """Validate that a date range falls fully within an enclosing range.
+
+    Args:
+        started_at: Start of the inner range (already validated/aware).
+        ended_at: End of the inner range (already validated/aware).
+        bounds_started_at: Start of the enclosing range.
+        bounds_ended_at: End of the enclosing range.
+        subject_label: Human-readable name for the inner range's subject,
+            used as the leading word in error messages (e.g. "Module").
+        bounds_label: Human-readable name for the enclosing range, used in
+            error messages (e.g. "program").
+
+    Raises:
+        ValidationError: If the inner range escapes the enclosing range.
+
+    """
+    prefix = f"{subject_label} " if subject_label else ""
+
+    if started_at < bounds_started_at:
+        msg = f"{prefix}start date cannot be before {bounds_label} start date."
+        raise ValidationError(msg)
+
+    if ended_at > bounds_ended_at:
+        msg = f"{prefix}end date cannot be after {bounds_label} end date."
+        raise ValidationError(msg)
+
+
+def validate_no_duplicates(values: list[str], *, field_label: str = "values") -> None:
+    """Validate that a list contains no duplicate entries.
+
+    Args:
+        values: The list to check.
+        field_label: Human-readable name for the field, used in error messages.
+
+    Raises:
+        ValidationError: If duplicates are found.
+
+    """
+    if len(set(values)) != len(values):
+        msg = f"Duplicate {field_label} are not allowed."
+        raise ValidationError(msg)
+
+
+def validate_not_in_past(value: datetime, *, field_label: str = "date") -> datetime:
+    """Validate that a datetime is not in the past, normalizing to aware.
+
+    Args:
+        value: The datetime to check.
+        field_label: Human-readable name for the field, used in error messages.
+
+    Returns:
+        The normalized, timezone-aware datetime.
+
+    Raises:
+        ValidationError: If the date is in the past.
+
+    """
+    value = ensure_aware(value)
+    if value.date() < timezone.now().date():
+        msg = f"{field_label.capitalize()} cannot be in the past."
+        raise ValidationError(msg)
+    return value

--- a/backend/apps/mentorship/api/internal/mutations/module.py
+++ b/backend/apps/mentorship/api/internal/mutations/module.py
@@ -10,6 +10,10 @@ from django.db.utils import IntegrityError
 from django.utils import timezone
 from graphql import GraphQLError
 
+from apps.common.graphql.validators import (
+    validate_date_range,
+    validate_date_range_within_bounds,
+)
 from apps.github.models import User as GithubUser
 from apps.mentorship.api.internal.nodes.module import (
     CreateModuleInput,
@@ -52,27 +56,15 @@ def resolve_mentors_from_logins(logins: list[str]) -> set[Mentor]:
 
 def _validate_module_dates(started_at, ended_at, program_started_at, program_ended_at) -> tuple:
     """Validate and normalize module start/end dates against program constraints."""
-    if started_at is None or ended_at is None:
-        msg = "Both start and end dates are required."
-        raise ValidationError(message=msg)
-
-    if timezone.is_naive(started_at):
-        started_at = timezone.make_aware(started_at)
-    if timezone.is_naive(ended_at):
-        ended_at = timezone.make_aware(ended_at)
-
-    if ended_at <= started_at:
-        msg = "End date must be after start date."
-        raise ValidationError(message=msg)
-
-    if started_at < program_started_at:
-        msg = "Module start date cannot be before program start date."
-        raise ValidationError(message=msg)
-
-    if ended_at > program_ended_at:
-        msg = "Module end date cannot be after program end date."
-        raise ValidationError(message=msg)
-
+    started_at, ended_at = validate_date_range(started_at, ended_at)
+    validate_date_range_within_bounds(
+        started_at,
+        ended_at,
+        bounds_started_at=program_started_at,
+        bounds_ended_at=program_ended_at,
+        subject_label="Module",
+        bounds_label="program",
+    )
     return started_at, ended_at
 
 

--- a/backend/tests/unit/apps/common/graphql/validators_test.py
+++ b/backend/tests/unit/apps/common/graphql/validators_test.py
@@ -1,0 +1,124 @@
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from django.core.exceptions import ValidationError
+
+from apps.common.graphql.validators import (
+    ensure_aware,
+    validate_date_range,
+    validate_date_range_within_bounds,
+    validate_no_duplicates,
+    validate_not_in_past,
+)
+
+
+class TestValidators:
+    def test_ensure_aware_makes_naive_datetime_aware(self):
+        naive = datetime(2026, 1, 1)  # noqa: DTZ001
+        result = ensure_aware(naive)
+        assert result.tzinfo is not None
+
+    def test_ensure_aware_leaves_aware_datetime_unchanged(self):
+        aware = datetime(2026, 1, 1, tzinfo=UTC)
+        result = ensure_aware(aware)
+        assert result == aware
+
+    def test_validate_date_range_valid(self):
+        started_at = datetime(2026, 1, 1, tzinfo=UTC)
+        ended_at = datetime(2026, 2, 1, tzinfo=UTC)
+        result_started, result_ended = validate_date_range(started_at, ended_at)
+        assert result_started == started_at
+        assert result_ended == ended_at
+
+    def test_validate_date_range_raises_when_end_before_start(self):
+        started_at = datetime(2026, 2, 1, tzinfo=UTC)
+        ended_at = datetime(2026, 1, 1, tzinfo=UTC)
+        with pytest.raises(ValidationError, match="End date must be after start date"):
+            validate_date_range(started_at, ended_at)
+
+    def test_validate_date_range_raises_when_end_equals_start(self):
+        same = datetime(2026, 1, 1, tzinfo=UTC)
+        with pytest.raises(ValidationError, match="End date must be after start date"):
+            validate_date_range(same, same)
+
+    @pytest.mark.parametrize(
+        ("started_at", "ended_at"),
+        [
+            (None, datetime(2026, 1, 1, tzinfo=UTC)),
+            (datetime(2026, 1, 1, tzinfo=UTC), None),
+            (None, None),
+        ],
+    )
+    def test_validate_date_range_raises_when_required_and_missing(self, started_at, ended_at):
+        with pytest.raises(ValidationError, match="Both start and end dates are required"):
+            validate_date_range(started_at, ended_at)
+
+    def test_validate_date_range_allows_missing_when_not_required(self):
+        result = validate_date_range(None, None, required=False)
+        assert result == (None, None)
+
+    def test_validate_date_range_within_bounds_valid(self):
+        validate_date_range_within_bounds(
+            datetime(2026, 2, 1, tzinfo=UTC),
+            datetime(2026, 3, 1, tzinfo=UTC),
+            bounds_started_at=datetime(2026, 1, 1, tzinfo=UTC),
+            bounds_ended_at=datetime(2026, 4, 1, tzinfo=UTC),
+        )
+
+    def test_validate_date_range_within_bounds_raises_when_starts_too_early(self):
+        with pytest.raises(ValidationError, match="start date cannot be before"):
+            validate_date_range_within_bounds(
+                datetime(2025, 12, 1, tzinfo=UTC),
+                datetime(2026, 3, 1, tzinfo=UTC),
+                bounds_started_at=datetime(2026, 1, 1, tzinfo=UTC),
+                bounds_ended_at=datetime(2026, 4, 1, tzinfo=UTC),
+            )
+
+    def test_validate_date_range_within_bounds_raises_when_ends_too_late(self):
+        with pytest.raises(ValidationError, match="end date cannot be after"):
+            validate_date_range_within_bounds(
+                datetime(2026, 2, 1, tzinfo=UTC),
+                datetime(2026, 5, 1, tzinfo=UTC),
+                bounds_started_at=datetime(2026, 1, 1, tzinfo=UTC),
+                bounds_ended_at=datetime(2026, 4, 1, tzinfo=UTC),
+            )
+
+    def test_validate_date_range_within_bounds_uses_custom_label(self):
+        with pytest.raises(ValidationError, match="before module start date"):
+            validate_date_range_within_bounds(
+                datetime(2025, 12, 1, tzinfo=UTC),
+                datetime(2026, 3, 1, tzinfo=UTC),
+                bounds_started_at=datetime(2026, 1, 1, tzinfo=UTC),
+                bounds_ended_at=datetime(2026, 4, 1, tzinfo=UTC),
+                bounds_label="module",
+            )
+
+    def test_validate_no_duplicates_passes_for_unique_values(self):
+        validate_no_duplicates(["a", "b", "c"])
+
+    def test_validate_no_duplicates_raises_for_duplicates(self):
+        with pytest.raises(ValidationError, match="Duplicate values are not allowed"):
+            validate_no_duplicates(["a", "b", "a"])
+
+    def test_validate_no_duplicates_uses_custom_label(self):
+        with pytest.raises(ValidationError, match="Duplicate module keys are not allowed"):
+            validate_no_duplicates(["x", "x"], field_label="module keys")
+
+    def test_validate_not_in_past_accepts_future_date(self):
+        future = datetime.now(tz=UTC) + timedelta(days=1)
+        result = validate_not_in_past(future)
+        assert result == future
+
+    def test_validate_not_in_past_accepts_today(self):
+        today = datetime.now(tz=UTC)
+        validate_not_in_past(today)
+
+    def test_validate_not_in_past_raises_for_past_date(self):
+        past = datetime.now(tz=UTC) - timedelta(days=1)
+        with pytest.raises(ValidationError, match="Date cannot be in the past"):
+            validate_not_in_past(past)
+
+    def test_validate_not_in_past_uses_custom_label(self):
+        past = datetime.now(tz=UTC) - timedelta(days=1)
+        with pytest.raises(ValidationError, match="Deadline cannot be in the past"):
+            validate_not_in_past(past, field_label="deadline")


### PR DESCRIPTION
## Description

This is a prototype based on the team discussion about GraphQL input validation.

The problem I noticed: validation logic is copy-pasted across mutations with slightly different error messages each time. `_validate_module_dates` in module.py does the same date-range and bounds checks as program.py, just worded differently.

I added a shared validator layer at `apps/common/graphql/validators.py` with four functions that cover the patterns I kept seeing:
- date range validation (required fields, end after start, timezone normalization)
- bounds checking (inner range within enclosing range)
- duplicate detection
- past-date rejection

To prove it works, I refactored `_validate_module_dates` to use the shared validators. 19 lines down to 9, same behavior. All 3582 existing tests pass.

Two more spots in module.py map directly onto these validators (`set_task_deadline` and `reorder_modules`) but I left them for discussion 
before expanding further.

## Checklist
- [x] **Required:** I followed the contributing workflow
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [ ] I used AI for code, documentation, tests, or communication related to this PR