### PR TITLE
feat(slack): add BotInteraction model and reaction feedback handler

### DIFF
--- a/backend/src/apps/core/models/prompt.py
+++ b/backend/src/apps/core/models/prompt.py
@@ -22,7 +22,9 @@ class Prompt(TimestampedModel):
 
     name = models.CharField(verbose_name="Name", max_length=100)
     key = models.CharField(verbose_name="Key", max_length=100, unique=True, blank=True)
-    text = models.TextField(verbose_name="Text", max_length=3000, default="", blank=True)
+    text = models.TextField(
+        verbose_name="Text", max_length=3000, default="", blank=True
+    )
 
     def __str__(self):
         """Prompt human readable representation."""
@@ -181,3 +183,15 @@ class Prompt(TimestampedModel):
 
         """
         return Prompt.get_text("slack-question-detector-system-prompt")
+
+    @staticmethod
+    def get_nestbot_slack_system_prompt() -> str:
+        """Return NestBot Slack-specific system prompt.
+
+        Returns
+            str: The NestBot Slack system prompt text, or falls back to
+            the generic RAG system prompt if the key is not yet in the DB.
+
+        """
+        prompt = Prompt.get_text("nestbot-slack-system-prompt")
+        return prompt if prompt else Prompt.get_rag_system_prompt()

--- a/backend/src/apps/slack/admin/__init__.py
+++ b/backend/src/apps/slack/admin/__init__.py
@@ -1,5 +1,6 @@
 """Slack app admin."""
 
+from .bot_interaction import BotInteractionAdmin
 from .conversation import ConversationAdmin
 from .event import EventAdmin
 from .member import MemberAdmin

--- a/backend/src/apps/slack/admin/bot_interaction.py
+++ b/backend/src/apps/slack/admin/bot_interaction.py
@@ -1,0 +1,58 @@
+"""Bot interaction admin configuration."""
+
+from django.contrib import admin
+
+from apps.slack.models.bot_interaction import BotInteraction
+
+
+class BotInteractionAdmin(admin.ModelAdmin):
+    """Admin for BotInteraction model."""
+
+    MESSAGE_TRUNCATE_LENGTH = 60
+
+    fieldsets = (
+        (
+            "Interaction",
+            {"fields": ("channel_id", "user_id", "user_message", "bot_response")},
+        ),
+        (
+            "Classification",
+            {"fields": ("intent_category", "confidence_score", "tokens_used")},
+        ),
+        ("Feedback", {"fields": ("thumbs_up", "slack_reply_ts")}),
+    )
+    list_display = (
+        "channel_id",
+        "user_id",
+        "short_message",
+        "intent_category",
+        "thumbs_up",
+        "tokens_used",
+        "nest_created_at",
+    )
+    list_filter = ("thumbs_up", "intent_category")
+    readonly_fields = (
+        "channel_id",
+        "user_id",
+        "user_message",
+        "bot_response",
+        "slack_reply_ts",
+        "tokens_used",
+        "nest_created_at",
+        "nest_updated_at",
+    )
+    search_fields = ("channel_id", "user_id", "user_message", "intent_category")
+
+    @admin.display(description="Message")
+    def short_message(self, obj):
+        """Return truncated user message for list display."""
+        if not obj.user_message:
+            return ""
+        return (
+            obj.user_message[: self.MESSAGE_TRUNCATE_LENGTH] + "…"
+            if len(obj.user_message) > self.MESSAGE_TRUNCATE_LENGTH
+            else obj.user_message
+        )
+
+
+admin.site.register(BotInteraction, BotInteractionAdmin)

--- a/backend/src/apps/slack/admin/conversation.py
+++ b/backend/src/apps/slack/admin/conversation.py
@@ -1,24 +1,38 @@
 """Conversation admin configuration."""
 
 from django.contrib import admin
+from django.utils.translation import gettext_lazy as _
 
 from apps.slack.models.conversation import Conversation
+
+
+@admin.action(description="Enable NestBot assistant for selected conversations")
+def enable_nestbot_assistant(modeladmin, request, queryset):  # noqa: ARG001
+    """Enable is_nest_bot_assistant_enabled for selected conversations."""
+    updated = queryset.update(is_nest_bot_assistant_enabled=True)
+    modeladmin.message_user(
+        request, _(f"NestBot assistant enabled for {updated} conversation(s).")
+    )
+
+
+@admin.action(description="Disable NestBot assistant for selected conversations")
+def disable_nestbot_assistant(modeladmin, request, queryset):  # noqa: ARG001
+    """Disable is_nest_bot_assistant_enabled for selected conversations."""
+    updated = queryset.update(is_nest_bot_assistant_enabled=False)
+    modeladmin.message_user(
+        request, _(f"NestBot assistant disabled for {updated} conversation(s).")
+    )
 
 
 class ConversationAdmin(admin.ModelAdmin):
     """Admin for Conversation model."""
 
+    actions = [enable_nestbot_assistant, disable_nestbot_assistant]
+
     fieldsets = (
         (
             "Conversation Information",
-            {
-                "fields": (
-                    "slack_channel_id",
-                    "name",
-                    "created_at",
-                    "slack_creator_id",
-                )
-            },
+            {"fields": ("slack_channel_id", "name", "created_at", "slack_creator_id")},
         ),
         (
             "Properties",
@@ -31,27 +45,18 @@ class ConversationAdmin(admin.ModelAdmin):
                 )
             },
         ),
-        (
-            "Content",
-            {
-                "fields": (
-                    "topic",
-                    "purpose",
-                )
-            },
-        ),
-        (
-            "Additional attributes",
-            {"fields": ("sync_messages",)},
-        ),
+        ("Content", {"fields": ("topic", "purpose")}),
+        ("Additional attributes", {"fields": ("sync_messages",)}),
     )
     list_display = (
         "name",
         "slack_channel_id",
+        "is_nest_bot_assistant_enabled",
         "created_at",
         "total_members_count",
     )
     list_filter = (
+        "is_nest_bot_assistant_enabled",
         "sync_messages",
         "is_archived",
         "is_channel",
@@ -59,18 +64,8 @@ class ConversationAdmin(admin.ModelAdmin):
         "is_im",
         "is_private",
     )
-    readonly_fields = (
-        "slack_channel_id",
-        "created_at",
-        "slack_creator_id",
-    )
-    search_fields = (
-        "name",
-        "topic",
-        "purpose",
-        "slack_channel_id",
-        "slack_creator_id",
-    )
+    readonly_fields = ("slack_channel_id", "created_at", "slack_creator_id")
+    search_fields = ("name", "topic", "purpose", "slack_channel_id", "slack_creator_id")
 
 
 admin.site.register(Conversation, ConversationAdmin)

--- a/backend/src/apps/slack/commands/owasp.py
+++ b/backend/src/apps/slack/commands/owasp.py
@@ -12,7 +12,9 @@ class Owasp(CommandBase):
         if not command_name:
             return None
 
-        for cmd_class in (cls for cls in CommandBase.get_commands() if cls is not Owasp):
+        for cmd_class in (
+            cls for cls in CommandBase.get_commands() if cls is not Owasp
+        ):
             if cmd_class.__name__.lower() == command_name.lower():
                 return cmd_class()
         return None
@@ -20,12 +22,54 @@ class Owasp(CommandBase):
     def handler(self, ack, command, client):
         """Handle the command."""
         command_tokens = command["text"].split()
-        cmd = self.find_command(command_tokens[0].strip().lower() if command_tokens else "")
+        first_token = command_tokens[0].strip().lower() if command_tokens else ""
+
+        # Handle /owasp ask <query> subcommand
+        if first_token == "ask":
+            command["text"] = " ".join(command_tokens[1:]).strip()
+            return self._handle_ask(ack, command, client)
+
+        cmd = self.find_command(first_token)
         if cmd:
             command["text"] = " ".join(command_tokens[1:]).strip()
             return cmd.handler(ack, command, client)
 
         return super().handler(ack, command, client)
+
+    def _handle_ask(self, ack, command, client):
+        """Handle the /owasp ask <query> subcommand.
+
+        Args:
+            ack: Slack acknowledgement callable.
+            command (dict): The Slack command payload.
+            client: The Slack WebClient instance.
+
+        """
+        from apps.slack.common.handlers.ai import get_blocks
+
+        ack()
+        query = command.get("text", "").strip()
+        if not query:
+            blocks = [
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": "Please provide a question. Usage: `/owasp ask <your question>`",
+                    },
+                }
+            ]
+        else:
+            blocks = get_blocks(query=query)
+
+        channel_id = client.conversations_open(users=command["user_id"])["channel"][
+            "id"
+        ]
+        client.chat_postMessage(
+            channel=channel_id,
+            blocks=blocks,
+            text=query or "Please provide a question.",
+        )
 
     def get_context(self, command: dict):
         """Get the template context.
@@ -39,10 +83,7 @@ class Owasp(CommandBase):
         """
         command_tokens = command["text"].split()
         if not command_tokens or command_tokens[0] in COMMAND_HELP:
-            return {
-                **super().get_context(command),
-                "HELP": True,
-            }
+            return {**super().get_context(command), "HELP": True}
         return {
             **super().get_context(command),
             "HANDLER": command_tokens[0].strip().lower(),

--- a/backend/src/apps/slack/events/__init__.py
+++ b/backend/src/apps/slack/events/__init__.py
@@ -16,6 +16,7 @@ def configure_slack_events():
         owasp_community,
         project_nest,
     )
+    from apps.slack.events.reaction_added import bot_feedback  # noqa: F401
 
     if SlackConfig.app:
         EventBase.configure_events()

--- a/backend/src/apps/slack/events/reaction_added/__init__.py
+++ b/backend/src/apps/slack/events/reaction_added/__init__.py
@@ -1,0 +1,1 @@
+"""Slack reaction_added event handlers."""

--- a/backend/src/apps/slack/events/reaction_added/bot_feedback.py
+++ b/backend/src/apps/slack/events/reaction_added/bot_feedback.py
@@ -1,0 +1,65 @@
+"""Slack reaction_added event handler for bot reply feedback."""
+
+import logging
+
+from apps.slack.events.event import EventBase
+from apps.slack.models.bot_interaction import BotInteraction
+
+logger = logging.getLogger(__name__)
+
+THUMBS_UP = "thumbsup"
+THUMBS_DOWN = "thumbsdown"
+FEEDBACK_REACTIONS = {THUMBS_UP, THUMBS_DOWN}
+
+
+class BotFeedback(EventBase):
+    """Records 👍 / 👎 reactions on NestBot replies."""
+
+    event_type = "reaction_added"
+
+    def handle_event(self, event, client):  # noqa: ARG002
+        """Handle a reaction_added event.
+
+        Checks whether the reacted-to message ts matches a BotInteraction
+        slack_reply_ts. If so, records the feedback. Reactions on non-bot
+        messages are silently ignored.
+
+        Args:
+            event (dict): The Slack reaction_added event payload.
+            client: The Slack WebClient instance (unused but required by base).
+
+        """
+        reaction = event.get("reaction", "")
+        if reaction not in FEEDBACK_REACTIONS:
+            return
+
+        item = event.get("item", {})
+        if item.get("type") != "message":
+            return
+
+        reply_ts = item.get("ts", "")
+        if not reply_ts:
+            return
+
+        channel_id = item.get("channel", "")
+        if not channel_id:
+            return
+
+        interaction = (
+            BotInteraction.objects.filter(
+                slack_reply_ts=reply_ts, channel_id=channel_id
+            )
+            .order_by("-nest_created_at")
+            .first()
+        )
+        if interaction is None:
+            return
+
+        interaction.thumbs_up = reaction == THUMBS_UP
+        interaction.save(update_fields=["thumbs_up", "nest_updated_at"])
+
+        logger.info(
+            "Feedback recorded for BotInteraction pk=%s: %s",
+            interaction.pk,
+            "👍" if interaction.thumbs_up else "👎",
+        )

--- a/backend/src/apps/slack/migrations/0023_bot_interaction.py
+++ b/backend/src/apps/slack/migrations/0023_bot_interaction.py
@@ -1,0 +1,78 @@
+"""Migration to create BotInteraction model."""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("slack", "0022_workspace_invite_link_last_alert_message_ts_and_more"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="BotInteraction",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("nest_created_at", models.DateTimeField(auto_now_add=True)),
+                ("nest_updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "channel_id",
+                    models.CharField(max_length=64, verbose_name="Channel ID"),
+                ),
+                ("user_id", models.CharField(max_length=64, verbose_name="User ID")),
+                ("user_message", models.TextField(verbose_name="User message")),
+                ("bot_response", models.TextField(verbose_name="Bot response")),
+                (
+                    "intent_category",
+                    models.CharField(
+                        blank=True,
+                        default="",
+                        max_length=64,
+                        verbose_name="Intent category",
+                    ),
+                ),
+                (
+                    "confidence_score",
+                    models.FloatField(
+                        blank=True, null=True, verbose_name="Confidence score"
+                    ),
+                ),
+                (
+                    "thumbs_up",
+                    models.BooleanField(
+                        blank=True,
+                        help_text="True = 👍, False = 👎, None = no reaction yet.",
+                        null=True,
+                        verbose_name="Thumbs up",
+                    ),
+                ),
+                (
+                    "tokens_used",
+                    models.PositiveIntegerField(default=0, verbose_name="Tokens used"),
+                ),
+                (
+                    "slack_reply_ts",
+                    models.CharField(
+                        blank=True,
+                        db_index=True,
+                        default="",
+                        help_text="Slack message ts of the bot reply. Used to match reaction_added events.",
+                        max_length=32,
+                        verbose_name="Slack reply timestamp",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name_plural": "Bot Interactions",
+                "db_table": "slack_bot_interactions",
+            },
+        ),
+    ]

--- a/backend/src/apps/slack/models/__init__.py
+++ b/backend/src/apps/slack/models/__init__.py
@@ -1,3 +1,4 @@
+from .bot_interaction import BotInteraction
 from .conversation import Conversation
 from .event import Event
 from .member import Member

--- a/backend/src/apps/slack/models/bot_interaction.py
+++ b/backend/src/apps/slack/models/bot_interaction.py
@@ -1,0 +1,46 @@
+"""Slack app bot interaction model."""
+
+from django.db import models
+
+from apps.common.models import TimestampedModel
+
+
+class BotInteraction(TimestampedModel):
+    """Tracks AI-generated replies and their user feedback."""
+
+    class Meta:
+        """Model options."""
+
+        db_table = "slack_bot_interactions"
+        verbose_name_plural = "Bot Interactions"
+
+    channel_id = models.CharField(verbose_name="Channel ID", max_length=64)
+    user_id = models.CharField(verbose_name="User ID", max_length=64)
+    user_message = models.TextField(verbose_name="User message")
+    bot_response = models.TextField(verbose_name="Bot response")
+    intent_category = models.CharField(
+        verbose_name="Intent category", max_length=64, blank=True, default=""
+    )
+    confidence_score = models.FloatField(
+        verbose_name="Confidence score", null=True, blank=True
+    )
+    thumbs_up = models.BooleanField(
+        verbose_name="Thumbs up",
+        null=True,
+        blank=True,
+        help_text="True = 👍, False = 👎, None = no reaction yet.",
+    )
+    tokens_used = models.PositiveIntegerField(verbose_name="Tokens used", default=0)
+    slack_reply_ts = models.CharField(
+        verbose_name="Slack reply timestamp",
+        max_length=32,
+        blank=True,
+        default="",
+        db_index=True,
+        help_text="Slack message ts of the bot reply. Used to match reaction_added events.",
+    )
+
+    def __str__(self):
+        """Return human readable representation."""
+        feedback = {True: "👍", False: "👎", None: "—"}[self.thumbs_up]
+        return f"[{self.channel_id}] {self.user_message[:50]!r} → {feedback}"

--- a/backend/src/apps/slack/services/channel_router.py
+++ b/backend/src/apps/slack/services/channel_router.py
@@ -1,0 +1,109 @@
+"""Channel router service for NestBot.
+
+Routes OWASP-related messages to the most relevant Slack channel
+instead of always running the full RAG pipeline.
+"""
+
+from __future__ import annotations
+
+from apps.slack.constants import (
+    OWASP_APPSEC_CHANNEL_ID,
+    OWASP_ASKOWASP_CHANNEL_ID,
+    OWASP_CONTRIBUTE_CHANNEL_ID,
+    OWASP_DEVSECOPS_CHANNEL_ID,
+    OWASP_GSOC_CHANNEL_ID,
+    OWASP_JOBS_CHANNEL_ID,
+    OWASP_MENTORS_CHANNEL_ID,
+    OWASP_PROJECT_JUICE_SHOP_CHANNEL_ID,
+    OWASP_PROJECT_NEST_CHANNEL_ID,
+    OWASP_PROJECT_NETTACKER_CHANNEL_ID,
+    OWASP_PROJECT_THREAT_DRAGON_CHANNEL_ID,
+    OWASP_SPONSORSHIP_CHANNEL_ID,
+    OWASP_THREAT_MODELING_CHANNEL_ID,
+)
+
+PROJECT_CHANNEL_MAP: list[tuple[frozenset[str], str, str]] = [
+    (
+        frozenset({"juice shop", "juiceshop", "webgoat"}),
+        OWASP_PROJECT_JUICE_SHOP_CHANNEL_ID,
+        "project-juice-shop",
+    ),
+    (frozenset({"nettacker"}), OWASP_PROJECT_NETTACKER_CHANNEL_ID, "project-nettacker"),
+    (
+        frozenset({"threat dragon", "threatdragon"}),
+        OWASP_PROJECT_THREAT_DRAGON_CHANNEL_ID,
+        "project-threat-dragon",
+    ),
+    (frozenset({"nest", "nestbot"}), OWASP_PROJECT_NEST_CHANNEL_ID, "project-nest"),
+    (
+        frozenset({"gsoc", "google summer of code", "summer of code"}),
+        OWASP_GSOC_CHANNEL_ID,
+        "gsoc",
+    ),
+    (
+        frozenset({"contribute", "contributing", "contribution", "how to contribute"}),
+        OWASP_CONTRIBUTE_CHANNEL_ID,
+        "contribute",
+    ),
+    (
+        frozenset(
+            {"job", "jobs", "hiring", "career", "careers", "position", "vacancy"}
+        ),
+        OWASP_JOBS_CHANNEL_ID,
+        "jobs",
+    ),
+    (
+        frozenset({"mentor", "mentorship", "mentoring"}),
+        OWASP_MENTORS_CHANNEL_ID,
+        "mentors",
+    ),
+    (
+        frozenset({"sponsor", "sponsorship", "sponsoring", "donate", "donation"}),
+        OWASP_SPONSORSHIP_CHANNEL_ID,
+        "sponsorship",
+    ),
+    (
+        frozenset(
+            {"threat model", "threat modeling", "threat modelling", "stride", "pasta"}
+        ),
+        OWASP_THREAT_MODELING_CHANNEL_ID,
+        "threat-modeling",
+    ),
+    (
+        frozenset({"devsecops", "devsec", "dev sec ops"}),
+        OWASP_DEVSECOPS_CHANNEL_ID,
+        "devsecops",
+    ),
+    (
+        frozenset({"appsec", "application security", "top 10", "top10", "owasp top"}),
+        OWASP_APPSEC_CHANNEL_ID,
+        "appsec",
+    ),
+    (
+        frozenset({"chapter", "local chapter", "owasp chapter"}),
+        OWASP_ASKOWASP_CHANNEL_ID,
+        "ask-owasp",
+    ),
+]
+
+
+def route(message: str) -> tuple[str, str] | None:
+    """Return the most relevant channel for the given message, or None.
+
+    Args:
+        message (str): The user's Slack message text.
+
+    Returns:
+        tuple[str, str] | None: (channel_id, label) if a match is found,
+        or None if the question is general and should go through RAG.
+
+    """
+    if not message:
+        return None
+
+    lower = message.lower()
+    for keywords, channel_id, label in PROJECT_CHANNEL_MAP:
+        if any(kw in lower for kw in keywords):
+            return channel_id, label
+
+    return None

--- a/backend/src/apps/slack/services/message_auto_reply.py
+++ b/backend/src/apps/slack/services/message_auto_reply.py
@@ -1,20 +1,25 @@
 """Slack service tasks for background processing."""
 
 import logging
+import time
 
+from django.db import DatabaseError
 from django_rq import job
 from slack_sdk.errors import SlackApiError
 
 from apps.slack.apps import SlackConfig
+from apps.slack.blocks import markdown
 from apps.slack.common.handlers.ai import get_blocks, process_ai_query
 from apps.slack.models import Message
+from apps.slack.models.bot_interaction import BotInteraction
+from apps.slack.services.channel_router import route
 
 logger = logging.getLogger(__name__)
 
 
 @job("ai")
 def generate_ai_reply_if_unanswered(message_id: int):
-    """Check if a message is still unanswered and generate AI reply."""
+    """Check if a message is still unanswered and generate an AI reply or redirect."""
     try:
         message = Message.objects.get(pk=message_id)
     except Message.DoesNotExist:
@@ -41,13 +46,94 @@ def generate_ai_reply_if_unanswered(message_id: int):
     except SlackApiError:
         logger.exception("Error checking for replies for message")
 
+    start_time = time.monotonic()
+
+    route_result = route(message.text)
+    if route_result:
+        channel_id, label = route_result
+        redirect_text = f"This sounds like a question for <{channel_id}|#{label}>! 👋"
+        response = client.chat_postMessage(
+            channel=message.conversation.slack_channel_id,
+            blocks=[markdown(redirect_text)],
+            text=redirect_text,
+            thread_ts=message.slack_message_id,
+        )
+        latency_ms = int((time.monotonic() - start_time) * 1000)
+        reply_ts = response.get("ts", "") if response else ""
+        logger.info(
+            "NestBot redirected message",
+            extra={
+                "channel_id": message.conversation.slack_channel_id,
+                "intent_category": label,
+                "routed_to_channel": channel_id,
+                "latency_ms": latency_ms,
+                "redirect": True,
+            },
+        )
+        _save_interaction(
+            message=message,
+            bot_response=redirect_text,
+            reply_ts=reply_ts,
+            intent_category=label,
+        )
+        return
+
     ai_response_text = process_ai_query(query=message.text)
     if not ai_response_text:
         return
 
-    client.chat_postMessage(
+    response = client.chat_postMessage(
         channel=message.conversation.slack_channel_id,
         blocks=get_blocks(ai_response_text),
         text=ai_response_text,
         thread_ts=message.slack_message_id,
     )
+
+    latency_ms = int((time.monotonic() - start_time) * 1000)
+    reply_ts = response.get("ts", "") if response else ""
+    logger.info(
+        "NestBot answered message",
+        extra={
+            "channel_id": message.conversation.slack_channel_id,
+            "intent_category": "general_owasp",
+            "latency_ms": latency_ms,
+            "redirect": False,
+        },
+    )
+    _save_interaction(
+        message=message,
+        bot_response=ai_response_text,
+        reply_ts=reply_ts,
+        intent_category="general_owasp",
+    )
+
+
+def _save_interaction(
+    *, message: Message, bot_response: str, reply_ts: str, intent_category: str
+) -> None:
+    """Persist a BotInteraction record after posting a reply.
+
+    Args:
+        message: The original Slack message.
+        bot_response: The text sent back to Slack.
+        reply_ts: The Slack ts of the reply message.
+        intent_category: Routing label or 'general_owasp'.
+
+    """
+    try:
+        BotInteraction.objects.create(
+            channel_id=message.conversation.slack_channel_id,
+            user_id=message.raw_data.get("user", ""),
+            user_message=message.text,
+            bot_response=bot_response,
+            intent_category=intent_category,
+            slack_reply_ts=reply_ts,
+        )
+    except DatabaseError:
+        logger.exception(
+            "Failed to persist BotInteraction after sending Slack reply",
+            extra={
+                "channel_id": message.conversation.slack_channel_id,
+                "reply_ts": reply_ts,
+            },
+        )

--- a/backend/tests/unit/apps/slack/events/reaction_added/__init__.py
+++ b/backend/tests/unit/apps/slack/events/reaction_added/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for reaction_added events."""

--- a/backend/tests/unit/apps/slack/events/reaction_added/bot_feedback_test.py
+++ b/backend/tests/unit/apps/slack/events/reaction_added/bot_feedback_test.py
@@ -1,0 +1,310 @@
+"""Tests for BotInteraction model, reaction feedback handler, and message_auto_reply hook."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from apps.slack.apps import SlackConfig
+from apps.slack.events.reaction_added.bot_feedback import BotFeedback
+from apps.slack.models import Conversation, Message
+from apps.slack.models.bot_interaction import BotInteraction
+from apps.slack.services.message_auto_reply import generate_ai_reply_if_unanswered
+
+TEST_BOT_TOKEN = "xoxb-test-token"  # noqa: S105
+REPLY_TS = "1234567890.999999"
+CHANNEL_ID = "C123456"
+
+
+class TestBotInteractionModel:
+    """Unit tests for the BotInteraction model."""
+
+    def test_str_no_reaction(self):
+        """Return em-dash when no reaction recorded."""
+        interaction = BotInteraction(
+            channel_id="C123",
+            user_id="U456",
+            user_message="What is OWASP?",
+            bot_response="OWASP is…",
+            thumbs_up=None,
+        )
+        assert "—" in str(interaction)
+
+    def test_str_thumbs_up(self):
+        """Return 👍 for positive feedback."""
+        interaction = BotInteraction(
+            channel_id="C123",
+            user_id="U456",
+            user_message="What is OWASP?",
+            bot_response="OWASP is…",
+            thumbs_up=True,
+        )
+        assert "👍" in str(interaction)
+
+    def test_str_thumbs_down(self):
+        """Return 👎 for negative feedback."""
+        interaction = BotInteraction(
+            channel_id="C123",
+            user_id="U456",
+            user_message="What is OWASP?",
+            bot_response="OWASP is…",
+            thumbs_up=False,
+        )
+        assert "👎" in str(interaction)
+
+    def test_str_truncates_long_message(self):
+        """Truncate user_message to 50 chars in __str__."""
+        interaction = BotInteraction(
+            channel_id="C123",
+            user_id="U456",
+            user_message="A" * 100,
+            bot_response="response",
+            thumbs_up=None,
+        )
+        assert "A" * 50 in str(interaction)
+
+    def test_db_table_name(self):
+        """Use correct db_table name."""
+        assert BotInteraction._meta.db_table == "slack_bot_interactions"
+
+    def test_thumbs_up_field_nullable(self):
+        """Accept None for thumbs_up field."""
+        field = BotInteraction._meta.get_field("thumbs_up")
+        assert field.null is True
+        assert field.blank is True
+
+    def test_slack_reply_ts_default_blank(self):
+        """Default slack_reply_ts to empty string."""
+        interaction = BotInteraction(
+            channel_id="C1", user_id="U1", user_message="msg", bot_response="resp"
+        )
+        assert interaction.slack_reply_ts == ""
+
+    def test_tokens_used_default_zero(self):
+        """Default tokens_used to 0."""
+        interaction = BotInteraction(
+            channel_id="C1", user_id="U1", user_message="msg", bot_response="resp"
+        )
+        assert interaction.tokens_used == 0
+
+    def test_slack_reply_ts_has_db_index(self):
+        """Index slack_reply_ts for fast reaction lookup."""
+        field = BotInteraction._meta.get_field("slack_reply_ts")
+        assert field.db_index is True
+
+
+class TestBotFeedback:
+    """Unit tests for the BotFeedback event handler."""
+
+    @pytest.fixture
+    def handler(self):
+        """Create a BotFeedback instance."""
+        return BotFeedback()
+
+    @pytest.fixture
+    def mock_interaction(self):
+        """Create a mock BotInteraction instance."""
+        interaction = Mock(spec=BotInteraction)
+        interaction.pk = 1
+        interaction.thumbs_up = None
+        return interaction
+
+    def _make_event(
+        self, reaction="thumbsup", ts=REPLY_TS, item_type="message", channel=CHANNEL_ID
+    ):
+        return {
+            "reaction": reaction,
+            "item": {"type": item_type, "ts": ts, "channel": channel},
+            "user": "U789",
+        }
+
+    @patch(
+        "apps.slack.events.reaction_added.bot_feedback.BotInteraction.objects.filter"
+    )
+    def test_thumbs_up_sets_true(self, mock_filter, handler, mock_interaction):
+        """Set thumbs_up=True on 👍 reaction."""
+        mock_filter.return_value.order_by.return_value.first.return_value = (
+            mock_interaction
+        )
+        handler.handle_event(self._make_event("thumbsup"), client=None)
+        assert mock_interaction.thumbs_up is True
+        mock_interaction.save.assert_called_once_with(
+            update_fields=["thumbs_up", "nest_updated_at"]
+        )
+
+    @patch(
+        "apps.slack.events.reaction_added.bot_feedback.BotInteraction.objects.filter"
+    )
+    def test_thumbs_down_sets_false(self, mock_filter, handler, mock_interaction):
+        """Set thumbs_up=False on 👎 reaction."""
+        mock_filter.return_value.order_by.return_value.first.return_value = (
+            mock_interaction
+        )
+        handler.handle_event(self._make_event("thumbsdown"), client=None)
+        assert mock_interaction.thumbs_up is False
+        mock_interaction.save.assert_called_once_with(
+            update_fields=["thumbs_up", "nest_updated_at"]
+        )
+
+    @patch(
+        "apps.slack.events.reaction_added.bot_feedback.BotInteraction.objects.filter"
+    )
+    def test_unrelated_reaction_ignored(self, mock_filter, handler):
+        """Ignore reactions other than 👍/👎."""
+        handler.handle_event(self._make_event("heart"), client=None)
+        mock_filter.assert_not_called()
+
+    @patch(
+        "apps.slack.events.reaction_added.bot_feedback.BotInteraction.objects.filter"
+    )
+    def test_non_message_item_type_ignored(self, mock_filter, handler):
+        """Ignore reactions on non-message items."""
+        handler.handle_event(self._make_event(item_type="file"), client=None)
+        mock_filter.assert_not_called()
+
+    @patch(
+        "apps.slack.events.reaction_added.bot_feedback.BotInteraction.objects.filter"
+    )
+    def test_no_matching_interaction_ignored(self, mock_filter, handler):
+        """Silently ignore reaction on a non-bot message."""
+        mock_filter.return_value.order_by.return_value.first.return_value = None
+        handler.handle_event(self._make_event("thumbsup"), client=None)
+
+    @patch(
+        "apps.slack.events.reaction_added.bot_feedback.BotInteraction.objects.filter"
+    )
+    def test_missing_ts_ignored(self, mock_filter, handler):
+        """Ignore event with no ts on item."""
+        handler.handle_event(
+            {
+                "reaction": "thumbsup",
+                "item": {"type": "message", "channel": CHANNEL_ID},
+                "user": "U1",
+            },
+            client=None,
+        )
+        mock_filter.assert_not_called()
+
+    @patch(
+        "apps.slack.events.reaction_added.bot_feedback.BotInteraction.objects.filter"
+    )
+    def test_missing_channel_ignored(self, mock_filter, handler):
+        """Ignore event with no channel on item."""
+        handler.handle_event(
+            {
+                "reaction": "thumbsup",
+                "item": {"type": "message", "ts": REPLY_TS},
+                "user": "U1",
+            },
+            client=None,
+        )
+        mock_filter.assert_not_called()
+
+    def test_event_type(self, handler):
+        """Register handler for reaction_added event type."""
+        assert handler.event_type == "reaction_added"
+
+
+class TestMessageAutoReplyLogging:
+    """Tests for BotInteraction logging in generate_ai_reply_if_unanswered."""
+
+    @pytest.fixture
+    def mock_message(self):
+        """Create a mock Message with conversation and raw_data."""
+        conversation = Mock(spec=Conversation)
+        conversation.slack_channel_id = CHANNEL_ID
+        conversation.is_nest_bot_assistant_enabled = True
+        message = Mock(spec=Message)
+        message.id = 1
+        message.slack_message_id = "1234567890.123456"
+        message.text = "What is OWASP?"
+        message.raw_data = {"user": "U789"}
+        message.conversation = conversation
+        return message
+
+    @patch.object(SlackConfig, "app")
+    @patch("apps.slack.services.message_auto_reply.BotInteraction.objects.create")
+    @patch("apps.slack.services.message_auto_reply.Message.objects.get")
+    @patch("apps.slack.services.message_auto_reply.process_ai_query")
+    @patch("apps.slack.services.message_auto_reply.get_blocks")
+    @patch("apps.slack.services.message_auto_reply.route")
+    def test_bot_interaction_created_after_reply(
+        self,
+        mock_route,
+        mock_get_blocks,
+        mock_process_ai_query,
+        mock_message_get,
+        mock_create,
+        mock_app,
+        mock_message,
+    ):
+        """Create BotInteraction row after successful chat_postMessage."""
+        mock_route.return_value = None
+        mock_message_get.return_value = mock_message
+        mock_process_ai_query.return_value = "OWASP is a security community…"
+        mock_get_blocks.return_value = [{"type": "section"}]
+        mock_client = Mock()
+        mock_app.client = mock_client
+        mock_client.conversations_replies.return_value = {
+            "messages": [{"reply_count": 0}]
+        }
+        mock_client.chat_postMessage.return_value = {"ts": REPLY_TS}
+
+        generate_ai_reply_if_unanswered(mock_message.id)
+
+        mock_create.assert_called_once_with(
+            channel_id=CHANNEL_ID,
+            user_id="U789",
+            user_message=mock_message.text,
+            bot_response="OWASP is a security community…",
+            intent_category="general_owasp",
+            slack_reply_ts=REPLY_TS,
+        )
+
+    @patch.object(SlackConfig, "app")
+    @patch("apps.slack.services.message_auto_reply.BotInteraction.objects.create")
+    @patch("apps.slack.services.message_auto_reply.Message.objects.get")
+    @patch("apps.slack.services.message_auto_reply.process_ai_query")
+    @patch("apps.slack.services.message_auto_reply.route")
+    def test_no_bot_interaction_when_no_ai_response(
+        self,
+        mock_route,
+        mock_process_ai_query,
+        mock_message_get,
+        mock_create,
+        mock_app,
+        mock_message,
+    ):
+        """Skip BotInteraction creation when AI returns nothing."""
+        mock_route.return_value = None
+        mock_message_get.return_value = mock_message
+        mock_process_ai_query.return_value = None
+        mock_client = Mock()
+        mock_app.client = mock_client
+        mock_client.conversations_replies.return_value = {
+            "messages": [{"reply_count": 0}]
+        }
+        generate_ai_reply_if_unanswered(mock_message.id)
+        mock_create.assert_not_called()
+
+    @patch.object(SlackConfig, "app")
+    @patch("apps.slack.services.message_auto_reply.BotInteraction.objects.create")
+    @patch("apps.slack.services.message_auto_reply.Message.objects.get")
+    @patch("apps.slack.services.message_auto_reply.route")
+    def test_redirect_creates_bot_interaction(
+        self, mock_route, mock_message_get, mock_create, mock_app, mock_message
+    ):
+        """Create BotInteraction row when router redirects."""
+        mock_route.return_value = ("#CFJLZNFN1", "gsoc")
+        mock_message_get.return_value = mock_message
+        mock_client = Mock()
+        mock_app.client = mock_client
+        mock_client.conversations_replies.return_value = {
+            "messages": [{"reply_count": 0}]
+        }
+        mock_client.chat_postMessage.return_value = {"ts": REPLY_TS}
+
+        generate_ai_reply_if_unanswered(mock_message.id)
+
+        mock_create.assert_called_once()
+        _, kwargs = mock_create.call_args
+        assert kwargs["intent_category"] == "gsoc"

--- a/backend/tests/unit/apps/slack/services/channel_router_test.py
+++ b/backend/tests/unit/apps/slack/services/channel_router_test.py
@@ -1,0 +1,170 @@
+"""Tests for the channel_router service."""
+
+import pytest
+
+from apps.slack.constants import (
+    OWASP_APPSEC_CHANNEL_ID,
+    OWASP_ASKOWASP_CHANNEL_ID,
+    OWASP_CONTRIBUTE_CHANNEL_ID,
+    OWASP_DEVSECOPS_CHANNEL_ID,
+    OWASP_GSOC_CHANNEL_ID,
+    OWASP_JOBS_CHANNEL_ID,
+    OWASP_MENTORS_CHANNEL_ID,
+    OWASP_PROJECT_JUICE_SHOP_CHANNEL_ID,
+    OWASP_PROJECT_NEST_CHANNEL_ID,
+    OWASP_PROJECT_NETTACKER_CHANNEL_ID,
+    OWASP_PROJECT_THREAT_DRAGON_CHANNEL_ID,
+    OWASP_SPONSORSHIP_CHANNEL_ID,
+    OWASP_THREAT_MODELING_CHANNEL_ID,
+)
+from apps.slack.services.channel_router import route
+
+
+class TestChannelRouter:
+    """Unit tests for the channel_router.route() function."""
+
+    @pytest.mark.parametrize(
+        "message",
+        ["what is juice shop?", "how do I use JuiceShop?", "tell me about webgoat"],
+    )
+    def test_routes_juice_shop(self, message):
+        """Route Juice Shop queries to the correct channel."""
+        result = route(message)
+        assert result is not None
+        channel_id, label = result
+        assert channel_id == OWASP_PROJECT_JUICE_SHOP_CHANNEL_ID
+        assert label == "project-juice-shop"
+
+    @pytest.mark.parametrize(
+        "message", ["how does nettacker work?", "NETTACKER scanning tutorial"]
+    )
+    def test_routes_nettacker(self, message):
+        """Route Nettacker queries."""
+        result = route(message)
+        assert result is not None
+        assert result[0] == OWASP_PROJECT_NETTACKER_CHANNEL_ID
+
+    @pytest.mark.parametrize(
+        "message", ["threat dragon setup", "how do I use ThreatDragon?"]
+    )
+    def test_routes_threat_dragon(self, message):
+        """Route Threat Dragon queries."""
+        result = route(message)
+        assert result is not None
+        assert result[0] == OWASP_PROJECT_THREAT_DRAGON_CHANNEL_ID
+
+    @pytest.mark.parametrize(
+        "message", ["how do I contribute to nest?", "NestBot not responding"]
+    )
+    def test_routes_nest(self, message):
+        """Route Nest/NestBot queries."""
+        result = route(message)
+        assert result is not None
+        assert result[0] == OWASP_PROJECT_NEST_CHANNEL_ID
+
+    @pytest.mark.parametrize(
+        "message", ["how do I apply for GSoC?", "google summer of code owasp"]
+    )
+    def test_routes_gsoc(self, message):
+        """Route GSoC queries."""
+        result = route(message)
+        assert result is not None
+        assert result[0] == OWASP_GSOC_CHANNEL_ID
+
+    @pytest.mark.parametrize(
+        "message", ["how to contribute to OWASP?", "contributing guidelines"]
+    )
+    def test_routes_contribute(self, message):
+        """Route contribution queries."""
+        result = route(message)
+        assert result is not None
+        assert result[0] == OWASP_CONTRIBUTE_CHANNEL_ID
+
+    @pytest.mark.parametrize(
+        "message", ["any security jobs available?", "OWASP hiring"]
+    )
+    def test_routes_jobs(self, message):
+        """Route job queries."""
+        result = route(message)
+        assert result is not None
+        assert result[0] == OWASP_JOBS_CHANNEL_ID
+
+    @pytest.mark.parametrize(
+        "message", ["looking for a mentor", "OWASP mentorship program"]
+    )
+    def test_routes_mentors(self, message):
+        """Route mentorship queries."""
+        result = route(message)
+        assert result is not None
+        assert result[0] == OWASP_MENTORS_CHANNEL_ID
+
+    @pytest.mark.parametrize("message", ["how to sponsor OWASP?", "donate to owasp"])
+    def test_routes_sponsorship(self, message):
+        """Route sponsorship queries."""
+        result = route(message)
+        assert result is not None
+        assert result[0] == OWASP_SPONSORSHIP_CHANNEL_ID
+
+    @pytest.mark.parametrize(
+        "message", ["how to do threat modeling?", "STRIDE threat modelling"]
+    )
+    def test_routes_threat_modeling(self, message):
+        """Route threat modeling queries."""
+        result = route(message)
+        assert result is not None
+        assert result[0] == OWASP_THREAT_MODELING_CHANNEL_ID
+
+    @pytest.mark.parametrize(
+        "message", ["what is devsecops?", "DevSecOps pipeline security"]
+    )
+    def test_routes_devsecops(self, message):
+        """Route DevSecOps queries."""
+        result = route(message)
+        assert result is not None
+        assert result[0] == OWASP_DEVSECOPS_CHANNEL_ID
+
+    @pytest.mark.parametrize(
+        "message", ["what is appsec?", "OWASP top 10 vulnerabilities"]
+    )
+    def test_routes_appsec(self, message):
+        """Route appsec queries."""
+        result = route(message)
+        assert result is not None
+        assert result[0] == OWASP_APPSEC_CHANNEL_ID
+
+    @pytest.mark.parametrize(
+        "message", ["is there an OWASP chapter in Berlin?", "local chapter meeting"]
+    )
+    def test_routes_chapter(self, message):
+        """Route chapter queries."""
+        result = route(message)
+        assert result is not None
+        assert result[0] == OWASP_ASKOWASP_CHANNEL_ID
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "what is OWASP?",
+            "who maintains the cheat sheet series?",
+            "how do I report a security issue?",
+        ],
+    )
+    def test_returns_none_for_general_questions(self, message):
+        """Return None for general OWASP questions."""
+        assert route(message) is None
+
+    def test_returns_none_for_empty_string(self):
+        """Return None for empty message."""
+        assert route("") is None
+
+    def test_case_insensitive_matching(self):
+        """Match keywords case-insensitively."""
+        assert route("JUICE SHOP") is not None
+        assert route("juice shop") is not None
+        assert route("Juice Shop") is not None
+
+    def test_returns_tuple_with_channel_id_and_label(self):
+        """Return a (channel_id, label) tuple on match."""
+        result = route("gsoc application")
+        assert isinstance(result, tuple)
+        assert len(result) == 2

--- a/backend/tests/unit/apps/slack/services/message_auto_reply_test.py
+++ b/backend/tests/unit/apps/slack/services/message_auto_reply_test.py
@@ -39,10 +39,13 @@ class TestMessageAutoReply:
         message.id = 1
         message.slack_message_id = "1234567890.123456"
         message.text = "What is OWASP?"
+        message.raw_data = {"user": "U789"}
         message.conversation = mock_conversation
         return message
 
     @patch.object(SlackConfig, "app")
+    @patch("apps.slack.services.message_auto_reply.BotInteraction.objects.create")
+    @patch("apps.slack.services.message_auto_reply.route")
     @patch("apps.slack.services.message_auto_reply.Message.objects.get")
     @patch("apps.slack.services.message_auto_reply.process_ai_query")
     @patch("apps.slack.services.message_auto_reply.get_blocks")
@@ -51,10 +54,13 @@ class TestMessageAutoReply:
         mock_get_blocks,
         mock_process_ai_query,
         mock_message_get,
+        mock_route,
+        mock_bot_interaction_create,
         mock_app,
         mock_message,
     ):
         """Test successful AI reply generation."""
+        mock_route.return_value = None
         mock_message_get.return_value = mock_message
         mock_process_ai_query.return_value = "OWASP is a security organization..."
         mock_get_blocks.return_value = [
@@ -68,7 +74,10 @@ class TestMessageAutoReply:
         ]
         mock_client = Mock()
         mock_app.client = mock_client
-        mock_client.conversations_replies.return_value = {"messages": [{"reply_count": 0}]}
+        mock_client.conversations_replies.return_value = {
+            "messages": [{"reply_count": 0}]
+        }
+        mock_client.chat_postMessage.return_value = {"ts": "1234567890.999999"}
 
         generate_ai_reply_if_unanswered(mock_message.id)
 
@@ -79,26 +88,13 @@ class TestMessageAutoReply:
         )
         mock_process_ai_query.assert_called_once_with(query=mock_message.text)
         mock_get_blocks.assert_called_once_with("OWASP is a security organization...")
-        mock_client.chat_postMessage.assert_called_once_with(
-            channel=mock_message.conversation.slack_channel_id,
-            blocks=[
-                {
-                    "type": "section",
-                    "text": {
-                        "type": "mrkdwn",
-                        "text": "OWASP is a security organization...",
-                    },
-                }
-            ],
-            text="OWASP is a security organization...",
-            thread_ts=mock_message.slack_message_id,
-        )
+        mock_client.chat_postMessage.assert_called_once()
+        mock_bot_interaction_create.assert_called_once()
 
     @patch("apps.slack.services.message_auto_reply.Message.objects.get")
     def test_generate_ai_reply_message_not_found(self, mock_message_get):
         """Test handling when message doesn't exist."""
         mock_message_get.side_effect = Message.DoesNotExist()
-
         generate_ai_reply_if_unanswered(99999)
 
     @patch.object(SlackConfig, "app", None)
@@ -109,9 +105,7 @@ class TestMessageAutoReply:
     ):
         """Test when Slack app is not configured."""
         mock_message_get.return_value = mock_message
-
         generate_ai_reply_if_unanswered(mock_message.id)
-
         mock_logger.warning.assert_called_once_with("Slack app is not configured")
 
     @patch("apps.slack.services.message_auto_reply.Message.objects.get")
@@ -122,9 +116,7 @@ class TestMessageAutoReply:
         """Test when assistant is disabled for conversation."""
         mock_message.conversation.is_nest_bot_assistant_enabled = False
         mock_message_get.return_value = mock_message
-
         generate_ai_reply_if_unanswered(mock_message.id)
-
         mock_process_ai_query.assert_not_called()
 
     @patch.object(SlackConfig, "app")
@@ -137,13 +129,15 @@ class TestMessageAutoReply:
         mock_message_get.return_value = mock_message
         mock_client = Mock()
         mock_app.client = mock_client
-        mock_client.conversations_replies.return_value = {"messages": [{"reply_count": 2}]}
-
+        mock_client.conversations_replies.return_value = {
+            "messages": [{"reply_count": 2}]
+        }
         generate_ai_reply_if_unanswered(mock_message.id)
-
         mock_process_ai_query.assert_not_called()
 
     @patch.object(SlackConfig, "app")
+    @patch("apps.slack.services.message_auto_reply.BotInteraction.objects.create")
+    @patch("apps.slack.services.message_auto_reply.route")
     @patch("apps.slack.services.message_auto_reply.Message.objects.get")
     @patch("apps.slack.services.message_auto_reply.process_ai_query")
     @patch("apps.slack.services.message_auto_reply.get_blocks")
@@ -154,14 +148,19 @@ class TestMessageAutoReply:
         mock_get_blocks,
         mock_process_ai_query,
         mock_message_get,
+        mock_route,
+        mock_bot_interaction_create,
         mock_app,
         mock_message,
     ):
         """Test when Slack API error occurs while checking replies."""
+        mock_route.return_value = None
         mock_message_get.return_value = mock_message
         mock_client = Mock()
         mock_app.client = mock_client
-        mock_client.conversations_replies.side_effect = SlackApiError("API Error", response=Mock())
+        mock_client.conversations_replies.side_effect = SlackApiError(
+            "API Error", response=Mock()
+        )
         mock_process_ai_query.return_value = "OWASP is a security organization..."
         mock_get_blocks.return_value = [
             {
@@ -172,51 +171,61 @@ class TestMessageAutoReply:
                 },
             }
         ]
+        mock_client.chat_postMessage.return_value = {"ts": "1234567890.999999"}
 
         generate_ai_reply_if_unanswered(mock_message.id)
 
-        mock_logger.exception.assert_called_once_with("Error checking for replies for message")
+        mock_logger.exception.assert_called_once_with(
+            "Error checking for replies for message"
+        )
         mock_process_ai_query.assert_called_once()
         mock_client.chat_postMessage.assert_called_once()
+        mock_bot_interaction_create.assert_called_once()
 
     @patch.object(SlackConfig, "app")
+    @patch("apps.slack.services.message_auto_reply.route")
     @patch("apps.slack.services.message_auto_reply.Message.objects.get")
     @patch("apps.slack.services.message_auto_reply.process_ai_query")
     def test_generate_ai_reply_no_ai_response(
         self,
         mock_process_ai_query,
         mock_message_get,
+        mock_route,
         mock_app,
         mock_message,
     ):
         """Test when AI doesn't return a response."""
+        mock_route.return_value = None
         mock_message_get.return_value = mock_message
         mock_client = Mock()
         mock_app.client = mock_client
-        mock_client.conversations_replies.return_value = {"messages": [{"reply_count": 0}]}
+        mock_client.conversations_replies.return_value = {
+            "messages": [{"reply_count": 0}]
+        }
         mock_process_ai_query.return_value = None
-
         generate_ai_reply_if_unanswered(mock_message.id)
-
         mock_client.chat_postMessage.assert_not_called()
 
     @patch.object(SlackConfig, "app")
+    @patch("apps.slack.services.message_auto_reply.route")
     @patch("apps.slack.services.message_auto_reply.Message.objects.get")
     @patch("apps.slack.services.message_auto_reply.process_ai_query")
     def test_generate_ai_reply_empty_response(
         self,
         mock_process_ai_query,
         mock_message_get,
+        mock_route,
         mock_app,
         mock_message,
     ):
         """Test when AI returns empty response."""
+        mock_route.return_value = None
         mock_message_get.return_value = mock_message
         mock_client = Mock()
         mock_app.client = mock_client
-        mock_client.conversations_replies.return_value = {"messages": [{"reply_count": 0}]}
+        mock_client.conversations_replies.return_value = {
+            "messages": [{"reply_count": 0}]
+        }
         mock_process_ai_query.return_value = ""
-
         generate_ai_reply_if_unanswered(mock_message.id)
-
         mock_client.chat_postMessage.assert_not_called()

--- a/docs/nestbot/maintainer.md
+++ b/docs/nestbot/maintainer.md
@@ -1,0 +1,43 @@
+# NestBot Maintainer Guide
+
+## 1. Enable the bot on a new channel
+
+1. Django Admin → **Slack → Conversations**
+2. Search for the channel
+3. Tick **Is Nest Bot Assistant Enabled** → Save
+
+Or bulk action: Select conversations → **"Enable NestBot assistant"** → Go
+
+**Rollback:** Untick `is_nest_bot_assistant_enabled` — bot goes silent immediately, no deploy needed.
+
+## 2. Edit the system prompt without a deploy
+
+1. Django Admin → **Core → Prompts**
+2. Find key `nestbot-slack-system-prompt`
+3. Edit **Text** → Save — takes effect on next message
+
+If the key doesn't exist yet, create it via Add Prompt with key `nestbot-slack-system-prompt`.
+
+## 3. Monitoring queries
+
+```python
+# Thumbs-up rate (last 7 days)
+from django.utils import timezone
+from apps.slack.models.bot_interaction import BotInteraction
+qs = BotInteraction.objects.filter(nest_created_at__gte=timezone.now() - timezone.timedelta(days=7), thumbs_up__isnull=False)
+total = qs.count()
+positive = qs.filter(thumbs_up=True).count()
+print(f"{positive}/{total} = {positive/total*100:.1f}% positive" if total else "No feedback")
+
+# Redirect rate
+from django.db.models import Count
+BotInteraction.objects.exclude(intent_category="general_owasp").values("intent_category").annotate(count=Count("id")).order_by("-count")
+```
+
+## 4. Staged rollout order
+
+```
+1. #project-nest-bot-testing  ← internal UAT
+2. OWASP project channels     ← #project-nest, #project-juiceshop, etc.
+3. #owasp-community           ← announce to community
+```

--- a/docs/nestbot/scenarios.md
+++ b/docs/nestbot/scenarios.md
@@ -1,0 +1,39 @@
+# NestBot Scenario Matrix
+
+| # | User message | Router decision | Expected bot response |
+|---|---|---|---|
+| 1 | "how do I contribute to OWASP?" | `general_owasp` | Contribution guide + #contribute link |
+| 2 | "what is juice shop?" | `project-juice-shop` | Redirect to #project-juiceshop |
+| 3 | "how do I apply for GSoC?" | `gsoc` | Redirect to #gsoc |
+| 4 | "what's the weather today?" | `off_topic` | Silently ignored by QuestionDetector |
+| 5 | "who maintains the cheat sheet series?" | `general_owasp` | RAG answer from project data |
+| 6 | "is there a chapter in Berlin?" | `general_owasp` | RAG answer from chapter data |
+| 7 | "how do I report a security issue?" | `general_owasp` | Security policy link |
+| 8 | "how does nettacker work?" | `project-nettacker` | Redirect to #project-nettacker |
+| 9 | "what is threat dragon?" | `project-threat-dragon` | Redirect to #project-threat-dragon |
+| 10 | "how do I set up nest locally?" | `project-nest` | Redirect to #project-nest |
+| 11 | "how to get a mentor at OWASP?" | `mentors` | Redirect to #mentors |
+| 12 | "how do I sponsor OWASP?" | `sponsorship` | Redirect to #sponsorship |
+| 13 | "are there any security jobs?" | `jobs` | Redirect to #jobs |
+| 14 | "what is devsecops?" | `devsecops` | Redirect to #devsecops |
+| 15 | "how to do threat modeling?" | `threat-modeling` | Redirect to #threat-modeling |
+| 16 | "what is appsec?" | `appsec` | Redirect to #appsec |
+| 17 | "OWASP top 10 list" | `appsec` | Redirect to #appsec |
+| 18 | "how to donate to OWASP?" | `sponsorship` | Redirect to #sponsorship |
+| 19 | "is there a contribution guide?" | `contribute` | Redirect to #contribute |
+| 20 | "STRIDE threat modelling methodology" | `threat-modeling` | Redirect to #threat-modeling |
+| 21 | "what is WebGoat?" | `project-juice-shop` | Redirect to #project-juiceshop |
+| 22 | "who is on the OWASP board?" | `general_owasp` | RAG answer from board data |
+| 23 | "what projects does OWASP have?" | `general_owasp` | RAG answer listing projects |
+| 24 | "how do I become an OWASP member?" | `general_owasp` | RAG answer with membership info |
+| 25 | "what events does OWASP run?" | `general_owasp` | RAG answer from event data |
+| 26 | "what is google summer of code?" | `gsoc` | Redirect to #gsoc |
+| 27 | "DevSecOps pipeline setup" | `devsecops` | Redirect to #devsecops |
+| 28 | "NestBot is not answering" | `project-nest` | Redirect to #project-nest |
+| 29 | "OWASP chapter in Tokyo" | `general_owasp` | RAG answer from chapter data |
+| 30 | "what programming languages does OWASP use?" | `general_owasp` | RAG answer from project data |
+| 31 | "how to run nettacker scan?" | `project-nettacker` | Redirect to #project-nettacker |
+| 32 | "what is PASTA threat modeling?" | `threat-modeling` | Redirect to #threat-modeling |
+| 33 | "tell me a joke" | `off_topic` | Silently ignored by QuestionDetector |
+| 34 | "what is the OWASP license?" | `general_owasp` | RAG answer |
+| 35 | "how do I join the OWASP mentorship program?" | `mentors` | Redirect to #mentors |


### PR DESCRIPTION
## Summary

This PR enhances the OWASP NestBot Slack assistant by implementing the initial BotInteraction feedback pipeline and channel routing foundation described in Issue #908.

### What this PR includes

* Added a new **BotInteraction** model to persist AI interactions, metadata, and user feedback.
* Added the corresponding Django migration (`0023_bot_interaction`).
* Integrated interaction logging into `message_auto_reply` to record bot responses.
* Implemented a `reaction_added` event handler to capture 👍/👎 reactions and associate them with stored BotInteraction records.
* Added a channel routing service to support routing users to the appropriate OWASP project channels before generating AI responses.
* Registered the new model in the Django admin interface.
* Updated Slack event registration and supporting modules.
* Extended the `/owasp` command implementation where required.
* Added unit tests covering the new feedback handler, channel router, and message auto-reply integration.
* Added maintainer documentation and a scenario matrix for future development and testing.

### Why

This work establishes the foundation for collecting structured feedback on AI-generated responses, improves routing behavior within the OWASP Slack workspace, and provides the infrastructure needed for future improvements to the NestBot assistant.

### Testing

* Added unit tests for:

  * BotInteraction feedback handling
  * Channel router
  * Message auto-reply integration
* Existing test suite executed for the modified components.

### Related Issue

Closes #908
