### PR TITLE
Improve module mentor assignment and ordering consistency

### DIFF
--- a/backend/src/apps/mentorship/api/internal/nodes/module.py
+++ b/backend/src/apps/mentorship/api/internal/nodes/module.py
@@ -50,7 +50,7 @@ class ModuleNode:
     @strawberry.field
     def mentors(self) -> list[MentorNode]:
         """Get the list of mentors for this module."""
-        return self.mentors.all()
+        return self.mentors.order_by( "github_user__login" )
 
     @strawberry.field
     def mentees(self) -> list[UserNode]:

--- a/backend/src/apps/mentorship/api/internal/nodes/module.py
+++ b/backend/src/apps/mentorship/api/internal/nodes/module.py
@@ -50,7 +50,7 @@ class ModuleNode:
     @strawberry.field
     def mentors(self) -> list[MentorNode]:
         """Get the list of mentors for this module."""
-        return self.mentors.order_by( "github_user__login" )
+        return self.mentors.order_by("github_user__login")
 
     @strawberry.field
     def mentees(self) -> list[UserNode]:

--- a/backend/tests/unit/apps/mentorship/api/internal/nodes/api_internal_module_test.py
+++ b/backend/tests/unit/apps/mentorship/api/internal/nodes/api_internal_module_test.py
@@ -100,8 +100,10 @@ class FakeModuleNode:
 def mock_module_node():
     """Fixture for a mock ModuleNode instance."""
     m = FakeModuleNode()
+    mentor1 = MagicMock()
+    mentor2 = MagicMock()
 
-    m.mentors.all.return_value = [MagicMock(), MagicMock()]
+    m.mentors.order_by.return_value = [mentor1, mentor2]
     m.menteemodule_set.select_related.return_value.filter.return_value.values_list.return_value = [
         "github_user_id_1",
         "github_user_id_2",
@@ -139,7 +141,7 @@ class TestModuleNodeResolvers:
         """Test the mentors resolver."""
         mentors = mock_module_node.mock_mentors()
         assert len(mentors) == 2
-        mock_module_node.mentors.all.assert_called_once()
+        mock_module_node.mentors.order_by.assert_called_once_with( "github_user__login" )
 
     def test_module_node_mentees(self, mock_module_node):
         """Test the mentees resolver."""

--- a/backend/tests/unit/apps/mentorship/api/internal/nodes/api_internal_module_test.py
+++ b/backend/tests/unit/apps/mentorship/api/internal/nodes/api_internal_module_test.py
@@ -141,7 +141,7 @@ class TestModuleNodeResolvers:
         """Test the mentors resolver."""
         mentors = mock_module_node.mock_mentors()
         assert len(mentors) == 2
-        mock_module_node.mentors.order_by.assert_called_once_with( "github_user__login" )
+        mock_module_node.mentors.order_by.assert_called_once_with("github_user__login")
 
     def test_module_node_mentees(self, mock_module_node):
         """Test the mentees resolver."""

--- a/frontend/__tests__/unit/components/ModuleForm.test.tsx
+++ b/frontend/__tests__/unit/components/ModuleForm.test.tsx
@@ -343,10 +343,12 @@ describe('ModuleForm', () => {
       expect(screen.getByTestId('text-input-module-labels')).toBeInTheDocument()
     })
 
-    it('renders mentor logins field only when isEdit is true (line 312)', () => {
+    it('renders mentor logins field when creating a module', () => {
       renderModuleForm({ isEdit: false })
-      expect(screen.queryByTestId('text-input-module-mentor-logins')).not.toBeInTheDocument()
+      expect(screen.getByTestId('text-input-module-mentor-logins')).toBeInTheDocument()
+    })
 
+    it('renders mentor logins field when editing a module', () => {
       renderModuleForm({ isEdit: true })
       expect(screen.getByTestId('text-input-module-mentor-logins')).toBeInTheDocument()
     })

--- a/frontend/__tests__/unit/pages/CreateModule.test.tsx
+++ b/frontend/__tests__/unit/pages/CreateModule.test.tsx
@@ -85,6 +85,7 @@ describe('CreateModulePage', () => {
     await user.type(screen.getByLabelText(/End Date/i), '2025-08-15')
     await user.type(screen.getByLabelText(/Domains/i), 'AI, ML')
     await user.type(screen.getByLabelText(/Tags/i), 'react, graphql')
+    await user.type(screen.getByLabelText(/Mentor GitHub Usernames/i), 'alice, bob')
     const projectInput = await waitFor(() => {
       return screen.getByPlaceholderText('Start typing project name...')
     })
@@ -121,10 +122,7 @@ describe('CreateModulePage', () => {
       () => {
         expect(mockCreateModule).toHaveBeenCalled()
         const variables = mockCreateModule.mock.calls[0][0].variables
-        expect(variables.input.mentorLogins).toEqual([
-          'alice',
-          'bob',
-        ])
+        expect(variables.input.mentorLogins).toEqual(['alice', 'bob'])
         expect(mockPush).toHaveBeenCalledWith('/my/mentorship/programs/test-program')
       },
       { timeout: 10000 }

--- a/frontend/__tests__/unit/pages/CreateModule.test.tsx
+++ b/frontend/__tests__/unit/pages/CreateModule.test.tsx
@@ -85,7 +85,6 @@ describe('CreateModulePage', () => {
     await user.type(screen.getByLabelText(/End Date/i), '2025-08-15')
     await user.type(screen.getByLabelText(/Domains/i), 'AI, ML')
     await user.type(screen.getByLabelText(/Tags/i), 'react, graphql')
-
     const projectInput = await waitFor(() => {
       return screen.getByPlaceholderText('Start typing project name...')
     })
@@ -121,6 +120,11 @@ describe('CreateModulePage', () => {
     await waitFor(
       () => {
         expect(mockCreateModule).toHaveBeenCalled()
+        const variables = mockCreateModule.mock.calls[0][0].variables
+        expect(variables.input.mentorLogins).toEqual([
+          'alice',
+          'bob',
+        ])
         expect(mockPush).toHaveBeenCalledWith('/my/mentorship/programs/test-program')
       },
       { timeout: 10000 }

--- a/frontend/src/app/my/mentorship/programs/[programKey]/modules/[moduleKey]/edit/page.tsx
+++ b/frontend/src/app/my/mentorship/programs/[programKey]/modules/[moduleKey]/edit/page.tsx
@@ -192,7 +192,6 @@ const EditModulePage = () => {
       onSubmit={handleSubmit}
       loading={mutationLoading}
       submitText="Save"
-      isEdit
       validationErrors={validationErrors}
       minDate={
         data?.managementProgram?.startedAt

--- a/frontend/src/app/my/mentorship/programs/[programKey]/modules/create/page.tsx
+++ b/frontend/src/app/my/mentorship/programs/[programKey]/modules/create/page.tsx
@@ -172,7 +172,6 @@ const CreateModulePage = () => {
       setFormData={setFormData}
       onSubmit={handleSubmit}
       loading={mutationLoading}
-      isEdit={false}
       validationErrors={validationErrors}
       minDate={
         programData?.managementProgram?.startedAt

--- a/frontend/src/components/ModuleForm.tsx
+++ b/frontend/src/components/ModuleForm.tsx
@@ -40,7 +40,6 @@ interface ModuleFormProps {
   setFormData: React.Dispatch<React.SetStateAction<ModuleFormProps['formData']>>
   onSubmit: (e: React.FormEvent) => void
   loading: boolean
-  isEdit?: boolean
   title: string
   submitText?: string
   minDate?: string
@@ -61,7 +60,6 @@ const ModuleForm = ({
   onSubmit,
   loading,
   title,
-  isEdit,
   submitText = 'Save',
   minDate,
   maxDate,
@@ -309,16 +307,14 @@ const ModuleForm = ({
                     errorMessage={touched.projectId ? errors.projectId : undefined}
                   />
                 </div>
-                {isEdit && (
-                  <FormTextInput
-                    id="module-mentor-logins"
-                    label="Mentor GitHub Usernames"
-                    placeholder="johndoe, jane-doe"
-                    value={formData.mentorLogins}
-                    onValueChange={(value) => handleInputChange('mentorLogins', value)}
-                    className="w-full min-w-0 lg:col-span-2"
-                  />
-                )}
+                <FormTextInput
+                  id="module-mentor-logins"
+                  label="Mentor GitHub Usernames"
+                  placeholder="johndoe, jane-doe"
+                  value={formData.mentorLogins}
+                  onValueChange={(value) => handleInputChange('mentorLogins', value)}
+                  className="w-full min-w-0 lg:col-span-2"
+                />
                 <div className="flex w-full min-w-0 items-center gap-3 lg:col-span-2">
                   <Switch
                     aria-label="Mentees can manage deadlines"


### PR DESCRIPTION
## Summary

This PR implements part of the improvements described in #4987 by improving module management consistency.

### Changes

- Allow mentor assignment through the module creation flow.
- Keep create/edit module behavior aligned through regression tests.
- Return mentors in deterministic alphabetical order from the GraphQL API.
- Add regression tests covering mentor ordering and mentor assignment.

## Why

This improves consistency between the create and edit module workflows while ensuring mentor ordering is deterministic across API responses and UI rendering.

Fixes #4987