### PR TITLE
feat(o11y): add grafana with VM datasource & dashboard

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,7 +128,7 @@ Ensure that all `.env` files are saved in **UTF-8 format without BOM (Byte Order
 
    - Leave this terminal session running and wait until you see that [Nest local](http://localhost:8000/api/v0) is responding.
    - Please note as we use containerized approach this command must be run in parallel to other Nest commands you may want to use. You need to keep it running in the current terminal and use another terminal session for your work.
-   - To also start the observability stack, run `make run-o11y` instead. It is opt-in, so the regular `make run` does not start it.
+   - To also start the observability stack, run `make run-o11y` instead. It is opt-in, so the regular `make run` does not start it. This brings up VictoriaMetrics and Grafana; the pre-provisioned RED dashboard is available at [Grafana](http://localhost:3001) (login `admin` / `admin`).
 
 1. **Load Initial Data**:
 

--- a/cspell/custom-dict.txt
+++ b/cspell/custom-dict.txt
@@ -210,6 +210,7 @@ rediss
 relativedelta
 replicationgroup
 repositorycontributor
+reqps
 requirepass
 rqworker
 rsc

--- a/docker-compose/local/compose.o11y.yaml
+++ b/docker-compose/local/compose.o11y.yaml
@@ -45,7 +45,7 @@ services:
     networks:
       - nest-network
     ports:
-      - 3001:3000
+      - 127.0.0.1:3001:3000
     volumes:
       - o11y-grafana-data:/var/lib/grafana
       - ./grafana/provisioning:/etc/grafana/provisioning:ro

--- a/docker-compose/local/compose.o11y.yaml
+++ b/docker-compose/local/compose.o11y.yaml
@@ -36,10 +36,10 @@ services:
       o11y-metrics:
         condition: service_healthy
     environment:
-      - GF_SECURITY_ADMIN_USER=admin
-      - GF_SECURITY_ADMIN_PASSWORD=admin
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Viewer
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_SECURITY_ADMIN_USER=admin
       - GF_USERS_DEFAULT_THEME=light
       - O11Y_METRICS_URL=http://o11y-metrics:8428
     image: grafana/grafana-oss:13.0.2@sha256:5dad0df181cb644a14e13617b913b261a54f7d4fd4510721dba420929f35bea2
@@ -48,9 +48,9 @@ services:
     ports:
       - 127.0.0.1:3001:3000
     volumes:
-      - o11y-grafana-data:/var/lib/grafana
-      - ./grafana/provisioning:/etc/grafana/provisioning:ro
       - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - o11y-grafana-data:/var/lib/grafana
 
 volumes:
   o11y-grafana-data:

--- a/docker-compose/local/compose.o11y.yaml
+++ b/docker-compose/local/compose.o11y.yaml
@@ -30,5 +30,27 @@ services:
     volumes:
       - o11y-metrics-data:/data
 
+  o11y-grafana:
+    container_name: nest-o11y-grafana
+    depends_on:
+      o11y-metrics:
+        condition: service_healthy
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Viewer
+      - GF_USERS_DEFAULT_THEME=light
+    image: grafana/grafana-oss:13.0.2@sha256:5dad0df181cb644a14e13617b913b261a54f7d4fd4510721dba420929f35bea2
+    networks:
+      - nest-network
+    ports:
+      - 3001:3000
+    volumes:
+      - o11y-grafana-data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+
 volumes:
+  o11y-grafana-data:
   o11y-metrics-data:

--- a/docker-compose/local/compose.o11y.yaml
+++ b/docker-compose/local/compose.o11y.yaml
@@ -43,6 +43,11 @@ services:
       - GF_USERS_DEFAULT_THEME=light
       - O11Y_METRICS_URL=http://o11y-metrics:8428
     image: grafana/grafana-oss:13.0.2@sha256:5dad0df181cb644a14e13617b913b261a54f7d4fd4510721dba420929f35bea2
+    healthcheck:
+      interval: 5s
+      retries: 5
+      test: [CMD, wget, --spider, -q, http://127.0.0.1:3000/api/health]
+      timeout: 5s
     networks:
       - nest-network
     ports:

--- a/docker-compose/local/compose.o11y.yaml
+++ b/docker-compose/local/compose.o11y.yaml
@@ -41,6 +41,7 @@ services:
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Viewer
       - GF_USERS_DEFAULT_THEME=light
+      - O11Y_METRICS_URL=http://o11y-metrics:8428
     image: grafana/grafana-oss:13.0.2@sha256:5dad0df181cb644a14e13617b913b261a54f7d4fd4510721dba420929f35bea2
     networks:
       - nest-network

--- a/docker-compose/local/grafana/dashboards/nest-red.json
+++ b/docker-compose/local/grafana/dashboards/nest-red.json
@@ -1,0 +1,131 @@
+{
+  "uid": "nest-red",
+  "title": "Nest - RED & Runtime",
+  "tags": ["nest", "o11y"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "10s",
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "annotations": {
+    "list": []
+  },
+  "templating": {
+    "list": []
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Request rate (req/s)",
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 10 } },
+        "overrides": []
+      },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "editorMode": "code",
+          "expr": "sum(rate({__name__=\"http.server.duration_count\"}[1m]))",
+          "legendFormat": "requests/s",
+          "range": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Error rate (5xx req/s)",
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 10 } },
+        "overrides": []
+      },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "editorMode": "code",
+          "expr": "sum(rate({__name__=\"http.server.duration_count\", http.status_code=~\"5..\"}[5m]))",
+          "legendFormat": "5xx/s",
+          "range": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Latency p95 (ms)",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "fieldConfig": {
+        "defaults": { "unit": "ms", "custom": { "drawStyle": "line", "fillOpacity": 10 } },
+        "overrides": []
+      },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate({__name__=\"http.server.duration_bucket\"}[5m])))",
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "Process memory by service (bytes)",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "fieldConfig": {
+        "defaults": { "unit": "decbytes", "custom": { "drawStyle": "line", "fillOpacity": 10 } },
+        "overrides": []
+      },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "editorMode": "code",
+          "expr": "{__name__=\"process.memory.usage\"}",
+          "legendFormat": "{{service.name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Process CPU utilization by service",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "fieldConfig": {
+        "defaults": { "unit": "percentunit", "custom": { "drawStyle": "line", "fillOpacity": 10 } },
+        "overrides": []
+      },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "editorMode": "code",
+          "expr": "sum by (service.name) ({__name__=\"process.cpu.utilization\"})",
+          "legendFormat": "{{service.name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ]
+    }
+  ]
+}

--- a/docker-compose/local/grafana/provisioning/dashboards/dashboards.yaml
+++ b/docker-compose/local/grafana/provisioning/dashboards/dashboards.yaml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: Nest
+    orgId: 1
+    type: file
+    disableDeletion: false
+    allowUiUpdates: true
+    updateIntervalSeconds: 10
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/docker-compose/local/grafana/provisioning/dashboards/dashboards.yaml
+++ b/docker-compose/local/grafana/provisioning/dashboards/dashboards.yaml
@@ -5,7 +5,7 @@ providers:
     orgId: 1
     type: file
     disableDeletion: false
-    allowUiUpdates: true
+    allowUiUpdates: false
     updateIntervalSeconds: 10
     options:
       path: /var/lib/grafana/dashboards

--- a/docker-compose/local/grafana/provisioning/datasources/victoriametrics.yaml
+++ b/docker-compose/local/grafana/provisioning/datasources/victoriametrics.yaml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+datasources:
+  - name: VictoriaMetrics
+    uid: victoriametrics
+    type: prometheus
+    access: proxy
+    url: http://o11y-metrics:8428
+    isDefault: true
+    jsonData:
+      httpMethod: POST

--- a/docker-compose/local/grafana/provisioning/datasources/victoriametrics.yaml
+++ b/docker-compose/local/grafana/provisioning/datasources/victoriametrics.yaml
@@ -5,7 +5,7 @@ datasources:
     uid: victoriametrics
     type: prometheus
     access: proxy
-    url: http://o11y-metrics:8428
+    url: ${O11Y_METRICS_URL}
     isDefault: true
     jsonData:
       httpMethod: POST


### PR DESCRIPTION
## Proposed change

<!-- Don't forget to link your PR to an existing issue.-->
Resolves #5061

<!-- Describe the big picture of your changes.-->

- Adds a **Grafana** service to the o11y compose stack.
- Provisions VictoriaMetrics as a datasource
- Adds a **RED + runtime dashboard** as version-controlled JSON, auto-provisioned on startup: request rate, error rate, p95 latency (backend), plus process memory/CPU (frontend).
- Verified locally, generated traffic, and confirmed via the provisioned datasource.

## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran all required checks and tests locally; all warnings addressed and failures resolved
- [x] I used AI for code, documentation, tests, or communication related to this PR
