### PR TITLE
feat: implement infrastructure integration testing suite using LocalStack and Terraform test framework

### DIFF
--- a/.github/actions/setup-terraform-environment/action.yaml
+++ b/.github/actions/setup-terraform-environment/action.yaml
@@ -1,0 +1,31 @@
+name: Setup Terraform Environment
+description: "Checks out the repository, installs Terraform, and configures the provider cache."
+
+inputs:
+  terraform_version:
+    description: "The version of Terraform to install"
+    required: false
+    default: "1.14"
+
+runs:
+  using: composite
+  steps:
+    - name: Check out repository
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      with:
+        persist-credentials: false
+
+    - name: Install Terraform
+      uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e  # v4.0.1
+      with:
+        terraform_version: ${{ inputs.terraform_version }}
+
+    - name: Create plugin cache directory
+      run: mkdir -p "${{ env.TF_PLUGIN_CACHE_DIR }}"
+      shell: bash
+
+    - name: Cache Terraform plugins
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+      with:
+        key: ${{ runner.os }}-${{ runner.arch }}-terraform-${{ hashFiles('infrastructure/**/.terraform.lock.hcl') }}
+        path: ${{ env.TF_PLUGIN_CACHE_DIR }}

--- a/.github/actions/setup-terraform-environment/action.yaml
+++ b/.github/actions/setup-terraform-environment/action.yaml
@@ -7,9 +7,9 @@ description: >
 
 inputs:
   terraform_version:
-    description: "The version of Terraform to install"
+    description: The version of Terraform to install
     required: false
-    default: "1.14"
+    default: '1.14'
 
 runs:
   using: composite
@@ -20,7 +20,9 @@ runs:
         terraform_version: ${{ inputs.terraform_version }}
 
     - name: Create plugin cache directory
-      run: mkdir -p "${{ env.TF_PLUGIN_CACHE_DIR }}"
+      env:
+        TF_PLUGIN_CACHE_DIR: ${{ env.TF_PLUGIN_CACHE_DIR }}
+      run: mkdir -p "$TF_PLUGIN_CACHE_DIR"
       shell: bash
 
     - name: Cache Terraform plugins

--- a/.github/actions/setup-terraform-environment/action.yaml
+++ b/.github/actions/setup-terraform-environment/action.yaml
@@ -1,5 +1,9 @@
 name: Setup Terraform Environment
-description: "Checks out the repository, installs Terraform, and configures the provider cache."
+description: >
+  Installs Terraform and configures the provider cache.
+  NOTE: The calling job must check out the repository before using this
+  action - local composite actions can only be resolved by the runner
+  after checkout, so an internal checkout here would be unreachable.
 
 inputs:
   terraform_version:
@@ -10,11 +14,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Check out repository
-      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
-      with:
-        persist-credentials: false
-
     - name: Install Terraform
       uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e  # v4.0.1
       with:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -97,3 +97,35 @@ updates:
     schedule:
       interval: daily
     target-branch: main
+
+  - package-ecosystem: terraform
+    cooldown:
+      default-days: 21
+    directories:
+      - infrastructure/bootstrap
+      - infrastructure/live
+      - infrastructure/modules/alb
+      - infrastructure/modules/cache
+      - infrastructure/modules/database
+      - infrastructure/modules/ecr-cache
+      - infrastructure/modules/kms
+      - infrastructure/modules/networking
+      - infrastructure/modules/networking/modules/nacl
+      - infrastructure/modules/networking/modules/vpc-endpoint
+      - infrastructure/modules/parameters
+      - infrastructure/modules/security
+      - infrastructure/modules/service
+      - infrastructure/modules/storage
+      - infrastructure/modules/storage/modules/s3-bucket
+      - infrastructure/modules/storage/modules/shared-data-bucket
+      - infrastructure/modules/tasks
+      - infrastructure/modules/tasks/modules/task
+      - infrastructure/state
+    groups:
+      version-updates:
+        applies-to: version-updates
+        patterns:
+          - '*'
+    schedule:
+      interval: daily
+    target-branch: main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,8 @@ jobs:
       actions: write
       contents: read
       id-token: write
+    secrets:
+      LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
     uses: ./.github/workflows/run-code-tests.yaml
 
   run-dependency-audit:

--- a/.github/workflows/run-code-tests.yaml
+++ b/.github/workflows/run-code-tests.yaml
@@ -2,6 +2,9 @@ name: Code tests
 
 on:
   workflow_call:
+    secrets:
+      LOCALSTACK_AUTH_TOKEN:
+        required: false
 
 permissions: {}
 
@@ -74,4 +77,6 @@ jobs:
     name: Infrastructure tests
     permissions:
       contents: read
+    secrets:
+      LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
     uses: ./.github/workflows/run-infrastructure-tests.yaml

--- a/.github/workflows/run-infrastructure-tests.yaml
+++ b/.github/workflows/run-infrastructure-tests.yaml
@@ -64,19 +64,10 @@ jobs:
       - name: Setup Terraform Environment
         uses: ./.github/actions/setup-terraform-environment
 
-      - name: Validate LocalStack auth token
-        env:
-          LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
-        run: |
-          test -n "$LOCALSTACK_AUTH_TOKEN" || {
-            echo "LOCALSTACK_AUTH_TOKEN is required for LocalStack integration tests."
-            exit 1
-          }
-
       - name: Start LocalStack
         uses: localstack/setup-localstack@7c8a0cb3405bc58be4c8f763f812aa000bc46303  # v0.3.2
         with:
-          image-tag: 4.2.0
+          image-tag: 4.14.0
         env:
           LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
 

--- a/.github/workflows/run-infrastructure-tests.yaml
+++ b/.github/workflows/run-infrastructure-tests.yaml
@@ -67,7 +67,7 @@ jobs:
       - name: Start LocalStack
         uses: localstack/setup-localstack@7c8a0cb3405bc58be4c8f763f812aa000bc46303  # v0.3.2
         with:
-          image-tag: 4.14.0
+          image-tag: 2026.6.0
         env:
           LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
 

--- a/.github/workflows/run-infrastructure-tests.yaml
+++ b/.github/workflows/run-infrastructure-tests.yaml
@@ -36,6 +36,11 @@ jobs:
       contents: read
     runs-on: ubuntu-24.04-arm
     steps:
+      - name: Check out repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
+
       - name: Setup Terraform Environment
         uses: ./.github/actions/setup-terraform-environment
 

--- a/.github/workflows/run-infrastructure-tests.yaml
+++ b/.github/workflows/run-infrastructure-tests.yaml
@@ -2,6 +2,9 @@ name: Infrastructure tests
 
 on:
   workflow_call:
+    secrets:
+      LOCALSTACK_AUTH_TOKEN:
+        required: false
 
 env:
   FORCE_COLOR: 1
@@ -10,6 +13,22 @@ env:
 permissions: {}
 
 jobs:
+  check-secrets:
+    name: Check secrets availability
+    runs-on: ubuntu-24.04-arm
+    outputs:
+      has-token: ${{ steps.check.outputs.has-token }}
+    steps:
+      - id: check
+        env:
+          LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
+        run: |
+          if [ -n "$LOCALSTACK_AUTH_TOKEN" ]; then
+            echo "has-token=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-token=false" >> "$GITHUB_OUTPUT"
+          fi
+
   run-infrastructure-tests:
     name: Infrastructure tests
     permissions:
@@ -37,4 +56,51 @@ jobs:
 
       - name: Run tests
         run: make test-infrastructure
+    timeout-minutes: 10
+
+  infrastructure-integration-tests:
+    name: Infrastructure integration tests
+    needs: check-secrets
+    if: ${{ needs.check-secrets.outputs.has-token == 'true' }}
+    permissions:
+      contents: read
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e  # v4.0.1
+        with:
+          terraform_version: 1.14
+
+      - name: Validate LocalStack auth token
+        env:
+          LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
+        run: |
+          test -n "$LOCALSTACK_AUTH_TOKEN" || {
+            echo "LOCALSTACK_AUTH_TOKEN is required for LocalStack integration tests."
+            exit 1
+          }
+
+      - name: Start LocalStack
+        uses: localstack/setup-localstack@e6a1e5c3a9cb6c37fca3b4bb951c87e3967afa59  # v0.2.1
+        with:
+          image-tag: 4.2.0
+        env:
+          LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
+
+      - name: Create plugin cache directory
+        run: mkdir -p "$TF_PLUGIN_CACHE_DIR"
+
+      - name: Cache Terraform plugins
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          key: ${{ runner.os }}-${{ runner.arch }}-terraform-${{ hashFiles('infrastructure/**/.terraform.lock.hcl') }}
+          path: ${{ env.TF_PLUGIN_CACHE_DIR }}
+
+      - name: Run integration tests
+        run: make test-infrastructure-integration
     timeout-minutes: 10

--- a/.github/workflows/run-infrastructure-tests.yaml
+++ b/.github/workflows/run-infrastructure-tests.yaml
@@ -56,6 +56,11 @@ jobs:
       contents: read
     runs-on: ubuntu-24.04-arm
     steps:
+      - name: Check out repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
+
       - name: Setup Terraform Environment
         uses: ./.github/actions/setup-terraform-environment
 

--- a/.github/workflows/run-infrastructure-tests.yaml
+++ b/.github/workflows/run-infrastructure-tests.yaml
@@ -16,6 +16,7 @@ jobs:
   check-secrets:
     name: Check secrets availability
     runs-on: ubuntu-24.04-arm
+    permissions: {}
     outputs:
       has-token: ${{ steps.check.outputs.has-token }}
     steps:
@@ -35,24 +36,8 @@ jobs:
       contents: read
     runs-on: ubuntu-24.04-arm
     steps:
-      - name: Check out repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
-        with:
-          persist-credentials: false
-
-      - name: Install Terraform
-        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e  # v4.0.1
-        with:
-          terraform_version: 1.14
-
-      - name: Create plugin cache directory
-        run: mkdir -p "$TF_PLUGIN_CACHE_DIR"
-
-      - name: Cache Terraform plugins
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
-        with:
-          key: ${{ runner.os }}-${{ runner.arch }}-terraform-${{ hashFiles('infrastructure/**/.terraform.lock.hcl') }}
-          path: ${{ env.TF_PLUGIN_CACHE_DIR }}
+      - name: Setup Terraform Environment
+        uses: ./.github/actions/setup-terraform-environment
 
       - name: Run tests
         run: make test-infrastructure
@@ -66,15 +51,8 @@ jobs:
       contents: read
     runs-on: ubuntu-24.04-arm
     steps:
-      - name: Check out repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
-        with:
-          persist-credentials: false
-
-      - name: Install Terraform
-        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e  # v4.0.1
-        with:
-          terraform_version: 1.14
+      - name: Setup Terraform Environment
+        uses: ./.github/actions/setup-terraform-environment
 
       - name: Validate LocalStack auth token
         env:
@@ -86,21 +64,12 @@ jobs:
           }
 
       - name: Start LocalStack
-        uses: localstack/setup-localstack@e6a1e5c3a9cb6c37fca3b4bb951c87e3967afa59  # v0.2.1
+        uses: localstack/setup-localstack@7c8a0cb3405bc58be4c8f763f812aa000bc46303  # v0.3.2
         with:
           image-tag: 4.2.0
         env:
           LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
 
-      - name: Create plugin cache directory
-        run: mkdir -p "$TF_PLUGIN_CACHE_DIR"
-
-      - name: Cache Terraform plugins
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
-        with:
-          key: ${{ runner.os }}-${{ runner.arch }}-terraform-${{ hashFiles('infrastructure/**/.terraform.lock.hcl') }}
-          path: ${{ env.TF_PLUGIN_CACHE_DIR }}
-
       - name: Run integration tests
         run: make test-infrastructure-integration
-    timeout-minutes: 10
+    timeout-minutes: 15

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,11 @@ __pycache__
 *.tfstate.*
 *.tfvars
 !*.tfvars.example
+# Override files
+*_override.tf
+*_override.tf.json
+override.tf
+override.tf.json
 **/.terraform/
 backend-sbom-local.cdx.json
 backend/.hypothesis/

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ include infrastructure/Makefile
 	check-graphql clean clean-tooling-dependencies clean-trivy-cache eslint fix-eslint fix-prettier graphql-codegen help install-frontend-dependencies install-tooling-dependencies pre-commit prettier prune run \
 	scan-images security-scan security-scan-backend-image security-scan-code security-scan-code-semgrep \
 	security-scan-code-trivy security-scan-frontend-image security-scan-images security-scan-zap test \
-	test-infrastructure test-nest-app update update-tooling-dependencies
+	test-infrastructure test-infrastructure-integration test-nest-app update update-tooling-dependencies
 
 AUDIT_LEVEL ?= high
 

--- a/cspell/custom-dict.txt
+++ b/cspell/custom-dict.txt
@@ -230,6 +230,7 @@ speakerdeck
 subgrp
 superfences
 tfbackend
+tftest
 tgz
 tiktok
 trailofbits

--- a/docker/localstack/Dockerfile
+++ b/docker/localstack/Dockerfile
@@ -1,1 +1,1 @@
-FROM localstack/localstack:4.2.0@sha256:4e079715a49b0d8102a59b0dec5140bf0627f4b301ca7a4ec479ee5802d3e2b4
+FROM localstack/localstack:2026.6.0@sha256:337d85adc17c2af7c90620a7dc4c07163f55f2ea15c4f0fe59eddcd8d6535b08

--- a/docker/localstack/Dockerfile
+++ b/docker/localstack/Dockerfile
@@ -1,0 +1,1 @@
+FROM localstack/localstack:4.2.0@sha256:4e079715a49b0d8102a59b0dec5140bf0627f4b301ca7a4ec479ee5802d3e2b4

--- a/infrastructure/Makefile
+++ b/infrastructure/Makefile
@@ -7,7 +7,21 @@ test-infrastructure: ## Run infrastructure tests
 		-not -path "*/.terraform/*" | \
 	while IFS= read -r test_dir; do \
 		module_dir=$$(dirname "$$test_dir"); \
-		echo "Testing $$module_dir..."; \
-		terraform -chdir="$$module_dir" init -backend=false -input=false && \
-		terraform -chdir="$$module_dir" test || exit 1; \
+	filters=""; \
+		for test_file in "$$test_dir"/*.tftest.hcl; do \
+			[ -e "$$test_file" ] || continue; \
+		filename=$$(basename "$$test_file"); \
+			case "$$filename" in \
+				*integration*) ;; \
+				*) filters="$$filters -filter=tests/$$filename" ;; \
+			esac; \
+		done; \
+		if [ -n "$$filters" ]; then \
+			echo "Testing $$module_dir..."; \
+			terraform -chdir="$$module_dir" init -backend=false -input=false && \
+			terraform -chdir="$$module_dir" test $$filters || exit 1; \
+		fi; \
 	done
+
+test-infrastructure-integration: ## Run infrastructure integration tests
+	@./infrastructure/scripts/run-integration-tests.sh

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -377,6 +377,37 @@ aws ecs run-task \
         --region AWS_REGION
     ```
 
+## Testing
+
+Infrastructure configurations are tested using Terraform's native testing framework (`terraform test`).
+
+### Unit/Mock Testing
+
+These tests use a mock AWS provider and validate variable constraints, name formatting, and structure without creating actual cloud resources or contacting any APIs.
+
+To run unit/mock tests:
+
+```bash
+make test-infrastructure
+```
+
+### Integration Testing (with LocalStack)
+
+Integration tests deploy resources against a local LocalStack instance to verify IAM policies, SSM/KMS interactions, and resource wiring.
+
+#### Prerequisite
+
+You must have Docker running locally.
+
+To run integration tests, you only need to run:
+
+```bash
+export LOCALSTACK_AUTH_TOKEN="<your_auth_token>"
+make test-infrastructure-integration
+```
+
+The test runner script will automatically start, check health, and tear down the LocalStack container if it is not already running on port 4566.
+
 ## Cleaning Up
 
 - Ensure all buckets and ECR repositories are empty.

--- a/infrastructure/modules/ecr-cache/.terraform.lock.hcl
+++ b/infrastructure/modules/ecr-cache/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = "~> 6.36.0"
   hashes = [
     "h1:UYt6mrz0d3PfTJRbJAxe+fLcJt7voXJCLLdwfHrApGk=",
+    "h1:r9icn1WEZVvEXiy6ZKexLzAPnXkkt+22jJ9WQYPfKB0=",
     "zh:0eb4481315564aaeec4905a804fd0df22c40f509ad2af63615eeaa90abacf81c",
     "zh:12c3cddc461a8dbaa04387fe83420b64c4c05cb5479d181674168ca7daefcc38",
     "zh:1b55a09661e80acf6826faa38dd8fbff24c2ef620d2a0a16918491a222c55370",

--- a/infrastructure/modules/ecr-cache/tests/integration.tftest.hcl
+++ b/infrastructure/modules/ecr-cache/tests/integration.tftest.hcl
@@ -35,4 +35,14 @@ run "integration_apply" {
     condition     = aws_ecr_repository.main.image_tag_mutability == "MUTABLE"
     error_message = "ECR cache repository must allow mutable tags for build cache manifests."
   }
+
+  assert {
+    condition     = aws_ecr_repository.main.image_scanning_configuration[0].scan_on_push == false
+    error_message = "ECR cache repository image scanning on push must be disabled."
+  }
+
+  assert {
+    condition     = aws_ecr_lifecycle_policy.main.repository == aws_ecr_repository.main.name
+    error_message = "ECR lifecycle policy repository name does not match."
+  }
 }

--- a/infrastructure/modules/ecr-cache/tests/integration.tftest.hcl
+++ b/infrastructure/modules/ecr-cache/tests/integration.tftest.hcl
@@ -1,0 +1,38 @@
+provider "aws" {
+  access_key                  = "test"
+  region                      = "us-east-1"
+  s3_use_path_style           = true
+  secret_key                  = "test"
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+  endpoints {
+    ecr = "http://localhost:4566"
+    iam = "http://localhost:4566"
+    kms = "http://localhost:4566"
+    s3  = "http://localhost:4566"
+    sts = "http://localhost:4566"
+  }
+}
+
+variables {
+  common_tags = {
+    Environment = "test"
+    Project     = "nest"
+  }
+  name = "nest-test-backend-cache"
+}
+
+run "integration_apply" {
+  command = apply
+
+  assert {
+    condition     = aws_ecr_repository.main.name == var.name
+    error_message = "ECR cache repository name must match the configured name."
+  }
+
+  assert {
+    condition     = aws_ecr_repository.main.image_tag_mutability == "MUTABLE"
+    error_message = "ECR cache repository must allow mutable tags for build cache manifests."
+  }
+}

--- a/infrastructure/modules/kms/tests/integration.tftest.hcl
+++ b/infrastructure/modules/kms/tests/integration.tftest.hcl
@@ -1,0 +1,41 @@
+provider "aws" {
+  access_key                  = "test"
+  region                      = "us-east-1"
+  s3_use_path_style           = true
+  secret_key                  = "test"
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+  endpoints {
+    iam = "http://localhost:4566"
+    kms = "http://localhost:4566"
+    s3  = "http://localhost:4566"
+    sts = "http://localhost:4566"
+  }
+}
+
+variables {
+  alias_name   = "alias/nest-test-integration"
+  common_tags  = { Environment = "test", Project = "nest" }
+  environment  = "test"
+  project_name = "nest"
+}
+
+run "integration_apply" {
+  command = apply
+
+  assert {
+    condition     = can(aws_kms_key.main.key_id)
+    error_message = "KMS key was not created."
+  }
+
+  assert {
+    condition     = aws_kms_alias.main.name == var.alias_name
+    error_message = "KMS alias name format is incorrect."
+  }
+
+  assert {
+    condition     = aws_kms_alias.main.target_key_id == aws_kms_key.main.key_id
+    error_message = "KMS alias must point to the created KMS key."
+  }
+}

--- a/infrastructure/modules/parameters/tests/integration.tftest.hcl
+++ b/infrastructure/modules/parameters/tests/integration.tftest.hcl
@@ -50,4 +50,34 @@ run "integration_apply" {
     condition     = aws_ssm_parameter.django_allowed_hosts.value == var.django_allowed_hosts
     error_message = "SSM parameter value format is incorrect."
   }
+
+  assert {
+    condition     = aws_ssm_parameter.django_db_host.name == "/${var.project_name}/${var.environment}/DJANGO_DB_HOST"
+    error_message = "SSM database host parameter path format is incorrect."
+  }
+
+  assert {
+    condition     = aws_ssm_parameter.django_db_host.value == var.django_db_host
+    error_message = "SSM database host parameter value format is incorrect."
+  }
+
+  assert {
+    condition     = aws_ssm_parameter.nextauth_url.name == "/${var.project_name}/${var.environment}/NEXTAUTH_URL"
+    error_message = "SSM nextauth_url parameter path format is incorrect."
+  }
+
+  assert {
+    condition     = aws_ssm_parameter.nextauth_url.value == var.nextauth_url
+    error_message = "SSM nextauth_url parameter value format is incorrect."
+  }
+
+  assert {
+    condition     = aws_ssm_parameter.django_secret_key.name == "/${var.project_name}/${var.environment}/DJANGO_SECRET_KEY"
+    error_message = "SSM django_secret_key parameter path format is incorrect."
+  }
+
+  assert {
+    condition     = aws_ssm_parameter.django_secret_key.type == "SecureString"
+    error_message = "SSM django_secret_key parameter type must be SecureString."
+  }
 }

--- a/infrastructure/modules/parameters/tests/integration.tftest.hcl
+++ b/infrastructure/modules/parameters/tests/integration.tftest.hcl
@@ -1,0 +1,53 @@
+provider "aws" {
+  access_key                  = "test"
+  region                      = "us-east-1"
+  s3_use_path_style           = true
+  secret_key                  = "test"
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+  endpoints {
+    iam = "http://localhost:4566"
+    kms = "http://localhost:4566"
+    s3  = "http://localhost:4566"
+    ssm = "http://localhost:4566"
+    sts = "http://localhost:4566"
+  }
+}
+
+variables {
+  common_tags                   = { Environment = "test", Project = "nest" }
+  db_password_arn               = "arn:aws:ssm:us-east-1:000000000000:parameter/nest/test/DJANGO_DB_PASSWORD"
+  django_allowed_hosts          = "nest.owasp.dev"
+  django_allowed_origins        = "https://nest.owasp.dev"
+  django_aws_static_bucket_name = "nest-test-static-abcd1234"
+  django_configuration          = "Staging"
+  django_db_host                = "db.example.com"
+  django_db_name                = "nest_db"
+  django_db_port                = "5432"
+  django_db_user                = "nest_user"
+  django_redis_host             = "redis.example.com"
+  django_release_version        = "1.0.0"
+  django_settings_module        = "settings.staging"
+  environment                   = "test"
+  next_server_csrf_url          = "https://nest.owasp.dev/csrf"
+  next_server_graphql_url       = "https://nest.owasp.dev/graphql"
+  nextauth_url                  = "https://nest.owasp.dev"
+  project_name                  = "nest"
+  redis_password_arn            = "arn:aws:ssm:us-east-1:000000000000:parameter/nest/test/DJANGO_REDIS_PASSWORD"
+  slack_bot_token_suffix        = "T04T40NHX"
+}
+
+run "integration_apply" {
+  command = apply
+
+  assert {
+    condition     = aws_ssm_parameter.django_allowed_hosts.name == "/${var.project_name}/${var.environment}/DJANGO_ALLOWED_HOSTS"
+    error_message = "SSM parameter path format is incorrect."
+  }
+
+  assert {
+    condition     = aws_ssm_parameter.django_allowed_hosts.value == var.django_allowed_hosts
+    error_message = "SSM parameter value format is incorrect."
+  }
+}

--- a/infrastructure/modules/storage/.terraform.lock.hcl
+++ b/infrastructure/modules/storage/.terraform.lock.hcl
@@ -2,26 +2,29 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "6.36.0"
-  constraints = "~> 6.36.0"
+  version     = "6.53.0"
+  constraints = "~> 6.53.0"
   hashes = [
-    "h1:UYt6mrz0d3PfTJRbJAxe+fLcJt7voXJCLLdwfHrApGk=",
-    "h1:r9icn1WEZVvEXiy6ZKexLzAPnXkkt+22jJ9WQYPfKB0=",
-    "zh:0eb4481315564aaeec4905a804fd0df22c40f509ad2af63615eeaa90abacf81c",
-    "zh:12c3cddc461a8dbaa04387fe83420b64c4c05cb5479d181674168ca7daefcc38",
-    "zh:1b55a09661e80acf6826faa38dd8fbff24c2ef620d2a0a16918491a222c55370",
-    "zh:269cb1a406d0cac762bce82119247395a0bbf0d4ad2492fb2ea5653b4f44bc05",
-    "zh:3bfb78e3345f0c3846e76578952a09fb5dda05d2d73e19473fb0af0000469a66",
-    "zh:3ead4f4388c7dd78ed198082a981746324da0d7a51460c9b455fd884d86fc82c",
-    "zh:44906654199991b3f1a21c6a984bc5f9f556ff4baa4e5f77e168968e941c2725",
-    "zh:4803d050d581b05b0fd0ae5cce95ec1784d66e2bc9da4b1f7663df0ce7914609",
-    "zh:4cf9fe8fae58b62e83c0672a9c66e0963b7289aaf768a250e9bc44570d82cbd5",
-    "zh:5bfd7a1fb3116164b411777115dd4b272a68984fa949c687e41a3041318c82f1",
-    "zh:77cbcf2db512617f10b81e11c20d40fa534ef07163171cbe35214fa8f74b4e85",
-    "zh:8201cabed01f1434bf9ea7fbcf2a95612a87a0398b870b2643bd1a5119793d2d",
-    "zh:9aaded4cf36ec2abbe35086733a4510e08819698180b21a9387ba4112aee02e0",
+    "h1:UFEhEEFJcR/pAOZcwdR11gN9W3X8VwvSl1IS0vbj2G0=",
+    "h1:bvlWCSuVJQshwuA/vJONdjEUIzGdsW3uSfLxoP9RnIw=",
+    "h1:nZ85OLLO0sNw/76mgQQQmnOodiQGaaGVxq1NaV3ol4g=",
+    "h1:sSfqLt0XIbqfTvOSZr2gkyiv1Ysg6uuiVXFd/btmsoY=",
+    "zh:0757ce9d5a30e8225521857924f5d6c49e5885fd9e309e56193c9c9920b3f8f0",
+    "zh:10ddb3a20e0779788e8002bc67d184eb166dec70f9d07220bfc55e15c3e5e206",
+    "zh:1e943f59a8c3f3b04f09fd5d967fef2518e0ce3ec4959e31f5d7f820660e8524",
+    "zh:21d55ad3b28f48c6dd34faceeb1fd1fe2ec3b1aaecfc5eb0e0841884f6520d69",
+    "zh:2e551bc0ff29ea608a99f63d899afbdf2f23c14035f27dc0c0bdca60209d9575",
+    "zh:581db963564364200426f2a4be866470a975cde6a4bd6fd09362ec2bab119cbb",
+    "zh:71a7abc88e16ccbe4410fc4966bd35fae9e0161c1385a9b3c19800e3db626b01",
+    "zh:8767767776c45590d4cc74b4c37f6377e05ce75039a9c2e834de0bbcc29f7a1a",
+    "zh:99c8e37beb9b1017f67c41e402031559b745fa797848f1a4ef8b40421dee3f05",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:f594ef2683a0d23d3a6f0ad6c84a55ed79368c158ee08c2f3b7c41ec446a701f",
+    "zh:ba1477eda2f3ee51846492449338146f80806088d2952c08c2f8af874550a75d",
+    "zh:c389f68ba4d39fa2bf8a54d4af7f7b2132da2a964c260892c1dd1a89b67e61f8",
+    "zh:d7381490a637a1fa45769d0ee6b3e0578cce488d078077ec63d9090113784f2a",
+    "zh:df3b82fb1a675fc6548fac2fff10a8741efa5bcb5a53d01d8f0659179a2f717f",
+    "zh:e5d78b2ac3dc5477cf21d7cd4c8b9e3d944ff091e90b62c1b2ea9cc7c7eef57c",
+    "zh:fd224078287c6d82de2ec30ea03d3d550c2c554e372b234f7a6ac2b07c23dba0",
   ]
 }
 
@@ -30,6 +33,8 @@ provider "registry.terraform.io/hashicorp/random" {
   constraints = "~> 3.8.0"
   hashes = [
     "h1:Eexl06+6J+s75uD46+WnZtpJZYRVUMB0AiuPBifK6Jc=",
+    "h1:fdfOl1HabDT42XLH8qjmfTbVZpgQZ5lyOyOa+GQhm0w=",
+    "h1:m2y2fw9SBQ6+e7pNhi3+qsh8bYNmqkL89BulzH7uK3U=",
     "h1:u8AKlWVDTH5r9YLSeswoVEjiY72Rt4/ch7U+61ZDkiQ=",
     "zh:08dd03b918c7b55713026037c5400c48af5b9f468f483463321bd18e17b907b4",
     "zh:0eee654a5542dc1d41920bbf2419032d6f0d5625b03bd81339e5b33394a3e0ae",

--- a/infrastructure/modules/storage/README.md
+++ b/infrastructure/modules/storage/README.md
@@ -4,14 +4,14 @@
 | Name | Version |
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.14.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.36.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.53.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.8.0 |
 
 ## Providers
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.36.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.8.1 |
 
 ## Modules

--- a/infrastructure/modules/storage/main.tf
+++ b/infrastructure/modules/storage/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.36.0"
+      version = "~> 6.53.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/infrastructure/modules/storage/modules/s3-bucket/.terraform.lock.hcl
+++ b/infrastructure/modules/storage/modules/s3-bucket/.terraform.lock.hcl
@@ -2,25 +2,28 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "6.36.0"
-  constraints = "~> 6.36.0"
+  version     = "6.53.0"
+  constraints = "~> 6.53.0"
   hashes = [
-    "h1:UYt6mrz0d3PfTJRbJAxe+fLcJt7voXJCLLdwfHrApGk=",
-    "h1:r9icn1WEZVvEXiy6ZKexLzAPnXkkt+22jJ9WQYPfKB0=",
-    "zh:0eb4481315564aaeec4905a804fd0df22c40f509ad2af63615eeaa90abacf81c",
-    "zh:12c3cddc461a8dbaa04387fe83420b64c4c05cb5479d181674168ca7daefcc38",
-    "zh:1b55a09661e80acf6826faa38dd8fbff24c2ef620d2a0a16918491a222c55370",
-    "zh:269cb1a406d0cac762bce82119247395a0bbf0d4ad2492fb2ea5653b4f44bc05",
-    "zh:3bfb78e3345f0c3846e76578952a09fb5dda05d2d73e19473fb0af0000469a66",
-    "zh:3ead4f4388c7dd78ed198082a981746324da0d7a51460c9b455fd884d86fc82c",
-    "zh:44906654199991b3f1a21c6a984bc5f9f556ff4baa4e5f77e168968e941c2725",
-    "zh:4803d050d581b05b0fd0ae5cce95ec1784d66e2bc9da4b1f7663df0ce7914609",
-    "zh:4cf9fe8fae58b62e83c0672a9c66e0963b7289aaf768a250e9bc44570d82cbd5",
-    "zh:5bfd7a1fb3116164b411777115dd4b272a68984fa949c687e41a3041318c82f1",
-    "zh:77cbcf2db512617f10b81e11c20d40fa534ef07163171cbe35214fa8f74b4e85",
-    "zh:8201cabed01f1434bf9ea7fbcf2a95612a87a0398b870b2643bd1a5119793d2d",
-    "zh:9aaded4cf36ec2abbe35086733a4510e08819698180b21a9387ba4112aee02e0",
+    "h1:UFEhEEFJcR/pAOZcwdR11gN9W3X8VwvSl1IS0vbj2G0=",
+    "h1:bvlWCSuVJQshwuA/vJONdjEUIzGdsW3uSfLxoP9RnIw=",
+    "h1:nZ85OLLO0sNw/76mgQQQmnOodiQGaaGVxq1NaV3ol4g=",
+    "h1:sSfqLt0XIbqfTvOSZr2gkyiv1Ysg6uuiVXFd/btmsoY=",
+    "zh:0757ce9d5a30e8225521857924f5d6c49e5885fd9e309e56193c9c9920b3f8f0",
+    "zh:10ddb3a20e0779788e8002bc67d184eb166dec70f9d07220bfc55e15c3e5e206",
+    "zh:1e943f59a8c3f3b04f09fd5d967fef2518e0ce3ec4959e31f5d7f820660e8524",
+    "zh:21d55ad3b28f48c6dd34faceeb1fd1fe2ec3b1aaecfc5eb0e0841884f6520d69",
+    "zh:2e551bc0ff29ea608a99f63d899afbdf2f23c14035f27dc0c0bdca60209d9575",
+    "zh:581db963564364200426f2a4be866470a975cde6a4bd6fd09362ec2bab119cbb",
+    "zh:71a7abc88e16ccbe4410fc4966bd35fae9e0161c1385a9b3c19800e3db626b01",
+    "zh:8767767776c45590d4cc74b4c37f6377e05ce75039a9c2e834de0bbcc29f7a1a",
+    "zh:99c8e37beb9b1017f67c41e402031559b745fa797848f1a4ef8b40421dee3f05",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:f594ef2683a0d23d3a6f0ad6c84a55ed79368c158ee08c2f3b7c41ec446a701f",
+    "zh:ba1477eda2f3ee51846492449338146f80806088d2952c08c2f8af874550a75d",
+    "zh:c389f68ba4d39fa2bf8a54d4af7f7b2132da2a964c260892c1dd1a89b67e61f8",
+    "zh:d7381490a637a1fa45769d0ee6b3e0578cce488d078077ec63d9090113784f2a",
+    "zh:df3b82fb1a675fc6548fac2fff10a8741efa5bcb5a53d01d8f0659179a2f717f",
+    "zh:e5d78b2ac3dc5477cf21d7cd4c8b9e3d944ff091e90b62c1b2ea9cc7c7eef57c",
+    "zh:fd224078287c6d82de2ec30ea03d3d550c2c554e372b234f7a6ac2b07c23dba0",
   ]
 }

--- a/infrastructure/modules/storage/modules/s3-bucket/README.md
+++ b/infrastructure/modules/storage/modules/s3-bucket/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.14.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.36.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.53.0 |
 
 ## Providers
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.36.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
 
 ## Modules
 

--- a/infrastructure/modules/storage/modules/s3-bucket/README.md
+++ b/infrastructure/modules/storage/modules/s3-bucket/README.md
@@ -44,4 +44,5 @@ No modules.
 | ---- | ----------- |
 | <a name="output_arn"></a> [arn](#output\_arn) | The ARN of the S3 bucket. |
 | <a name="output_bucket"></a> [bucket](#output\_bucket) | The S3 bucket resource. |
+| <a name="output_server_side_encryption_configuration"></a> [server\_side\_encryption\_configuration](#output\_server\_side\_encryption\_configuration) | The server-side encryption configuration. |
 <!-- END_TF_DOCS -->

--- a/infrastructure/modules/storage/modules/s3-bucket/main.tf
+++ b/infrastructure/modules/storage/modules/s3-bucket/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.36.0"
+      version = "~> 6.53.0"
     }
   }
 }

--- a/infrastructure/modules/storage/modules/s3-bucket/outputs.tf
+++ b/infrastructure/modules/storage/modules/s3-bucket/outputs.tf
@@ -7,3 +7,8 @@ output "bucket" {
   description = "The S3 bucket resource."
   value       = aws_s3_bucket.this
 }
+
+output "server_side_encryption_configuration" {
+  description = "The server-side encryption configuration."
+  value       = aws_s3_bucket_server_side_encryption_configuration.this
+}

--- a/infrastructure/modules/storage/modules/shared-data-bucket/.terraform.lock.hcl
+++ b/infrastructure/modules/storage/modules/shared-data-bucket/.terraform.lock.hcl
@@ -2,25 +2,28 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "6.36.0"
-  constraints = "~> 6.36.0"
+  version     = "6.53.0"
+  constraints = "~> 6.53.0"
   hashes = [
-    "h1:UYt6mrz0d3PfTJRbJAxe+fLcJt7voXJCLLdwfHrApGk=",
-    "h1:r9icn1WEZVvEXiy6ZKexLzAPnXkkt+22jJ9WQYPfKB0=",
-    "zh:0eb4481315564aaeec4905a804fd0df22c40f509ad2af63615eeaa90abacf81c",
-    "zh:12c3cddc461a8dbaa04387fe83420b64c4c05cb5479d181674168ca7daefcc38",
-    "zh:1b55a09661e80acf6826faa38dd8fbff24c2ef620d2a0a16918491a222c55370",
-    "zh:269cb1a406d0cac762bce82119247395a0bbf0d4ad2492fb2ea5653b4f44bc05",
-    "zh:3bfb78e3345f0c3846e76578952a09fb5dda05d2d73e19473fb0af0000469a66",
-    "zh:3ead4f4388c7dd78ed198082a981746324da0d7a51460c9b455fd884d86fc82c",
-    "zh:44906654199991b3f1a21c6a984bc5f9f556ff4baa4e5f77e168968e941c2725",
-    "zh:4803d050d581b05b0fd0ae5cce95ec1784d66e2bc9da4b1f7663df0ce7914609",
-    "zh:4cf9fe8fae58b62e83c0672a9c66e0963b7289aaf768a250e9bc44570d82cbd5",
-    "zh:5bfd7a1fb3116164b411777115dd4b272a68984fa949c687e41a3041318c82f1",
-    "zh:77cbcf2db512617f10b81e11c20d40fa534ef07163171cbe35214fa8f74b4e85",
-    "zh:8201cabed01f1434bf9ea7fbcf2a95612a87a0398b870b2643bd1a5119793d2d",
-    "zh:9aaded4cf36ec2abbe35086733a4510e08819698180b21a9387ba4112aee02e0",
+    "h1:UFEhEEFJcR/pAOZcwdR11gN9W3X8VwvSl1IS0vbj2G0=",
+    "h1:bvlWCSuVJQshwuA/vJONdjEUIzGdsW3uSfLxoP9RnIw=",
+    "h1:nZ85OLLO0sNw/76mgQQQmnOodiQGaaGVxq1NaV3ol4g=",
+    "h1:sSfqLt0XIbqfTvOSZr2gkyiv1Ysg6uuiVXFd/btmsoY=",
+    "zh:0757ce9d5a30e8225521857924f5d6c49e5885fd9e309e56193c9c9920b3f8f0",
+    "zh:10ddb3a20e0779788e8002bc67d184eb166dec70f9d07220bfc55e15c3e5e206",
+    "zh:1e943f59a8c3f3b04f09fd5d967fef2518e0ce3ec4959e31f5d7f820660e8524",
+    "zh:21d55ad3b28f48c6dd34faceeb1fd1fe2ec3b1aaecfc5eb0e0841884f6520d69",
+    "zh:2e551bc0ff29ea608a99f63d899afbdf2f23c14035f27dc0c0bdca60209d9575",
+    "zh:581db963564364200426f2a4be866470a975cde6a4bd6fd09362ec2bab119cbb",
+    "zh:71a7abc88e16ccbe4410fc4966bd35fae9e0161c1385a9b3c19800e3db626b01",
+    "zh:8767767776c45590d4cc74b4c37f6377e05ce75039a9c2e834de0bbcc29f7a1a",
+    "zh:99c8e37beb9b1017f67c41e402031559b745fa797848f1a4ef8b40421dee3f05",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:f594ef2683a0d23d3a6f0ad6c84a55ed79368c158ee08c2f3b7c41ec446a701f",
+    "zh:ba1477eda2f3ee51846492449338146f80806088d2952c08c2f8af874550a75d",
+    "zh:c389f68ba4d39fa2bf8a54d4af7f7b2132da2a964c260892c1dd1a89b67e61f8",
+    "zh:d7381490a637a1fa45769d0ee6b3e0578cce488d078077ec63d9090113784f2a",
+    "zh:df3b82fb1a675fc6548fac2fff10a8741efa5bcb5a53d01d8f0659179a2f717f",
+    "zh:e5d78b2ac3dc5477cf21d7cd4c8b9e3d944ff091e90b62c1b2ea9cc7c7eef57c",
+    "zh:fd224078287c6d82de2ec30ea03d3d550c2c554e372b234f7a6ac2b07c23dba0",
   ]
 }

--- a/infrastructure/modules/storage/modules/shared-data-bucket/.terraform.lock.hcl
+++ b/infrastructure/modules/storage/modules/shared-data-bucket/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = "~> 6.36.0"
   hashes = [
     "h1:UYt6mrz0d3PfTJRbJAxe+fLcJt7voXJCLLdwfHrApGk=",
+    "h1:r9icn1WEZVvEXiy6ZKexLzAPnXkkt+22jJ9WQYPfKB0=",
     "zh:0eb4481315564aaeec4905a804fd0df22c40f509ad2af63615eeaa90abacf81c",
     "zh:12c3cddc461a8dbaa04387fe83420b64c4c05cb5479d181674168ca7daefcc38",
     "zh:1b55a09661e80acf6826faa38dd8fbff24c2ef620d2a0a16918491a222c55370",

--- a/infrastructure/modules/storage/modules/shared-data-bucket/README.md
+++ b/infrastructure/modules/storage/modules/shared-data-bucket/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.14.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.36.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.53.0 |
 
 ## Providers
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.36.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
 
 ## Modules
 

--- a/infrastructure/modules/storage/modules/shared-data-bucket/main.tf
+++ b/infrastructure/modules/storage/modules/shared-data-bucket/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.36.0"
+      version = "~> 6.53.0"
     }
   }
 }

--- a/infrastructure/modules/storage/tests/integration.tftest.hcl
+++ b/infrastructure/modules/storage/tests/integration.tftest.hcl
@@ -1,0 +1,52 @@
+provider "aws" {
+  access_key                  = "test"
+  region                      = "us-east-1"
+  s3_use_path_style           = true
+  secret_key                  = "test"
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+  endpoints {
+    iam = "http://localhost:4566"
+    kms = "http://localhost:4566"
+    s3  = "http://localhost:4566"
+    sts = "http://localhost:4566"
+  }
+}
+
+variables {
+  common_tags          = { Environment = "test", Project = "nest" }
+  environment          = "test"
+  fixtures_bucket_name = "nest-fixtures"
+  kms_key_arn          = "arn:aws:kms:us-east-1:000000000000:key/1234abcd-12ab-34cd-56ef-1234567890ab"
+  project_name         = "nest"
+}
+
+run "integration_apply" {
+  command = apply
+
+  assert {
+    condition     = can(module.fixtures_bucket.bucket.arn)
+    error_message = "Fixtures bucket was not created."
+  }
+
+  assert {
+    condition     = aws_iam_policy.fixtures_read_only.name == "${var.project_name}-${var.environment}-fixtures-read-only"
+    error_message = "IAM policy name format is incorrect."
+  }
+
+  assert {
+    condition     = aws_iam_policy.static_read_write.name == "${var.project_name}-${var.environment}-static-read-write"
+    error_message = "Static IAM policy name format is incorrect."
+  }
+
+  assert {
+    condition     = tolist(tolist(module.fixtures_bucket.server_side_encryption_configuration.rule)[0].apply_server_side_encryption_by_default)[0].kms_master_key_id == var.kms_key_arn
+    error_message = "Fixtures bucket server-side encryption KMS key ARN is incorrect."
+  }
+
+  assert {
+    condition     = tolist(tolist(module.fixtures_bucket.server_side_encryption_configuration.rule)[0].apply_server_side_encryption_by_default)[0].sse_algorithm == "aws:kms"
+    error_message = "Fixtures bucket server-side encryption algorithm is not aws:kms."
+  }
+}

--- a/infrastructure/scripts/run-integration-tests.sh
+++ b/infrastructure/scripts/run-integration-tests.sh
@@ -8,7 +8,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 LOCALSTACK_CONTAINER_NAME="localstack"
-LOCALSTACK_IMAGE="$(grep -E '^FROM localstack/localstack:' "$ROOT_DIR/docker/localstack/Dockerfile" | sed 's/^FROM //')"
+LOCALSTACK_IMAGE="$(grep -E '^FROM localstack/localstack(-pro)?:' "$ROOT_DIR/docker/localstack/Dockerfile" | sed 's/^FROM //')"
 LOCALSTACK_HEALTH_URL="http://localhost:4566/_localstack/health"
 HEALTH_MAX_ATTEMPTS=30
 HEALTH_POLL_INTERVAL=2
@@ -89,6 +89,20 @@ start_localstack() {
         sleep "$HEALTH_POLL_INTERVAL"
         attempt=$((attempt + 1))
     done
+
+    echo "Waiting for LocalStack license activation..."
+    local license_attempt=1
+    local license_max_attempts=15
+    while ! docker logs "$LOCALSTACK_CONTAINER_NAME" 2>&1 | grep -E -q "Successfully .*activated|activated.*license|Ready\."; do
+        if [[ "$license_attempt" -ge "$license_max_attempts" ]]; then
+            echo "Error: LocalStack license failed to activate within $((license_max_attempts * HEALTH_POLL_INTERVAL)) seconds." >&2
+            docker logs "$LOCALSTACK_CONTAINER_NAME" 2>&1 | tail -30
+            exit 1
+        fi
+        sleep "$HEALTH_POLL_INTERVAL"
+        license_attempt=$((license_attempt + 1))
+    done
+
     echo "LocalStack is ready!"
 }
 
@@ -107,7 +121,7 @@ run_module_tests() {
     echo "Testing integration for $module_dir..."
     terraform -chdir="$module_dir" init -backend=false -input=false || exit 1
     terraform -chdir="$module_dir" test "${filters[@]}" || exit 1
-    
+
     test_count=$((test_count + 1))
     return 0
 }

--- a/infrastructure/scripts/run-integration-tests.sh
+++ b/infrastructure/scripts/run-integration-tests.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# --- Config -------------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+LOCALSTACK_CONTAINER_NAME="localstack"
+LOCALSTACK_IMAGE="$(grep -E '^FROM localstack/localstack:' "$ROOT_DIR/docker/localstack/Dockerfile" | sed 's/^FROM //')"
+LOCALSTACK_HEALTH_URL="http://localhost:4566/_localstack/health"
+HEALTH_MAX_ATTEMPTS=30
+HEALTH_POLL_INTERVAL=2
+
+# S3 bucket override files, used to disable prevent_destroy during tests.
+OVERRIDE_FILES=(
+    "infrastructure/modules/storage/modules/s3-bucket/test_override.tf"
+    "infrastructure/modules/storage/modules/shared-data-bucket/test_override.tf"
+)
+OVERRIDE_RESOURCES=(
+    "aws_s3_bucket.this"
+    "aws_s3_bucket.nest_shared_data"
+)
+
+LOCALSTACK_STARTED=false
+
+# --- Helpers --------------------------------------------------------------
+
+require_cmd() {
+    local cmd="$1"
+    command -v "$cmd" >/dev/null 2>&1 || {
+        echo "Error: required command '$cmd' not found on PATH." >&2
+        exit 1
+    }
+}
+
+localstack_healthy() {
+    curl -sf --connect-timeout 2 "$LOCALSTACK_HEALTH_URL" >/dev/null 2>&1
+}
+
+write_override_files() {
+    local i resource_name local_name
+    for i in "${!OVERRIDE_FILES[@]}"; do
+        local_name="${OVERRIDE_RESOURCES[$i]#*.}"
+        resource_name="${OVERRIDE_RESOURCES[$i]%%.*}"
+        printf 'resource "%s" "%s" {\n  lifecycle {\n    prevent_destroy = false\n  }\n}\n' \
+            "$resource_name" "$local_name" > "${OVERRIDE_FILES[$i]}"
+    done
+}
+
+cleanup() {
+    echo "Cleaning up override files..."
+    rm -f "${OVERRIDE_FILES[@]}"
+
+    if [[ "$LOCALSTACK_STARTED" == "true" ]]; then
+        echo "Stopping and removing LocalStack container..."
+        docker stop "$LOCALSTACK_CONTAINER_NAME" >/dev/null 2>&1 || true
+        docker rm "$LOCALSTACK_CONTAINER_NAME" >/dev/null 2>&1 || true
+    fi
+}
+
+start_localstack() {
+    if [[ -z "${LOCALSTACK_AUTH_TOKEN:-}" ]]; then
+        echo "Error: LOCALSTACK_AUTH_TOKEN environment variable is not set." >&2
+        echo "LocalStack integration tests require a valid auth token to run." >&2
+        exit 1
+    fi
+
+    # In case a stale/stopped container from a previous failed run is lingering.
+    docker rm -f "$LOCALSTACK_CONTAINER_NAME" >/dev/null 2>&1 || true
+
+    echo "Starting LocalStack container..."
+    docker run -d --name "$LOCALSTACK_CONTAINER_NAME" \
+        -p 4566:4566 \
+        -e LOCALSTACK_AUTH_TOKEN="$LOCALSTACK_AUTH_TOKEN" \
+        "$LOCALSTACK_IMAGE" >/dev/null
+
+    LOCALSTACK_STARTED=true
+
+    echo "Waiting for LocalStack to become healthy..."
+    local attempt=1
+    while ! localstack_healthy; do
+        if [[ "$attempt" -ge "$HEALTH_MAX_ATTEMPTS" ]]; then
+            echo "Error: LocalStack failed to become healthy within $((HEALTH_MAX_ATTEMPTS * HEALTH_POLL_INTERVAL)) seconds." >&2
+            exit 1
+        fi
+        echo "Waiting... (attempt $attempt/$HEALTH_MAX_ATTEMPTS)"
+        sleep "$HEALTH_POLL_INTERVAL"
+        attempt=$((attempt + 1))
+    done
+    echo "LocalStack is ready!"
+}
+
+run_module_tests() {
+    local test_dir="$1"
+    local module_dir
+    module_dir="$(dirname "$test_dir")"
+
+    local filters=()
+    while IFS= read -r -d '' test_file; do
+        filters+=("-filter=tests/$(basename "$test_file")")
+    done < <(find "$test_dir" -maxdepth 1 -name "*integration*.tftest.hcl" -print0)
+
+    [[ "${#filters[@]}" -eq 0 ]] && return 1
+
+    echo "Testing integration for $module_dir..."
+    terraform -chdir="$module_dir" init -backend=false -input=false
+    terraform -chdir="$module_dir" test "${filters[@]}"
+    return 0
+}
+
+# --- Main -------------------------------------------------------------
+
+require_cmd docker
+require_cmd terraform
+require_cmd curl
+
+cd "$ROOT_DIR"
+
+for f in "${OVERRIDE_FILES[@]}"; do
+    if [[ -f "$f" ]]; then
+        echo "Error: $f already exists. Refusing to run to avoid overwriting." >&2
+        exit 1
+    fi
+done
+
+trap cleanup EXIT
+
+if localstack_healthy; then
+    echo "Using already running LocalStack instance."
+else
+    echo "LocalStack is not running on port 4566. Attempting to start it..."
+    start_localstack
+fi
+
+write_override_files
+
+test_count=0
+while IFS= read -r -d '' test_dir; do
+    if run_module_tests "$test_dir"; then
+        test_count=$((test_count + 1))
+    fi
+done < <(find infrastructure/bootstrap infrastructure/modules -name "tests" -type d -not -path "*/.terraform/*" -print0)
+
+if [[ "$test_count" -eq 0 ]]; then
+    echo "Error: No integration tests were found or executed." >&2
+    exit 1
+fi
+
+echo "All integration tests executed successfully!"

--- a/infrastructure/scripts/run-integration-tests.sh
+++ b/infrastructure/scripts/run-integration-tests.sh
@@ -102,11 +102,13 @@ run_module_tests() {
         filters+=("-filter=tests/$(basename "$test_file")")
     done < <(find "$test_dir" -maxdepth 1 -name "*integration*.tftest.hcl" -print0)
 
-    [[ "${#filters[@]}" -eq 0 ]] && return 1
+    [[ "${#filters[@]}" -eq 0 ]] && return 0
 
     echo "Testing integration for $module_dir..."
-    terraform -chdir="$module_dir" init -backend=false -input=false
-    terraform -chdir="$module_dir" test "${filters[@]}"
+    terraform -chdir="$module_dir" init -backend=false -input=false || exit 1
+    terraform -chdir="$module_dir" test "${filters[@]}" || exit 1
+    
+    test_count=$((test_count + 1))
     return 0
 }
 
@@ -138,9 +140,7 @@ write_override_files
 
 test_count=0
 while IFS= read -r -d '' test_dir; do
-    if run_module_tests "$test_dir"; then
-        test_count=$((test_count + 1))
-    fi
+    run_module_tests "$test_dir"
 done < <(find infrastructure/bootstrap infrastructure/modules -name "tests" -type d -not -path "*/.terraform/*" -print0)
 
 if [[ "$test_count" -eq 0 ]]; then


### PR DESCRIPTION
## Proposed change

Resolves #5078

This PR implements **Part A** of the LocalStack integration testing work for Terraform infrastructure modules.

Previously, pull requests only ran fast mock-based Terraform tests, which could miss issues that only appear during real resource creation. This PR introduces a LocalStack-backed integration testing job that provisions resources, validates them, and destroys them as part of CI.

### What's included

- Added LocalStack-backed integration tests for:
  - `storage`
  - `parameters`
  - `kms`
  - `ecr-cache`
- Upgraded LocalStack to `2026.6.0`, replacing the community `4.14.0` image, which does not support newer authentication tokens requiring LocalStack `2026.3.0+`.
- Improved LocalStack startup detection by making the readiness checks resilient across different versions, recognizing multiple successful activation messages and the generic `Ready.` indicator to avoid false timeout failures.
- Upgraded the AWS Terraform provider constraint to `~> 6.53.0` and updated the provider lockfiles.
- Added a `test-infrastructure-integration` Makefile target for running LocalStack integration tests locally.
- Kept the existing mock-based Terraform tests as a separate CI path so they continue to run independently of LocalStack.
- Added temporary Terraform test overrides to ensure S3 resources can be cleaned up successfully during integration tests.
- Added a GitHub Actions workflow job that starts LocalStack and runs the integration test suite for pull requests.
- Added documentation describing how to run both the existing mock tests and the new LocalStack integration tests locally.

## Checklist

* [x] **Required:** I followed the contributing workflow.
* [x] **Required:** I verified that my code works as intended and resolves the issue as described.
* [x] **Required:** I ran all required checks and tests locally; all warnings addressed and failures resolved.
* [x] I used AI for code, documentation, tests, or communication related to this PR.