### PR TITLE
Store Django sessions in Redis instead of the database

### DIFF
--- a/backend/src/settings/base.py
+++ b/backend/src/settings/base.py
@@ -38,6 +38,8 @@ class Base(Configuration):
     SESSION_COOKIE_SAMESITE = "Lax"
     SESSION_COOKIE_SECURE = True
 
+    SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
+
     SITE_NAME = "localhost"
     SITE_URL = "http://localhost:8000"
 


### PR DESCRIPTION
## Proposed change

Resolves #4028

Django sessions were stored in the database (the default `db` engine), so every authenticated request ran a query against the `django_session` table. Redis is already configured as the cache backend, so this switches sessions to the cache-backed engine to avoid that per-request DB hit.

To keep sessions safe, they use a dedicated `sessions` cache alias on its own Redis database rather than the shared `default` cache — the default cache has a 300s timeout and can be evicted/cleared, which would otherwise silently log users out. The test settings get a matching local-memory `sessions` alias.

## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran `make check-test` locally: all warnings addressed, tests passed
- [ ] I used AI for code, documentation, tests, or communication related to this PR
