### PR TITLE
fix(frontend): ensure consistent mobile spacing below search component

### DIFF
--- a/frontend/src/components/SearchPageLayout.tsx
+++ b/frontend/src/components/SearchPageLayout.tsx
@@ -126,29 +126,31 @@ const SearchPageLayout = ({
             ))}
         </div>
       )}
-      {isLoaded ? (
-        <>
-          <div>
-            {!inlineSort && totalPages !== 0 && (
-              <div className="flex justify-end" data-testid="sort-below">
-                {sortChildren}
-              </div>
+      <div className={`w-full ${filterChildren || (inlineSort && sortChildren) ? '' : 'mt-4 md:mt-0'}`}>
+        {isLoaded ? (
+          <>
+            <div>
+              {!inlineSort && totalPages !== 0 && (
+                <div className="flex justify-end" data-testid="sort-below">
+                  {sortChildren}
+                </div>
+              )}
+              {totalPages === 0 && <div className="text m-4 text-xl dark:text-white">{empty}</div>}
+              {children}
+            </div>
+            {totalPages > 1 && (
+              <Pagination
+                currentPage={currentPage}
+                totalPages={totalPages}
+                onPageChange={onPageChange}
+                isLoaded={isLoaded}
+              />
             )}
-            {totalPages === 0 && <div className="text m-4 text-xl dark:text-white">{empty}</div>}
-            {children}
-          </div>
-          {totalPages > 1 && (
-            <Pagination
-              currentPage={currentPage}
-              totalPages={totalPages}
-              onPageChange={onPageChange}
-              isLoaded={isLoaded}
-            />
-          )}
-        </>
-      ) : (
-        <SkeletonBase indexName={indexName} loadingImageUrl={loadingImageUrl} />
-      )}
+          </>
+        ) : (
+          <SkeletonBase indexName={indexName} loadingImageUrl={loadingImageUrl} />
+        )}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
Resolves #5148

## Summary

The bottom spacing below the Search component on mobile viewports is currently inconsistent across Nest pages. Pages with mobile filters/sorting controls (like Chapters) have adequate spacing (due to the mobile controls block bottom margin), whereas pages without these controls (like Projects and Members) have no vertical spacing, causing the content (or SortBy dropdown) to render directly against the bottom edge of the search bar.

This PR wraps the results and skeleton rendering blocks inside a wrapper container with conditional top margins, ensuring a consistent `16px` (`mt-4`) vertical spacing below the search component across all pages on mobile viewports.

---

## What Changed

### Spacing Normalization
- Wrapped the results and skeleton section in a container `div` with class ``w-full ${filterChildren || (inlineSort && sortChildren) ? '' : 'mt-4 md:mt-0'}``.
- On mobile:
  - If mobile controls are present (e.g. Chapters), the results container has no extra margin (spacing is managed by the mobile controls block's `mb-4`).
  - If mobile controls are not present (e.g. Projects, Members, Committees), the results container receives `mt-4` (16px), providing consistent spacing below the SearchBar.
- On desktop:
  - The results container receives `mt-0` (0px), preserving the original desktop layout and spacing.

---

## Files Changed

| File | Change |
|------|--------|
| `frontend/src/components/SearchPageLayout.tsx` | Wrap results and skeletons in a `div` with conditional margin based on mobile controls presence |

---

## Verification Plan

### Automated Tests
- Ran frontend unit tests for SearchPageLayout:
  `pnpm run test:unit __tests__/unit/components/SearchPageLayout.test.tsx`
  - All 30 unit tests passed successfully.
- Verified TypeScript compilation:
  `pnpm run test:unit` (typecheck phase) / `pnpm exec tsc --noEmit`
  - Compilation succeeded with zero type errors.

---

## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran all required checks and tests locally; all warnings addressed and failures resolved
