### PR TITLE
Add precise type annotations to search helpers

### DIFF
--- a/backend/src/apps/github/index/search/user.py
+++ b/backend/src/apps/github/index/search/user.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from algoliasearch_django import raw_search
 
 from apps.github.models.user import User
@@ -9,11 +11,11 @@ from apps.github.models.user import User
 
 def get_users(
     query: str,
-    attributes: list | None = None,
+    attributes: list[str] | None = None,
     limit: int = 25,
     page: int = 1,
-    searchable_attributes: list | None = None,
-) -> dict:
+    searchable_attributes: list[str] | None = None,
+) -> dict[str, Any]:
     """Return users relevant to a search query.
 
     Args:

--- a/backend/src/apps/owasp/index/search/chapter.py
+++ b/backend/src/apps/owasp/index/search/chapter.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from algoliasearch_django import raw_search
 
 from apps.owasp.models.chapter import Chapter
@@ -10,11 +12,11 @@ from apps.owasp.models.chapter import Chapter
 def get_chapters(
     query: str,
     *,
-    attributes: list | None = None,
+    attributes: list[str] | None = None,
     limit: int = 25,
     page: int = 1,
-    searchable_attributes: list | None = None,
-) -> dict:
+    searchable_attributes: list[str] | None = None,
+) -> dict[str, Any]:
     """Return chapters relevant to a search query.
 
     Args:

--- a/backend/src/apps/owasp/index/search/committee.py
+++ b/backend/src/apps/owasp/index/search/committee.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from algoliasearch_django import raw_search
 
 from apps.owasp.models.committee import Committee
@@ -10,10 +12,10 @@ from apps.owasp.models.committee import Committee
 def get_committees(
     query: str,
     *,
-    attributes: list | None = None,
+    attributes: list[str] | None = None,
     limit: int = 25,
     page: int = 1,
-) -> dict:
+) -> dict[str, Any]:
     """Return committees relevant to a search query.
 
     Args:

--- a/backend/src/apps/owasp/index/search/issue.py
+++ b/backend/src/apps/owasp/index/search/issue.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from algoliasearch_django import raw_search
 
 from apps.github.models.issue import Issue
@@ -12,11 +14,11 @@ ISSUE_CACHE_PREFIX = "issue:"
 def get_issues(
     query: str,
     *,
-    attributes: list | None = None,
+    attributes: list[str] | None = None,
     distinct: bool = False,
     limit: int = 25,
     page: int = 1,
-) -> dict:
+) -> dict[str, Any]:
     """Return issues relevant to a search query.
 
     Args:

--- a/backend/src/apps/owasp/index/search/project.py
+++ b/backend/src/apps/owasp/index/search/project.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from algoliasearch_django import raw_search
 
 from apps.owasp.models.project import Project
@@ -10,11 +12,11 @@ from apps.owasp.models.project import Project
 def get_projects(
     query: str,
     *,
-    attributes: list | None = None,
+    attributes: list[str] | None = None,
     limit: int = 25,
     page: int = 1,
-    searchable_attributes: list | None = None,
-) -> dict:
+    searchable_attributes: list[str] | None = None,
+) -> dict[str, Any]:
     """Return projects relevant to a search query.
 
     Args:


### PR DESCRIPTION
## Summary

Adds precise type annotations to the Algolia search helpers by specifying string element types for search attribute lists and the search result mapping type.

The changes cover all search helpers that directly use `algoliasearch_django.raw_search`.

## Related issue

Related to #5080.

## Changes

- Type `attributes` and `searchable_attributes` as `list[str] | None`.
- Type search helper return values as `dict[str, Any]`.
- Apply the annotations consistently across GitHub user and OWASP chapter, committee, issue, and project search helpers.

## Testing

- `pre-commit run ruff-check --files ...` - passed
- `pre-commit run ruff-format --files ...` - passed
- `pre-commit run mypy --all-files` - passed
- Targeted search helper unit tests - 18 passed
- `git diff --check upstream/main..HEAD` - passed