### PR TITLE
Draft: Improve typing for github_user attributes on GraphQL nodes

### DIFF
--- a/backend/src/apps/mentorship/api/internal/nodes/admin.py
+++ b/backend/src/apps/mentorship/api/internal/nodes/admin.py
@@ -1,13 +1,18 @@
 """GraphQL node for Admin model."""
 
+from typing import TYPE_CHECKING
+
 import strawberry
 
+if TYPE_CHECKING:
+    from apps.github.models.user import User as GitHubUser
 
 @strawberry.type
 class AdminNode:
     """A GraphQL node representing a mentorship admin."""
 
     id: strawberry.ID
+    github_user: GitHubUser | None
 
     @strawberry.field(name="avatarUrl")
     def avatar_url(self) -> str:

--- a/backend/src/apps/mentorship/api/internal/nodes/mentor.py
+++ b/backend/src/apps/mentorship/api/internal/nodes/mentor.py
@@ -1,14 +1,18 @@
 """GraphQL node for Mentor model."""
 
+from typing import TYPE_CHECKING
+
 import strawberry
 
+if TYPE_CHECKING:
+    from apps.github.models.user import User as GitHubUser
 
 @strawberry.type
 class MentorNode:
     """A GraphQL node representing a mentorship mentor."""
 
     id: strawberry.ID
-
+    github_user: GitHubUser | None
     @strawberry.field
     def avatar_url(self) -> str:
         """Get the GitHub avatar URL of the mentor."""

--- a/backend/src/apps/nest/api/internal/nodes/user.py
+++ b/backend/src/apps/nest/api/internal/nodes/user.py
@@ -1,14 +1,19 @@
 """GraphQL node for User model."""
 
+from typing import TYPE_CHECKING
+
 import strawberry
 import strawberry_django
 
 from apps.nest.models import User
 
-
+if TYPE_CHECKING:
+    from apps.github.models.user import User as GitHubUser
+    
 @strawberry_django.type(User, fields=["username"])
 class AuthUserNode(strawberry.relay.Node):
     """GraphQL node for User model."""
+    github_user: GitHubUser | None
 
     @strawberry_django.field
     def is_owasp_staff(self) -> bool:


### PR DESCRIPTION
Refs #5080

## Summary

This draft PR improves type information for several GraphQL node classes by making the `github_user` attribute visible to mypy.

Several resolver methods access `github_user`, but the attribute is not declared on the corresponding Strawberry types, which results in `attr-defined` errors during static type checking.

## Changes

- Add `TYPE_CHECKING` imports for `GitHubUser`
- Add `github_user: GitHubUser | None` annotations to:
  - `AdminNode`
  - `MentorNode`
  - `AuthUserNode`

## Validation

- Ran `pre-commit run mypy --all-files`
- No mypy errors were reported

## Feedback requested

I'd appreciate feedback on whether this is the preferred pattern for exposing internal model attributes on Strawberry GraphQL node types while improving static typing.

## Question for reviewers

Is explicitly annotating model-backed attributes on Strawberry node types the preferred approach for resolving these `attr-defined` mypy errors, or would you recommend a different typing pattern?