### PR TITLE
fix(types): avoid .value on Django TextChoices in MilestoneStateEnum

### DIFF
--- a/backend/src/apps/github/api/internal/queries/milestone.py
+++ b/backend/src/apps/github/api/internal/queries/milestone.py
@@ -18,8 +18,8 @@ MAX_LIMIT = 1000
 class MilestoneStateEnum(enum.StrEnum):
     """Milestone state filter options."""
 
-    CLOSED = GenericIssueModel.IssueState.CLOSED.value
-    OPEN = GenericIssueModel.IssueState.OPEN.value
+    CLOSED = GenericIssueModel.IssueState.CLOSED
+    OPEN = GenericIssueModel.IssueState.OPEN
 
 
 @strawberry.type


### PR DESCRIPTION
Related to #5080.

## Summary

Replace .value access with direct Django TextChoices members when defining MilestoneStateEnum.

Django `TextChoices` members are already `str` subclasses, so using the enum members directly preserves runtime behavior while avoiding unnecessary attribute access during type checking.

## Validation

- [x] `pre-commit run mypy --all-files`