### PR TITLE
feat(o11y): add RQ worker custom metrics

### DIFF
--- a/backend/src/apps/observability/metrics.py
+++ b/backend/src/apps/observability/metrics.py
@@ -1,0 +1,44 @@
+"""Reusable Otel metrics for background jobs."""
+
+import functools
+import time
+
+from opentelemetry import metrics
+
+_meter = metrics.get_meter("nest.jobs")
+_job_runs = _meter.create_counter(
+    "nest.job.runs",
+    description="Number of background job executions by status.",
+)
+_job_duration = _meter.create_histogram(
+    "nest.job.duration",
+    unit="s",
+    description="Background job execution duration in seconds.",
+)
+
+
+def track_job(name, queue="default"):
+    """Record run count and duration metrics for a background job.
+
+    Wraps a callable so each execution increments ``nest.job.runs`` (labelled by
+    job, queue and status) and records ``nest.job.duration``. The wrapped
+    exception, if any, still propagates.
+    """
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            start = time.perf_counter()
+            status = "failure"
+            try:
+                result = func(*args, **kwargs)
+                status = "success"
+            finally:
+                attributes = {"job": name, "queue": queue}
+                _job_runs.add(1, {**attributes, "status": status})
+                _job_duration.record(time.perf_counter() - start, attributes)
+            return result
+
+        return wrapper
+
+    return decorator

--- a/backend/src/apps/slack/services/message_auto_reply.py
+++ b/backend/src/apps/slack/services/message_auto_reply.py
@@ -5,6 +5,7 @@ import logging
 from django_rq import job
 from slack_sdk.errors import SlackApiError
 
+from apps.observability.metrics import track_job
 from apps.slack.apps import SlackConfig
 from apps.slack.common.handlers.ai import get_blocks, process_ai_query
 from apps.slack.models import Message
@@ -13,6 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 @job("ai")
+@track_job("generate_ai_reply", queue="ai")
 def generate_ai_reply_if_unanswered(message_id: int):
     """Check if a message is still unanswered and generate AI reply."""
     try:

--- a/backend/tests/unit/apps/observability/metrics_test.py
+++ b/backend/tests/unit/apps/observability/metrics_test.py
@@ -1,0 +1,64 @@
+"""Tests for the track_job metrics helper."""
+
+import pytest
+
+from apps.observability.metrics import track_job
+
+METRICS_PATH = "apps.observability.metrics"
+
+
+class TestTrackJob:
+    def test_records_success(self, mocker):
+        runs = mocker.patch(f"{METRICS_PATH}._job_runs")
+        duration = mocker.patch(f"{METRICS_PATH}._job_duration")
+
+        @track_job("generate_ai_reply", queue="ai")
+        def do_work(value):
+            return value * 2
+
+        result = do_work(5)
+
+        assert result == 10
+        runs.add.assert_called_once_with(
+            1, {"job": "generate_ai_reply", "queue": "ai", "status": "success"}
+        )
+        assert duration.record.call_args.args[1] == {"job": "generate_ai_reply", "queue": "ai"}
+
+    def test_records_failure_and_reraises(self, mocker):
+        runs = mocker.patch(f"{METRICS_PATH}._job_runs")
+        duration = mocker.patch(f"{METRICS_PATH}._job_duration")
+
+        @track_job("generate_ai_reply", queue="ai")
+        def do_work():
+            message = "boom"
+            raise ValueError(message)
+
+        with pytest.raises(ValueError, match="boom"):
+            do_work()
+
+        runs.add.assert_called_once_with(
+            1, {"job": "generate_ai_reply", "queue": "ai", "status": "failure"}
+        )
+        duration.record.assert_called_once()
+
+    def test_defaults_to_default_queue(self, mocker):
+        runs = mocker.patch(f"{METRICS_PATH}._job_runs")
+        mocker.patch(f"{METRICS_PATH}._job_duration")
+
+        @track_job("some_job")
+        def do_work():
+            return None
+
+        do_work()
+
+        runs.add.assert_called_once_with(
+            1, {"job": "some_job", "queue": "default", "status": "success"}
+        )
+
+    def test_preserves_wrapped_function_metadata(self):
+        @track_job("some_job")
+        def do_work():
+            """Do some work."""
+
+        assert do_work.__name__ == "do_work"
+        assert do_work.__doc__ == "Do some work."

--- a/backend/tests/unit/apps/observability/metrics_test.py
+++ b/backend/tests/unit/apps/observability/metrics_test.py
@@ -24,7 +24,7 @@ class TestTrackJob:
         )
         assert duration.record.call_args.args[1] == {"job": "generate_ai_reply", "queue": "ai"}
 
-    def test_records_failure_and_reraises(self, mocker):
+    def test_records_failure_and_propagates_exception(self, mocker):
         runs = mocker.patch(f"{METRICS_PATH}._job_runs")
         duration = mocker.patch(f"{METRICS_PATH}._job_duration")
 

--- a/backend/tests/unit/apps/observability/metrics_test.py
+++ b/backend/tests/unit/apps/observability/metrics_test.py
@@ -40,6 +40,7 @@ class TestTrackJob:
             1, {"job": "generate_ai_reply", "queue": "ai", "status": "failure"}
         )
         duration.record.assert_called_once()
+        assert duration.record.call_args.args[1] == {"job": "generate_ai_reply", "queue": "ai"}
 
     def test_defaults_to_default_queue(self, mocker):
         runs = mocker.patch(f"{METRICS_PATH}._job_runs")

--- a/docker-compose/local/compose.o11y.yaml
+++ b/docker-compose/local/compose.o11y.yaml
@@ -13,7 +13,6 @@ services:
       - OTEL_SERVICE_NAME=nest-frontend
 
   worker:
-    # Info ------ need to confirm this approach...
     # RQ's default worker forks a process per job, and metrics recorded in that
     # short-lived child are never exported (the exporter lives in the parent).
     # SimpleWorker runs jobs in the main process so job metrics are collected.

--- a/docker-compose/local/compose.o11y.yaml
+++ b/docker-compose/local/compose.o11y.yaml
@@ -14,7 +14,6 @@ services:
 
   worker:
     # Info ------ need to confirm this approach...
-    
     # RQ's default worker forks a process per job, and metrics recorded in that
     # short-lived child are never exported (the exporter lives in the parent).
     # SimpleWorker runs jobs in the main process so job metrics are collected.
@@ -22,6 +21,9 @@ services:
       sh -c '
         python manage.py rqworker ai --with-scheduler --worker-class rq.SimpleWorker
       '
+    depends_on:
+      o11y-metrics:
+        condition: service_healthy
     environment:
       - DJANGO_OTEL_METRICS_ENABLED=true
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://o11y-metrics:8428/opentelemetry

--- a/docker-compose/local/compose.o11y.yaml
+++ b/docker-compose/local/compose.o11y.yaml
@@ -12,6 +12,22 @@ services:
       - OTEL_METRIC_EXPORT_INTERVAL=15000
       - OTEL_SERVICE_NAME=nest-frontend
 
+  worker:
+    # Info ------ need to confirm this approach...
+    
+    # RQ's default worker forks a process per job, and metrics recorded in that
+    # short-lived child are never exported (the exporter lives in the parent).
+    # SimpleWorker runs jobs in the main process so job metrics are collected.
+    command: >
+      sh -c '
+        python manage.py rqworker ai --with-scheduler --worker-class rq.SimpleWorker
+      '
+    environment:
+      - DJANGO_OTEL_METRICS_ENABLED=true
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://o11y-metrics:8428/opentelemetry
+      - OTEL_METRIC_EXPORT_INTERVAL=15000
+      - OTEL_SERVICE_NAME=nest-worker
+
   o11y-metrics:
     container_name: nest-o11y-metrics
     command:


### PR DESCRIPTION
## Proposed change

<!-- Don't forget to link your PR to an existing issue.-->
Resolves #5203 

<!-- Describe the big picture of your changes.-->
## Proposed change

Resolves #5203

- Adds a reusable `track_job` decorator recording `nest.job.runs` and `nest.job.duration` for background jobs.
- Applies it to `generate_ai_reply_if_unanswered` on the `ai` queue.
- Wires OTEL env vars for the `worker` service in `compose.o11y.yaml` so job metrics reach VM.
- Overrides the worker to `rq.SimpleWorker` locally: RQ's default worker forks per job, and the exporter thread does   not survive `fork()`, so metrics recorded in the work-horse child are never flushed.
- Unit tested and verified locally
<img width="1508" height="825" alt="image" src="https://github.com/user-attachments/assets/0c668b24-1eb4-46cd-bceb-0c26daf84625" />

## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran all required checks and tests locally; all warnings addressed and failures resolved
- [x] I used AI for code, documentation, tests, or communication related to this PR
