### PR TITLE
Add humans.txt route

### DIFF
--- a/frontend/src/app/humans.txt/route.ts
+++ b/frontend/src/app/humans.txt/route.ts
@@ -23,9 +23,9 @@ export async function GET() {
         excludedUsernames: leaders,
         hasFullName: true,
         limit: 24,
-        leader1: 'arkid15r',
-        leader2: 'kasya',
-        leader3: 'mamicidal',
+        leader1: 'leaders[0]',
+        leader2: 'leaders[1]',
+        leader3: 'leaders[2]',
       },
     })
 

--- a/frontend/src/app/humans.txt/route.ts
+++ b/frontend/src/app/humans.txt/route.ts
@@ -23,9 +23,9 @@ export async function GET() {
         excludedUsernames: leaders,
         hasFullName: true,
         limit: 24,
-        leader1: 'leaders[0]',
-        leader2: 'leaders[1]',
-        leader3: 'leaders[2]',
+        leader1: leaders[0],
+        leader2: leaders[1],
+        leader3: leaders[2],
       },
     })
 

--- a/frontend/src/app/humans.txt/route.ts
+++ b/frontend/src/app/humans.txt/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from 'next/server'
+import { apolloClient } from 'server/apolloClient'
+import { GetAboutPageDataDocument } from 'types/__generated__/aboutQueries.generated'
+
+export const revalidate = 86400
+
+const projectKey = 'nest'
+const leaders = {
+  arkid15r: 'CCSP, CISSP, CSSLP',
+  kasya: 'CC',
+  mamicidal: 'CISSP',
+}
+
+function formatPerson(person?: { name?: string | null; login?: string | null } | null): string {
+  if (!person) return ''
+  if (person.name && person.login) return `${person.name} (@${person.login})`
+  if (person.name) return person.name
+  if (person.login) return `@${person.login}`
+  return ''
+}
+
+export async function GET() {
+  try {
+    const { data } = await apolloClient.query({
+      query: GetAboutPageDataDocument,
+      variables: {
+        projectKey,
+        excludedUsernames: Object.keys(leaders),
+        hasFullName: true,
+        limit: 24,
+        leader1: 'arkid15r',
+        leader2: 'kasya',
+        leader3: 'mamicidal',
+      },
+    })
+
+    const leadersList = [data?.leader1, data?.leader2, data?.leader3]
+      .map(formatPerson)
+      .filter(Boolean)
+
+    const contributorsList = (data?.topContributors ?? []).map(formatPerson).filter(Boolean)
+
+    const body =
+      [
+        '/* TEAM */',
+        ...leadersList,
+        '',
+        '/* CONTRIBUTORS */',
+        ...contributorsList,
+        '',
+        '/* SITE */',
+        'Standards: HTML5, CSS3, ECMAScript',
+        'Software: Next.js, TypeScript, GraphQL, Apollo Client',
+      ].join('\n') + '\n'
+
+    return new NextResponse(body, {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/plain; charset=utf-8',
+        'Cache-Control': 'public, max-age=86400, s-maxage=86400',
+      },
+    })
+  } catch {
+    return new NextResponse('humans.txt temporarily unavailable\n', {
+      status: 500,
+      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+    })
+  }
+}
+
+
+

--- a/frontend/src/app/humans.txt/route.ts
+++ b/frontend/src/app/humans.txt/route.ts
@@ -5,12 +5,7 @@ import { GetAboutPageDataDocument } from 'types/__generated__/aboutQueries.gener
 export const revalidate = 86400
 
 const projectKey = 'nest'
-const leaders = {
-  arkid15r: 'CCSP, CISSP, CSSLP',
-  kasya: 'CC',
-  mamicidal: 'CISSP',
-}
-
+const leaders = ['arkid15r', 'kasya', 'mamicidal']
 function formatPerson(person?: { name?: string | null; login?: string | null } | null): string {
   if (!person) return ''
   if (person.name && person.login) return `${person.name} (@${person.login})`
@@ -25,7 +20,7 @@ export async function GET() {
       query: GetAboutPageDataDocument,
       variables: {
         projectKey,
-        excludedUsernames: Object.keys(leaders),
+        excludedUsernames: leaders,
         hasFullName: true,
         limit: 24,
         leader1: 'arkid15r',


### PR DESCRIPTION
## Proposed change
Resolves #5186

Adds a /humans.txt route that lists the people behind OWASP Nest. It reuses the same GetAboutPageDataDocument query the about page already uses, so no new GraphQL query was added. Leaders are shown first, then top contributors, with duplicates avoided using the existing excludedUsernames param. The response is cached for 24 hours and returned as plain text.

## Checklist
- [x] **Required:** I followed the contributing workflow
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran all required checks and tests locally; all warnings addressed and failures resolved
- [x] I used AI for code, documentation, tests, or communication related to this PR