### PR TITLE
fix timeout errors for e2e tests

### DIFF
--- a/e2e/components/Footer.spec.ts
+++ b/e2e/components/Footer.spec.ts
@@ -9,7 +9,7 @@ test.describe('Footer - Desktop (Chrome)', () => {
   })
 
   test.beforeEach(async ({ page }) => {
-    await page.goto('/')
+    await page.goto('/', { waitUntil: 'domcontentloaded' })
   })
   test('should have buttons', async ({ page }) => {
     await expect(page.getByRole('button', { name: 'OWASP Nest' })).toBeVisible()
@@ -31,7 +31,7 @@ test.use({
 
 test.describe('Footer - Mobile (iPhone 13)', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/')
+    await page.goto('/', { waitUntil: 'domcontentloaded' })
   })
   test('should have buttons', async ({ page }) => {
     await expect(page.getByRole('button', { name: 'OWASP Nest' })).toBeVisible()

--- a/e2e/components/Header.spec.ts
+++ b/e2e/components/Header.spec.ts
@@ -9,7 +9,7 @@ test.describe('Header - Desktop (Chrome)', () => {
   })
 
   test.beforeEach(async ({ page }) => {
-    await page.goto('/')
+    await page.goto('/', { waitUntil: 'domcontentloaded' })
   })
 
   test('should have logo', async ({ page }) => {
@@ -37,7 +37,7 @@ test.describe('Header - Desktop (Chrome)', () => {
   })
 
   test('all dropdown triggers should use pointer cursor', async ({ page }) => {
-    await page.goto('/')
+    await page.goto('/', { waitUntil: 'domcontentloaded' })
 
     const dropdownButtons = page.locator('#navbar-sticky button')
 
@@ -60,7 +60,7 @@ test.use({
 
 test.describe('Header - Mobile (iPhone 13)', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/')
+    await page.goto('/', { waitUntil: 'domcontentloaded' })
   })
 
   test('should have logo', async ({ page }) => {

--- a/e2e/pages/CommitteeDetails.spec.ts
+++ b/e2e/pages/CommitteeDetails.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test.describe('Committee Details Page', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/committees/events')
+    await page.goto('/committees/events', { waitUntil: 'domcontentloaded' })
   })
 
   test('should have a heading and summary', async ({ page }) => {

--- a/e2e/pages/Committees.spec.ts
+++ b/e2e/pages/Committees.spec.ts
@@ -13,7 +13,7 @@ test.describe('Committees Page', () => {
         }),
       })
     })
-    await page.goto('/committees')
+    await page.goto('/committees', { waitUntil: 'domcontentloaded' })
   })
 
   test('renders committee data correctly', async ({ page }) => {
@@ -30,7 +30,7 @@ test.describe('Committees Page', () => {
         body: JSON.stringify({ hits: [], nbPages: 0 }),
       })
     })
-    await page.goto('/committees')
+    await page.goto('/committees', { waitUntil: 'domcontentloaded' })
     await expect(page.getByText('No committees found')).toBeVisible()
   })
 

--- a/e2e/pages/Community.spec.ts
+++ b/e2e/pages/Community.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test.describe('Community Page', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/community')
+    await page.goto('/community', { waitUntil: 'domcontentloaded' })
   })
 
   test('renders main heading', async ({ page }) => {

--- a/e2e/pages/Contribute.spec.ts
+++ b/e2e/pages/Contribute.spec.ts
@@ -13,7 +13,7 @@ test.describe('Contribute Page', () => {
         }),
       })
     })
-    await page.goto('/contribute')
+    await page.goto('/contribute', { waitUntil: 'domcontentloaded' })
   })
 
   test('renders issue data correctly', async ({ page }) => {
@@ -31,7 +31,7 @@ test.describe('Contribute Page', () => {
         body: JSON.stringify({ hits: [], totalPages: 0 }),
       })
     })
-    await page.goto('/contribute')
+    await page.goto('/contribute', { waitUntil: 'domcontentloaded' })
     await expect(page.getByText('No issues found')).toBeVisible()
   })
 

--- a/e2e/pages/Home.spec.ts
+++ b/e2e/pages/Home.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test.describe('Home Page', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/')
+    await page.goto('/', { waitUntil: 'domcontentloaded' })
   })
 
   test('should have a heading', async ({ page }) => {

--- a/e2e/pages/Login.spec.ts
+++ b/e2e/pages/Login.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test.describe('Login Page', () => {
   test('shows message authentication is enabled', async ({ page }) => {
-    await page.goto('/auth/login')
+    await page.goto('/auth/login', { waitUntil: 'domcontentloaded' })
 
     const welcomeMessage = page.getByText('Welcome back')
     const gitHubLoginButton = page.getByRole('button', { name: 'Sign In with GitHub' })

--- a/e2e/pages/MentorshipPrograms.spec.ts
+++ b/e2e/pages/MentorshipPrograms.spec.ts
@@ -21,7 +21,7 @@ test.describe('Mentorship Programs Page', () => {
         body: JSON.stringify({ hits: mockPrograms, nbPages: 1 }),
       })
     })
-    await page.goto('/mentorship/programs')
+    await page.goto('/mentorship/programs', { waitUntil: 'domcontentloaded' })
   })
 
   test('renders program card from mock data', async ({ page }) => {
@@ -48,7 +48,7 @@ test.describe('Mentorship Programs Page', () => {
         body: JSON.stringify({ hits: [], nbPages: 0 }),
       })
     })
-    await page.goto('/mentorship/programs')
+    await page.goto('/mentorship/programs', { waitUntil: 'domcontentloaded' })
     await expect(page.getByText('No programs found')).toBeVisible()
   })
 

--- a/e2e/pages/OrganizationDetails.spec.ts
+++ b/e2e/pages/OrganizationDetails.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test.describe('Organization Details Page', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/organizations/OWASP')
+    await page.goto('/organizations/OWASP', { waitUntil: 'domcontentloaded' })
   })
 
   test('should have a heading', async ({ page }) => {

--- a/e2e/pages/Organizations.spec.ts
+++ b/e2e/pages/Organizations.spec.ts
@@ -13,7 +13,7 @@ test.describe('Organization Page', () => {
         }),
       })
     })
-    await page.goto('/organizations')
+    await page.goto('/organizations', { waitUntil: 'domcontentloaded' })
   })
 
   test('renders organization data correctly', async ({ page }) => {

--- a/e2e/pages/ProjectDetails.spec.ts
+++ b/e2e/pages/ProjectDetails.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test.describe('Project Details Page', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/projects/nest')
+    await page.goto('/projects/nest', { waitUntil: 'domcontentloaded' })
   })
 
   test('should have a heading', async ({ page }) => {

--- a/e2e/pages/ProjectHealthDashboardMetricsDetails.spec.ts
+++ b/e2e/pages/ProjectHealthDashboardMetricsDetails.spec.ts
@@ -5,14 +5,14 @@ import { expect, test } from '@playwright/test'
 test.describe('Project Health Metrics Details Page', () => {
   test('renders 404 when user is not OWASP staff', async ({ page }) => {
     await mockDashboardCookies(page, mockProjectsDashboardMetricsDetailsData, false)
-    await page.goto('/projects/dashboard/metrics/test-project')
+    await page.goto('/projects/dashboard/metrics/test-project', { waitUntil: 'domcontentloaded' })
     await expect(page.getByText('404')).toBeVisible()
     await expect(page.getByText("Sorry, the page you're looking for doesn't exist.")).toBeVisible()
   })
 
   test('renders project health metrics details', async ({ page }) => {
     await mockDashboardCookies(page, mockProjectsDashboardMetricsDetailsData, true)
-    await page.goto('/projects/dashboard/metrics/nest')
+    await page.goto('/projects/dashboard/metrics/nest', { waitUntil: 'domcontentloaded' })
     const metricsLatest = mockProjectsDashboardMetricsDetailsData.project.healthMetricsLatest
     const headers = [
       'Days Metrics',

--- a/e2e/pages/Projects.spec.ts
+++ b/e2e/pages/Projects.spec.ts
@@ -13,7 +13,7 @@ test.describe('Projects Page', () => {
         }),
       })
     })
-    await page.goto('/projects')
+    await page.goto('/projects', { waitUntil: 'domcontentloaded' })
   })
 
   test('renders project data correctly', async ({ page }) => {
@@ -29,7 +29,7 @@ test.describe('Projects Page', () => {
         body: JSON.stringify({ hits: [], nbPages: 0 }),
       })
     })
-    await page.goto('/projects')
+    await page.goto('/projects', { waitUntil: 'domcontentloaded' })
     await expect(page.getByText('No projects found')).toBeVisible()
   })
 

--- a/e2e/pages/ProjectsHealthDashboardMetrics.spec.ts
+++ b/e2e/pages/ProjectsHealthDashboardMetrics.spec.ts
@@ -5,14 +5,14 @@ import { test, expect } from '@playwright/test'
 test.describe('Projects Health Dashboard Metrics', () => {
   test('renders 404 when user is not OWASP staff', async ({ page }) => {
     await mockDashboardCookies(page, mockHealthMetricsData, false)
-    await page.goto('/projects/dashboard/metrics')
+    await page.goto('/projects/dashboard/metrics', { waitUntil: 'domcontentloaded' })
     await expect(page.getByText('404')).toBeVisible()
     await expect(page.getByText("Sorry, the page you're looking for doesn't exist.")).toBeVisible()
   })
 
   test('renders page headers', async ({ page }) => {
     await mockDashboardCookies(page, mockHealthMetricsData, true)
-    await page.goto('/projects/dashboard/metrics')
+    await page.goto('/projects/dashboard/metrics', { waitUntil: 'domcontentloaded' })
     await expect(page.getByRole('heading', { name: 'Project Health Metrics' })).toBeVisible()
     await expect(page.getByRole('button', { name: 'Filter By' })).toBeVisible()
     await expect(page.getByRole('button', { name: 'Score' })).toBeVisible()
@@ -20,7 +20,7 @@ test.describe('Projects Health Dashboard Metrics', () => {
 
   test('renders health metrics data', async ({ page }) => {
     await mockDashboardCookies(page, mockHealthMetricsData, true)
-    await page.goto('/projects/dashboard/metrics')
+    await page.goto('/projects/dashboard/metrics', { waitUntil: 'domcontentloaded' })
     const firstMetric = mockHealthMetricsData.projectHealthMetrics[0]
     const metricsLink = page
       .getByRole('link')

--- a/e2e/pages/ProjectsHealthDashboardOverview.spec.ts
+++ b/e2e/pages/ProjectsHealthDashboardOverview.spec.ts
@@ -6,14 +6,14 @@ import millify from 'millify'
 test.describe('Projects Health Dashboard Overview', () => {
   test('renders 404 when user is not OWASP staff', async ({ page }) => {
     await mockDashboardCookies(page, mockProjectsDashboardOverviewData, false)
-    await page.goto('/projects/dashboard')
+    await page.goto('/projects/dashboard', { waitUntil: 'domcontentloaded' })
     await expect(page.getByText('404')).toBeVisible()
     await expect(page.getByText("Sorry, the page you're looking for doesn't exist.")).toBeVisible()
   })
 
   test('renders project health stats', async ({ page }) => {
     await mockDashboardCookies(page, mockProjectsDashboardOverviewData, true)
-    await page.goto('/projects/dashboard')
+    await page.goto('/projects/dashboard', { waitUntil: 'domcontentloaded' })
     await expect(page.getByText('Project Health Dashboard Overview')).toBeVisible()
 
     // Check for healthy projects

--- a/e2e/pages/RepositoryDetails.spec.ts
+++ b/e2e/pages/RepositoryDetails.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test.describe('Repository Details Page', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/organizations/OWASP/repositories/Nest')
+    await page.goto('/organizations/OWASP/repositories/Nest', { waitUntil: 'domcontentloaded' })
   })
 
   test('should have a heading and summary', async ({ page }) => {

--- a/e2e/pages/UserDetails.spec.ts
+++ b/e2e/pages/UserDetails.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test.describe('User Details Page', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/members/arkid15r')
+    await page.goto('/members/arkid15r', { waitUntil: 'domcontentloaded' })
   })
 
   test('should have a heading and summary', async ({ page }) => {

--- a/e2e/pages/Users.spec.ts
+++ b/e2e/pages/Users.spec.ts
@@ -13,7 +13,7 @@ test.describe('Users Page', () => {
         }),
       })
     })
-    await page.goto('/members')
+    await page.goto('/members', { waitUntil: 'domcontentloaded' })
   })
 
   test('renders user data correctly', async ({ page }) => {
@@ -28,7 +28,7 @@ test.describe('Users Page', () => {
         body: JSON.stringify({ hits: [], nbPages: 0 }),
       })
     })
-    await page.goto('/members')
+    await page.goto('/members', { waitUntil: 'domcontentloaded' })
     await expect(page.getByText('No Users Found')).toBeVisible()
   })
 


### PR DESCRIPTION
## Proposed change

<!-- Don't forget to link your PR to an existing issue.-->
Resolves #4932

<!-- Describe the big picture of your changes.-->
Add the PR description here.

- add `waitUntil: 'domcontentloaded'` to all `page.goto` calls

## Checklist

- [X] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [X] **Required:** I verified that my code works as intended and resolves the issue as described
- [X] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [ ] I used AI for code, documentation, tests, or communication related to this PR
