### PR TITLE
feat: display repository last updated date on repository cards

### DIFF
--- a/frontend/__tests__/unit/components/RepositoryCard.test.tsx
+++ b/frontend/__tests__/unit/components/RepositoryCard.test.tsx
@@ -30,11 +30,15 @@ jest.mock('components/TruncatedText', () => ({
   TruncatedText: ({ text }: { text: string }) => <span>{text}</span>,
 }))
 
-jest.mock('components/InfoItem', () => {
-  return function MockInfoItem({ unit, value }: { unit: string; value: number }) {
+jest.mock('components/InfoItem', () => ({
+  __esModule: true,
+  default: function MockInfoItem({ unit, value }: { unit: string; value: number }) {
     return <div data-testid={`info-item-${unit}`}>{value}</div>
-  }
-})
+  },
+  TextInfoItem: function MockTextInfoItem({ label, value }: { label: string; value: string }) {
+    return <div data-testid={`text-info-item-${label.toLowerCase()}`}>{value}</div>
+  },
+}))
 
 const mockPush = jest.fn()
 const mockUseRouter = useRouter as jest.Mock
@@ -69,6 +73,7 @@ describe('RepositoryCard', () => {
     },
     starsCount: 100 + index,
     subscribersCount: 20 + index,
+    updatedAt: '2024-06-15T00:00:00.000Z',
     url: `https://github.com/org-${index}/repo-${index}`,
   })
 
@@ -341,6 +346,55 @@ describe('RepositoryCard', () => {
       fireEvent.click(repositoryButton)
 
       expect(mockPush).toHaveBeenCalledWith('/organizations/org-0/repositories/repo-0')
+    })
+  })
+
+  describe('Last Updated Date on Repository Cards', () => {
+    it('displays formatted updatedAt date when provided', () => {
+      const repository: RepositoryCardProps = {
+        ...createMockRepository(0),
+        updatedAt: '2024-06-15T00:00:00.000Z',
+      }
+
+      render(<RepositoryCard repositories={[repository]} />)
+
+      expect(screen.getByTestId('text-info-item-updated')).toBeInTheDocument()
+    })
+
+    it('does not display updated date when updatedAt is undefined', () => {
+      const repository: RepositoryCardProps = {
+        ...createMockRepository(0),
+        updatedAt: undefined,
+      }
+
+      render(<RepositoryCard repositories={[repository]} />)
+
+      expect(screen.queryByTestId('text-info-item-updated')).not.toBeInTheDocument()
+    })
+
+    it('displays updated date for each repository in list', () => {
+      const repositories = Array.from({ length: 3 }, (_, i) => ({
+        ...createMockRepository(i),
+        updatedAt: '2024-06-15T00:00:00.000Z',
+      }))
+
+      render(<RepositoryCard repositories={repositories} />)
+
+      const updatedItems = screen.getAllByTestId('text-info-item-updated')
+      expect(updatedItems).toHaveLength(3)
+    })
+
+    it('only shows updated date for repositories that have updatedAt', () => {
+      const repositories = [
+        { ...createMockRepository(0), updatedAt: '2024-06-15T00:00:00.000Z' },
+        { ...createMockRepository(1), updatedAt: undefined },
+        { ...createMockRepository(2), updatedAt: '2024-03-01T00:00:00.000Z' },
+      ]
+
+      render(<RepositoryCard repositories={repositories} />)
+
+      const updatedItems = screen.getAllByTestId('text-info-item-updated')
+      expect(updatedItems).toHaveLength(2)
     })
   })
 

--- a/frontend/__tests__/unit/components/RepositoryCard.test.tsx
+++ b/frontend/__tests__/unit/components/RepositoryCard.test.tsx
@@ -358,7 +358,9 @@ describe('RepositoryCard', () => {
 
       render(<RepositoryCard repositories={[repository]} />)
 
-      expect(screen.getByTestId('text-info-item-updated')).toBeInTheDocument()
+      const updatedItem = screen.getByTestId('text-info-item-updated')
+      expect(updatedItem).toBeInTheDocument()
+      expect(updatedItem).toHaveTextContent('Jun 15, 2024')
     })
 
     it('does not display updated date when updatedAt is undefined', () => {
@@ -382,6 +384,7 @@ describe('RepositoryCard', () => {
 
       const updatedItems = screen.getAllByTestId('text-info-item-updated')
       expect(updatedItems).toHaveLength(3)
+      updatedItems.forEach((item) => expect(item).toHaveTextContent('Jun 15, 2024'))
     })
 
     it('only shows updated date for repositories that have updatedAt', () => {

--- a/frontend/src/components/RepositoryCard.tsx
+++ b/frontend/src/components/RepositoryCard.tsx
@@ -1,14 +1,15 @@
 import { useRouter } from 'next/navigation'
 import type React from 'react'
 import { useState } from 'react'
-import { FaExclamationCircle } from 'react-icons/fa'
+import { FaExclamationCircle, FaRegClock } from 'react-icons/fa'
 import { FaCodeFork, FaStar } from 'react-icons/fa6'
 import { HiUserGroup } from 'react-icons/hi'
 import type { RepositoryCardListProps, RepositoryCardProps } from 'types/project'
-import InfoItem from 'components/InfoItem'
+import InfoItem, { TextInfoItem } from 'components/InfoItem'
 import ShowMoreButton from 'components/ShowMoreButton'
 import StatusBadge from 'components/StatusBadge'
 import { TruncatedText } from 'components/TruncatedText'
+import { formatDate } from 'utils/dateFormatter'
 
 const RepositoryCard: React.FC<RepositoryCardListProps> = ({
   maxInitialDisplay = 4,
@@ -54,7 +55,7 @@ const RepositoryItem = ({ details }: { details: RepositoryCardProps }) => {
   }
 
   return (
-    <div className="flex h-46 w-full flex-col gap-3 rounded-lg border-1 border-gray-200 p-4 shadow-xs ease-in-out hover:shadow-md dark:border-gray-700 dark:bg-gray-800">
+    <div className="flex w-full flex-col gap-3 rounded-lg border-1 border-gray-200 p-4 shadow-xs ease-in-out hover:shadow-md dark:border-gray-700 dark:bg-gray-800">
       <div className="flex items-start justify-between gap-2">
         <button
           type="button"
@@ -86,6 +87,9 @@ const RepositoryItem = ({ details }: { details: RepositoryCardProps }) => {
           unit="Issue"
           value={details.openIssuesCount}
         />
+        {details.updatedAt && (
+          <TextInfoItem icon={FaRegClock} label="Updated" value={formatDate(details.updatedAt)} />
+        )}
       </div>
     </div>
   )

--- a/frontend/src/server/queries/organizationQueries.ts
+++ b/frontend/src/server/queries/organizationQueries.ts
@@ -88,6 +88,7 @@ export const GET_ORGANIZATION_DATA = gql`
         login
       }
       starsCount
+      updatedAt
       url
     }
     recentIssues(limit: 5, organization: $login, distinct: true) {

--- a/frontend/src/server/queries/projectQueries.ts
+++ b/frontend/src/server/queries/projectQueries.ts
@@ -83,6 +83,7 @@ export const GET_PROJECT_DATA = gql`
         }
         starsCount
         subscribersCount
+        updatedAt
         url
       }
       repositoriesCount

--- a/frontend/src/types/project.ts
+++ b/frontend/src/types/project.ts
@@ -72,5 +72,6 @@ export type RepositoryCardProps = {
   organization?: Organization | null
   starsCount: number
   subscribersCount?: number
+  updatedAt?: string
   url: string
 }


### PR DESCRIPTION
Resolves #4912

## Summary

Repository cards currently display stars, forks, contributors, and open issues — but give no indication of whether a repository is actively maintained. This PR surfaces the existing `updatedAt` field from the backend onto each repository card, giving users instant activity visibility without leaving the page.

---

## What Changed

### Data Flow

```mermaid
flowchart LR
    A[GraphQL Backend\nrepository.updatedAt] -->|Added to queries| B[GET_PROJECT_DATA\nGET_ORGANIZATION_DATA]
    B -->|Passed as prop| C[RepositoryCardProps\nupdatedAt?: string]
    C -->|Conditionally rendered| D[RepositoryItem\nTextInfoItem + FaRegClock]
    D -->|Formatted via| E[formatDate utility\n'Jun 15, 2024']
```

### Before vs After

| | Before | After |
|---|---|---|
| Stars | ✅ | ✅ |
| Forks | ✅ | ✅ |
| Contributors | ✅ | ✅ |
| Open Issues | ✅ | ✅ |
| **Last Updated** | ❌ | ✅ `Jun 15, 2024` |

---

## Files Changed

| File | Change |
|------|--------|
| `frontend/src/types/project.ts` | Added `updatedAt?: string` to `RepositoryCardProps` |
| `frontend/src/components/RepositoryCard.tsx` | Render `updatedAt` using `TextInfoItem` + `FaRegClock` |
| `frontend/src/server/queries/projectQueries.ts` | Added `updatedAt` to `repositories {}` in `GET_PROJECT_DATA` |
| `frontend/src/server/queries/organizationQueries.ts` | Added `updatedAt` to `repositories {}` in `GET_ORGANIZATION_DATA` |
| `frontend/__tests__/unit/components/RepositoryCard.test.tsx` | Updated mock + 4 new test cases for `updatedAt` |

---

## Implementation Details

**Component change** — uses existing `TextInfoItem` (already exported from `InfoItem.tsx`) and `formatDate` (from `dateFormatter.ts`). No new dependencies introduced.

```tsx
{details.updatedAt && (
  <TextInfoItem icon={FaRegClock} label="Updated" value={formatDate(details.updatedAt)} />
)}
```

**Conditional rendering** — `updatedAt` is optional. The field is only shown when data is available, so cards without the field render identically to before.

**Date formatting** — uses the project's existing `formatDate` utility, which outputs locale-aware strings like `Jun 15, 2024`.

---

## Test Coverage

4 new unit test cases added under `describe('Last Updated Date on Repository Cards')`:

| Test | Verifies |
|------|----------|
| Displays formatted date when `updatedAt` is provided | Happy path |
| Does not display when `updatedAt` is `undefined` | Graceful absence |
| Shows date for each repo in a list | List rendering |
| Only shows for repos that have `updatedAt` | Mixed list |

---

## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran all required checks and tests locally; all warnings addressed and failures resolved
- [x] I used AI for code, documentation, tests, or communication related to this PR