### PR TITLE
feat: adjust module dates when program dates update

### DIFF
--- a/backend/apps/mentorship/api/internal/mutations/program.py
+++ b/backend/apps/mentorship/api/internal/mutations/program.py
@@ -189,6 +189,24 @@ class ProgramMutation:
         except IntegrityError as e:
             _handle_program_save_integrity_error(e)
 
+        if input_data.started_at is not None or input_data.ended_at is not None:
+            for module in program.modules.all():
+                changed = False
+                if module.started_at < program.started_at:
+                    module.started_at = program.started_at
+                    changed = True
+                    if module.ended_at < program.started_at:
+                        module.ended_at = program.started_at
+
+                if module.ended_at > program.ended_at:
+                    module.ended_at = program.ended_at
+                    changed = True
+                    if module.started_at > program.ended_at:
+                        module.started_at = program.ended_at
+
+                if changed:
+                    module.save()
+
         if input_data.admin_logins is not None:
             program.admins.set(resolve_admins_from_logins(input_data.admin_logins))
 

--- a/backend/tests/unit/apps/mentorship/api/internal/mutations/program_mutation_test.py
+++ b/backend/tests/unit/apps/mentorship/api/internal/mutations/program_mutation_test.py
@@ -455,6 +455,84 @@ class TestUpdateProgram:
         assert result == mock_prog
         assert mock_prog.status == ProgramStatusEnum.COMPLETED.value
 
+    @patch("apps.mentorship.api.internal.mutations.program.Program")
+    def test_update_program_adjusts_module_dates_start(self, mock_program, mutation):
+        user = MagicMock()
+        info = _make_info(user)
+
+        input_data = MagicMock()
+        input_data.key = "prog-1"
+        input_data.name = "Updated"
+        input_data.started_at = datetime(2025, 6, 1, tzinfo=UTC)
+        input_data.ended_at = datetime(2025, 12, 31, tzinfo=UTC)
+        input_data.status = None
+        input_data.admin_logins = None
+
+        mock_prog = MagicMock()
+        mock_prog.started_at = datetime(2025, 6, 1, tzinfo=UTC)
+        mock_prog.ended_at = datetime(2025, 12, 31, tzinfo=UTC)
+        mock_prog.admins.filter.return_value.exists.return_value = True
+        mock_program.objects.select_for_update.return_value.get.return_value = mock_prog
+
+        mock_module_1 = MagicMock()
+        mock_module_1.started_at = datetime(2025, 5, 1, tzinfo=UTC)
+        mock_module_1.ended_at = datetime(2025, 5, 15, tzinfo=UTC)
+
+        mock_module_2 = MagicMock()
+        mock_module_2.started_at = datetime(2025, 7, 1, tzinfo=UTC)
+        mock_module_2.ended_at = datetime(2025, 8, 1, tzinfo=UTC)
+
+        mock_prog.modules.all.return_value = [mock_module_1, mock_module_2]
+
+        mutation.update_program(info, input_data)
+
+        assert mock_module_1.started_at == datetime(2025, 6, 1, tzinfo=UTC)
+        assert mock_module_1.ended_at == datetime(2025, 6, 1, tzinfo=UTC)
+        mock_module_1.save.assert_called_once()
+
+        assert mock_module_2.started_at == datetime(2025, 7, 1, tzinfo=UTC)
+        assert mock_module_2.ended_at == datetime(2025, 8, 1, tzinfo=UTC)
+        mock_module_2.save.assert_not_called()
+
+    @patch("apps.mentorship.api.internal.mutations.program.Program")
+    def test_update_program_adjusts_module_dates_end(self, mock_program, mutation):
+        user = MagicMock()
+        info = _make_info(user)
+
+        input_data = MagicMock()
+        input_data.key = "prog-1"
+        input_data.name = "Updated"
+        input_data.started_at = datetime(2025, 1, 1, tzinfo=UTC)
+        input_data.ended_at = datetime(2025, 10, 1, tzinfo=UTC)
+        input_data.status = None
+        input_data.admin_logins = None
+
+        mock_prog = MagicMock()
+        mock_prog.started_at = datetime(2025, 1, 1, tzinfo=UTC)
+        mock_prog.ended_at = datetime(2025, 10, 1, tzinfo=UTC)
+        mock_prog.admins.filter.return_value.exists.return_value = True
+        mock_program.objects.select_for_update.return_value.get.return_value = mock_prog
+
+        mock_module_1 = MagicMock()
+        mock_module_1.started_at = datetime(2025, 11, 1, tzinfo=UTC)
+        mock_module_1.ended_at = datetime(2025, 11, 15, tzinfo=UTC)
+
+        mock_module_2 = MagicMock()
+        mock_module_2.started_at = datetime(2025, 2, 1, tzinfo=UTC)
+        mock_module_2.ended_at = datetime(2025, 3, 1, tzinfo=UTC)
+
+        mock_prog.modules.all.return_value = [mock_module_1, mock_module_2]
+
+        mutation.update_program(info, input_data)
+
+        assert mock_module_1.started_at == datetime(2025, 10, 1, tzinfo=UTC)
+        assert mock_module_1.ended_at == datetime(2025, 10, 1, tzinfo=UTC)
+        mock_module_1.save.assert_called_once()
+
+        assert mock_module_2.started_at == datetime(2025, 2, 1, tzinfo=UTC)
+        assert mock_module_2.ended_at == datetime(2025, 3, 1, tzinfo=UTC)
+        mock_module_2.save.assert_not_called()
+
 
 class TestUpdateProgramStatus:
     """Tests for ProgramMutation.update_program_status."""


### PR DESCRIPTION
Resolves #4045

## Summary

When an administrator updates a mentorship program's date range (start or end date), associated modules may end up with dates falling outside the new program range, violating validation constraints and producing inconsistent database records. This PR automatically clamps associated module dates to remain within the program's updated date range.

---

## What Changed

### Auto-Adjustment Logic

For each module associated with the updated program:
1. **Start Date Clamping**: If `module.started_at < program.started_at`, it is updated to match `program.started_at`.
   - If this makes `started_at > ended_at` (i.e. the module was previously scheduled entirely before the new program range), `module.ended_at` is also set to `program.started_at` to preserve the date constraint.
2. **End Date Clamping**: If `module.ended_at > program.ended_at`, it is updated to match `program.ended_at`.
   - If this makes `started_at > ended_at` (i.e. the module was previously scheduled entirely after the new program range), `module.started_at` is also set to `program.ended_at`.

### Files Changed

| File | Change |
|------|--------|
| `backend/apps/mentorship/api/internal/mutations/program.py` | Added date clamping and validation alignment logic inside `update_program` mutation. |
| `backend/tests/unit/apps/mentorship/api/internal/mutations/program_mutation_test.py` | Added 2 new integration test cases covering module date updates on program start/end adjustments. |

---

## Design Decisions

- **Transactional Safety**: The module updates happen inside the existing `@transaction.atomic` block of the `update_program` mutation, ensuring database operations are fully rollback-safe if any integrity error or validation fails.
- **DCO Sign-off & SSH Signed Commits**: Both commits are signed with SSH key and contain the `Signed-off-by` trailer to pass the contribution checks.
- **Validation Fallbacks**: If the module dates are completely misaligned (e.g. module was Oct 1 to Oct 2, program became Dec 1 to Dec 10), it resets both start and end to the closest boundary (e.g. Dec 1 to Dec 1), guaranteeing that `started_at <= ended_at` is never violated.

---

## Test Coverage

2 new test cases added to `TestUpdateProgram` class:

| Test | Verifies |
|------|----------|
| `test_update_program_adjusts_module_dates_start` | Verifies module start (and end) dates are adjusted when program start is moved forward. |
| `test_update_program_adjusts_module_dates_end` | Verifies module end (and start) dates are adjusted when program end is moved backward. |

Tested locally:
```bash
poetry run pytest tests/unit/apps/mentorship/api/internal/mutations/program_mutation_test.py --no-cov
# Output: 24 passed in 5.88s ✅
```

---

## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran all required checks and tests locally; all warnings addressed and failures resolved
- [x] I used AI for code, documentation, tests, or communication related to this PR
