### PR TITLE
fix(backend): strip italic, strikethrough, and code markers in strip_markdown

### DIFF
--- a/backend/apps/slack/common/text.py
+++ b/backend/apps/slack/common/text.py
@@ -46,4 +46,12 @@ def strip_markdown(text: str) -> str:
         str: The text with markdown formatting removed.
 
     """
-    return SLACK_LINK_PATTERN.sub(r"\2 (\1)", text).replace("*", "")
+    if not text:
+        return text
+
+    text = SLACK_LINK_PATTERN.sub(r"\2 (\1)", text)
+    text = re.sub(r"```([\s\S]*?)```", r"\1", text)
+    text = re.sub(r"`([^`]+)`", r"\1", text)
+    text = re.sub(r"\*([^*]+)\*", r"\1", text)
+    text = re.sub(r"_([^_]+)_", r"\1", text)
+    return re.sub(r"~([^~]+)~", r"\1", text)

--- a/backend/tests/unit/apps/slack/utils_test.py
+++ b/backend/tests/unit/apps/slack/utils_test.py
@@ -78,6 +78,18 @@ class TestStripMarkdown:
                 "Multiple links: <https://example.com|First> and <https://example.org|Second>.",
                 "Multiple links: First (https://example.com) and Second (https://example.org).",
             ),
+            (
+                "This is _italic_ text and ~strikethrough~ text.",
+                "This is italic text and strikethrough text.",
+            ),
+            (
+                "Here is some `inline code` and a ```code block\nwith multiple lines```.",
+                "Here is some inline code and a code block\nwith multiple lines.",
+            ),
+            (
+                "Mixed formatting: *bold*, _italic_, ~strike~, `code`.",
+                "Mixed formatting: bold, italic, strike, code.",
+            ),
         ],
     )
     def test_process_mrkdwn(self, input_text, expected_output):


### PR DESCRIPTION
Resolves #4973

## Summary

This PR resolves issue #4973 by updating the `strip_markdown` helper method in `apps/slack/common/text.py` to correctly strip italic (`_italic_`), strikethrough (`~strikethrough~`), inline code (`` `code` ``), and code block (```` ```code block``` ````) formatting markers from Slack messages while preserving their inner text. 

---

## What Changed

### Complete Markdown Formatting Stripping

Previously, `strip_markdown` only removed Slack links and bold markers (`*`). It left italic, strikethrough, inline code, and code block formatting characters untouched in the plain text output. 

We updated `strip_markdown` to:
- Detect and substitute code blocks using `re.sub(r"```([\s\S]*?)```", r"\1", text)`.
- Detect and substitute inline code backticks using `re.sub(r"`([^`]+)`", r"\1", text)`.
- Detect and substitute bold asterisks using `re.sub(r"\*([^*]+)\*", r"\1", text)`.
- Detect and substitute italic underscores using `re.sub(r"_([^_]+)_", r"\1", text)`.
- Detect and substitute strikethrough tildes using `re.sub(r"~([^~]+)~", r"\1", text)`.

---

## Files Changed

| File | Change |
|------|--------|
| `backend/apps/slack/common/text.py` | Added regex formatting rules to strip italic, strikethrough, inline code, and code block markers. |
| `backend/tests/unit/apps/slack/utils_test.py` | Added new unit test cases covering combinations of bold, italic, strikethrough, inline code, and code block formatting. |

---

## Test Coverage

Verified that all Slack utility unit tests pass:
```bash
pytest tests/unit/apps/slack/utils_test.py --no-cov
# Output: 35 passed in 9.69s ✅
```

---

## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran all required checks and tests locally; all warnings addressed and failures resolved
- [x] I used AI for code, documentation, tests, or communication related to this PR
