### PR TITLE
fix(backend): refresh nest_updated_at for records during bulk_save

### DIFF
--- a/backend/apps/common/models.py
+++ b/backend/apps/common/models.py
@@ -25,12 +25,38 @@ class BulkSaveModel(models.Model):
             fields (list, optional): List of fields to update.
 
         """
-        model.objects.bulk_create((o for o in objects if not o.id), BATCH_SIZE)
-        model.objects.bulk_update(
-            (o for o in objects if o.id),
-            fields=fields or [field.name for field in model._meta.fields if not field.primary_key],
-            batch_size=BATCH_SIZE,
-        )
+        from django.utils import timezone
+
+        has_created_at = any(f.name == "nest_created_at" for f in model._meta.fields)
+        has_updated_at = any(f.name == "nest_updated_at" for f in model._meta.fields)
+
+        create_objs = [o for o in objects if not o.id]
+        if create_objs:
+            if has_created_at or has_updated_at:
+                now = timezone.now()
+                for o in create_objs:
+                    if has_created_at and not getattr(o, "nest_created_at", None):
+                        o.nest_created_at = now
+                    if has_updated_at and not getattr(o, "nest_updated_at", None):
+                        o.nest_updated_at = now
+            model.objects.bulk_create(create_objs, BATCH_SIZE)
+
+        update_objs = [o for o in objects if o.id]
+        if update_objs:
+            if has_updated_at:
+                now = timezone.now()
+                for o in update_objs:
+                    o.nest_updated_at = now
+                if fields is not None:
+                    fields = list(fields)
+                    if "nest_updated_at" not in fields:
+                        fields.append("nest_updated_at")
+
+            model.objects.bulk_update(
+                update_objs,
+                fields=fields or [field.name for field in model._meta.fields if not field.primary_key],
+                batch_size=BATCH_SIZE,
+            )
         objects.clear()
 
 

--- a/backend/tests/unit/apps/common/models_test.py
+++ b/backend/tests/unit/apps/common/models_test.py
@@ -40,3 +40,52 @@ class TestBulkSaveModel:
         mock_model.objects.bulk_update.assert_called_once()
 
         assert len(mock_objects) == 0
+
+    def test_bulk_save_with_timestamps(self, mock_model, mock_objects):
+        field_created = MagicMock()
+        field_created.name = "nest_created_at"
+        field_created.primary_key = False
+        field_updated = MagicMock()
+        field_updated.name = "nest_updated_at"
+        field_updated.primary_key = False
+        mock_model._meta.fields = [field_created, field_updated]
+
+        fields = ["field1", "field2"]
+        objs_copy = list(mock_objects)
+
+        BulkSaveModel.bulk_save(mock_model, mock_objects, fields=fields)
+
+        mock_obj1, mock_obj2 = objs_copy[0], objs_copy[1]
+        assert mock_obj1.nest_created_at is not None
+        assert mock_obj1.nest_updated_at is not None
+        assert mock_obj2.nest_updated_at is not None
+
+        mock_model.objects.bulk_update.assert_called_once_with(
+            [mock_obj2],
+            fields=["field1", "field2", "nest_updated_at"],
+            batch_size=1000,
+        )
+
+    def test_bulk_save_with_timestamps_no_fields(self, mock_model, mock_objects):
+        field_created = MagicMock()
+        field_created.name = "nest_created_at"
+        field_created.primary_key = False
+        field_updated = MagicMock()
+        field_updated.name = "nest_updated_at"
+        field_updated.primary_key = False
+        mock_model._meta.fields = [field_created, field_updated]
+
+        objs_copy = list(mock_objects)
+
+        BulkSaveModel.bulk_save(mock_model, mock_objects)
+
+        mock_obj1, mock_obj2 = objs_copy[0], objs_copy[1]
+        assert mock_obj1.nest_created_at is not None
+        assert mock_obj1.nest_updated_at is not None
+        assert mock_obj2.nest_updated_at is not None
+
+        mock_model.objects.bulk_update.assert_called_once_with(
+            [mock_obj2],
+            fields=["nest_created_at", "nest_updated_at"],
+            batch_size=1000,
+        )


### PR DESCRIPTION
Resolves #5090

## Summary

This PR resolves issue #5090 by updating the helper method `BulkSaveModel.bulk_save` to automatically manage and refresh `nest_created_at` and `nest_updated_at` timestamps for models inheriting from `TimestampedModel`. 

---

## What Changed

### Auto-timestamping logic in `BulkSaveModel`

Normally, Django's `bulk_create` and `bulk_update` bypass the model's standard lifecycle and save hook methods. Because of this, fields annotated with `auto_now_add` (`nest_created_at`) and `auto_now` (`nest_updated_at`) are left stale or unpopulated. 

We updated `BulkSaveModel.bulk_save` to:
- Detect if the model includes `nest_created_at` and `nest_updated_at` using model meta fields inspection.
- **For Creations (`bulk_create`)**: Populate both `nest_created_at` and `nest_updated_at` with the current timestamp (`timezone.now()`) on Python objects before insertion.
- **For Updates (`bulk_update`)**: Populate `nest_updated_at` on existing Python objects and, if a specific list of fields is passed, dynamically append `"nest_updated_at"` to the update list so that the column is included in Django's generated SQL.

---

## Files Changed

| File | Change |
|------|--------|
| `backend/apps/common/models.py` | Added timestamp detection, creation/update timezone population, and automatic field list inclusion. |
| `backend/tests/unit/apps/common/models_test.py` | Added 2 new backend unit tests verifying that fields and timestamps are populated correctly. |

---

## Test Coverage

Verified that all backend unit tests pass:
```bash
pytest tests/unit/apps/common/models_test.py --no-cov
# Output: 4 passed in 8.79s ✅
```
Verified that existing program date validation tests still pass:
```bash
pytest tests/unit/apps/mentorship/api/internal/mutations/program_mutation_test.py --no-cov
# Output: 22 passed in 10.02s ✅
```

---

## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran all required checks and tests locally; all warnings addressed and failures resolved
- [x] I used AI for code, documentation, tests, or communication related to this PR
