### PR TITLE
Optimize entity_leaders and entity_channels in ChapterNode

### DIFF
--- a/backend/src/apps/owasp/api/internal/dataloaders/__init__.py
+++ b/backend/src/apps/owasp/api/internal/dataloaders/__init__.py
@@ -3,6 +3,7 @@
 from apps.owasp.api.internal.dataloaders.board_of_directors import (
     get_board_of_directors_loaders,
 )
+from apps.owasp.api.internal.dataloaders.chapter import get_chapter_loaders
 from apps.owasp.api.internal.dataloaders.project import get_project_loaders
 
 
@@ -10,5 +11,6 @@ def get_owasp_dataloaders() -> dict[str, object]:
     """Return a dict of dataloader instances for OWASP API resolvers."""
     loaders: dict[str, object] = {}
     loaders.update(get_board_of_directors_loaders())
+    loaders.update(get_chapter_loaders())
     loaders.update(get_project_loaders())
     return loaders

--- a/backend/src/apps/owasp/api/internal/dataloaders/chapter.py
+++ b/backend/src/apps/owasp/api/internal/dataloaders/chapter.py
@@ -1,0 +1,56 @@
+"""DataLoaders for chapters."""
+
+from asgiref.sync import sync_to_async
+from django.contrib.contenttypes.models import ContentType
+from strawberry.dataloader import DataLoader
+
+from apps.common.api.internal.dataloaders.utils import get_results_by_keys
+from apps.owasp.models.chapter import Chapter
+from apps.owasp.models.entity_channel import EntityChannel
+from apps.owasp.models.entity_member import EntityMember
+
+ENTITY_CHANNELS_BY_CHAPTER_ID_LOADER = "entity_channels_by_chapter_id"
+ENTITY_LEADERS_BY_CHAPTER_ID_LOADER = "entity_leaders_by_chapter_id"
+
+
+async def load_entity_channels_by_chapter_id(
+    chapter_ids: list[int],
+) -> list[list[EntityChannel]]:
+    """Batch-load entity channels for the given chapter IDs in a single query."""
+    chapter_content_type = await sync_to_async(ContentType.objects.get_for_model)(Chapter)
+    channels = EntityChannel.objects.filter(
+        entity_type=chapter_content_type,
+        entity_id__in=chapter_ids,
+        is_active=True,
+        is_reviewed=True,
+    )
+    return await get_results_by_keys(channels, chapter_ids, key_field="entity_id")
+
+
+async def load_entity_leaders_by_chapter_id(
+    chapter_ids: list[int],
+) -> list[list[EntityMember]]:
+    """Batch-load entity leaders for the given chapter IDs in a single query."""
+    chapter_content_type = await sync_to_async(ContentType.objects.get_for_model)(Chapter)
+    leaders = (
+        EntityMember.objects.select_related("member")
+        .filter(
+            entity_type=chapter_content_type,
+            entity_id__in=chapter_ids,
+            role=EntityMember.Role.LEADER,
+        )
+        .order_by("order")
+    )
+    return await get_results_by_keys(leaders, chapter_ids, key_field="entity_id")
+
+
+def get_chapter_loaders() -> dict[str, object]:
+    """Return a mapping of per-request DataLoader instances."""
+    return {
+        ENTITY_CHANNELS_BY_CHAPTER_ID_LOADER: DataLoader[int, list[EntityChannel]](
+            load_fn=load_entity_channels_by_chapter_id,
+        ),
+        ENTITY_LEADERS_BY_CHAPTER_ID_LOADER: DataLoader[int, list[EntityMember]](
+            load_fn=load_entity_leaders_by_chapter_id,
+        ),
+    }

--- a/backend/src/apps/owasp/api/internal/dataloaders/chapter.py
+++ b/backend/src/apps/owasp/api/internal/dataloaders/chapter.py
@@ -38,6 +38,8 @@ async def load_entity_leaders_by_chapter_id(
             entity_type=chapter_content_type,
             entity_id__in=chapter_ids,
             role=EntityMember.Role.LEADER,
+            is_active=True,
+            is_reviewed=True,
         )
         .order_by("order")
     )

--- a/backend/src/apps/owasp/api/internal/nodes/chapter.py
+++ b/backend/src/apps/owasp/api/internal/nodes/chapter.py
@@ -4,7 +4,13 @@ import strawberry
 import strawberry_django
 
 from apps.core.utils.index import deep_camelize
+from apps.owasp.api.internal.dataloaders.chapter import (
+    ENTITY_CHANNELS_BY_CHAPTER_ID_LOADER,
+    ENTITY_LEADERS_BY_CHAPTER_ID_LOADER,
+)
 from apps.owasp.api.internal.nodes.common import GenericEntityNode
+from apps.owasp.api.internal.nodes.entity_channel import EntityChannelNode
+from apps.owasp.api.internal.nodes.entity_member import EntityMemberNode
 from apps.owasp.models.chapter import Chapter
 
 
@@ -52,6 +58,22 @@ class ChapterNode(GenericEntityNode):
             GeoLocationType(lat=root.latitude, lng=root.longitude)
             if root.latitude is not None and root.longitude is not None
             else None
+        )
+
+    @strawberry_django.field
+    async def entity_channels(
+        self, root: Chapter, info: strawberry.Info
+    ) -> list[EntityChannelNode]:
+        """Resolve entity channels."""
+        return await info.context.owasp_dataloaders[ENTITY_CHANNELS_BY_CHAPTER_ID_LOADER].load(
+            root.pk
+        )
+
+    @strawberry_django.field
+    async def entity_leaders(self, root: Chapter, info: strawberry.Info) -> list[EntityMemberNode]:
+        """Resolve entity leaders."""
+        return await info.context.owasp_dataloaders[ENTITY_LEADERS_BY_CHAPTER_ID_LOADER].load(
+            root.pk
         )
 
     @strawberry_django.field(only=["key"])

--- a/backend/tests/unit/apps/owasp/api/internal/dataloaders/chapter_test.py
+++ b/backend/tests/unit/apps/owasp/api/internal/dataloaders/chapter_test.py
@@ -1,0 +1,416 @@
+"""Tests for the chapter dataloaders."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from strawberry.dataloader import DataLoader
+
+from apps.owasp.api.internal.dataloaders.chapter import (
+    ENTITY_CHANNELS_BY_CHAPTER_ID_LOADER,
+    ENTITY_LEADERS_BY_CHAPTER_ID_LOADER,
+    Chapter,
+    get_chapter_loaders,
+    load_entity_channels_by_chapter_id,
+    load_entity_leaders_by_chapter_id,
+)
+
+
+async def _async_return(value):
+    return value
+
+
+def _fake_sync_to_async(fn):
+    return lambda *args, **kwargs: _async_return(fn(*args, **kwargs))
+
+
+class TestLoadEntityChannelsByChapterId:
+    """Tests for load_entity_channels_by_chapter_id."""
+
+    @patch(
+        "apps.owasp.api.internal.dataloaders.chapter.get_results_by_keys",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "apps.owasp.api.internal.dataloaders.chapter.sync_to_async",
+        new=_fake_sync_to_async,
+    )
+    @patch("apps.owasp.api.internal.dataloaders.chapter.ContentType")
+    @patch("apps.owasp.api.internal.dataloaders.chapter.EntityChannel")
+    @pytest.mark.asyncio
+    async def test_builds_queryset_with_correct_filter(
+        self, mock_entity_channel, mock_content_type, mock_get_results_by_keys
+    ):
+        """Queryset is built with the correct filter arguments."""
+        chapter_ids = [1, 2, 3]
+        mock_content_type_obj = MagicMock()
+        mock_content_type.objects.get_for_model.return_value = mock_content_type_obj
+        mock_queryset = MagicMock()
+        mock_entity_channel.objects.filter.return_value = mock_queryset
+        mock_get_results_by_keys.return_value = [[], [], []]
+
+        await load_entity_channels_by_chapter_id(chapter_ids)
+
+        mock_entity_channel.objects.filter.assert_called_once_with(
+            entity_type=mock_content_type_obj,
+            entity_id__in=chapter_ids,
+            is_active=True,
+            is_reviewed=True,
+        )
+
+    @patch(
+        "apps.owasp.api.internal.dataloaders.chapter.get_results_by_keys",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "apps.owasp.api.internal.dataloaders.chapter.sync_to_async",
+        new=_fake_sync_to_async,
+    )
+    @patch("apps.owasp.api.internal.dataloaders.chapter.ContentType")
+    @patch("apps.owasp.api.internal.dataloaders.chapter.EntityChannel")
+    @pytest.mark.asyncio
+    async def test_delegates_to_get_results_by_keys_correct_args(
+        self, mock_entity_channel, mock_content_type, mock_get_results_by_keys
+    ):
+        """get_results_by_keys receives the queryset, chapter_ids, and correct key_field."""
+        chapter_ids = [10, 20]
+        mock_content_type.objects.get_for_model.return_value = MagicMock()
+        mock_queryset = MagicMock()
+        mock_entity_channel.objects.filter.return_value = mock_queryset
+        mock_get_results_by_keys.return_value = [[], []]
+
+        await load_entity_channels_by_chapter_id(chapter_ids)
+
+        mock_get_results_by_keys.assert_called_once_with(
+            mock_queryset, chapter_ids, key_field="entity_id"
+        )
+
+    @patch(
+        "apps.owasp.api.internal.dataloaders.chapter.get_results_by_keys",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "apps.owasp.api.internal.dataloaders.chapter.sync_to_async",
+        new=_fake_sync_to_async,
+    )
+    @patch("apps.owasp.api.internal.dataloaders.chapter.ContentType")
+    @patch("apps.owasp.api.internal.dataloaders.chapter.EntityChannel")
+    @pytest.mark.asyncio
+    async def test_returns_result_from_get_results_by_keys(
+        self, mock_entity_channel, mock_content_type, mock_get_results_by_keys
+    ):
+        """The return value is exactly what get_results_by_keys resolves to."""
+        mock_channel_a = MagicMock()
+        mock_channel_b = MagicMock()
+        expected = [[mock_channel_a, mock_channel_b], [], [mock_channel_a]]
+        mock_content_type.objects.get_for_model.return_value = MagicMock()
+        mock_entity_channel.objects.filter.return_value = MagicMock()
+        mock_get_results_by_keys.return_value = expected
+
+        result = await load_entity_channels_by_chapter_id([1, 2, 3])
+
+        assert result is expected
+
+    @patch(
+        "apps.owasp.api.internal.dataloaders.chapter.get_results_by_keys",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "apps.owasp.api.internal.dataloaders.chapter.sync_to_async",
+        new=_fake_sync_to_async,
+    )
+    @patch("apps.owasp.api.internal.dataloaders.chapter.ContentType")
+    @patch("apps.owasp.api.internal.dataloaders.chapter.EntityChannel")
+    @pytest.mark.asyncio
+    async def test_empty_chapter_ids(
+        self, mock_entity_channel, mock_content_type, mock_get_results_by_keys
+    ):
+        """An empty chapter_ids list results in an empty filter and empty return."""
+        mock_content_type.objects.get_for_model.return_value = MagicMock()
+        mock_entity_channel.objects.filter.return_value = MagicMock()
+        mock_get_results_by_keys.return_value = []
+
+        result = await load_entity_channels_by_chapter_id([])
+
+        mock_entity_channel.objects.filter.assert_called_once_with(
+            entity_type=mock_content_type.objects.get_for_model.return_value,
+            entity_id__in=[],
+            is_active=True,
+            is_reviewed=True,
+        )
+        assert result == []
+
+    @patch(
+        "apps.owasp.api.internal.dataloaders.chapter.get_results_by_keys",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "apps.owasp.api.internal.dataloaders.chapter.sync_to_async",
+        new=_fake_sync_to_async,
+    )
+    @patch("apps.owasp.api.internal.dataloaders.chapter.ContentType")
+    @patch("apps.owasp.api.internal.dataloaders.chapter.EntityChannel")
+    @pytest.mark.asyncio
+    async def test_single_chapter_id(
+        self, mock_entity_channel, mock_content_type, mock_get_results_by_keys
+    ):
+        """A single-element list is handled correctly end-to-end."""
+        mock_channel = MagicMock()
+        mock_content_type.objects.get_for_model.return_value = MagicMock()
+        mock_entity_channel.objects.filter.return_value = MagicMock()
+        mock_get_results_by_keys.return_value = [[mock_channel]]
+
+        result = await load_entity_channels_by_chapter_id([42])
+
+        mock_entity_channel.objects.filter.assert_called_once_with(
+            entity_type=mock_content_type.objects.get_for_model.return_value,
+            entity_id__in=[42],
+            is_active=True,
+            is_reviewed=True,
+        )
+        assert result == [[mock_channel]]
+
+    @patch(
+        "apps.owasp.api.internal.dataloaders.chapter.get_results_by_keys",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "apps.owasp.api.internal.dataloaders.chapter.sync_to_async",
+        new=_fake_sync_to_async,
+    )
+    @patch("apps.owasp.api.internal.dataloaders.chapter.ContentType")
+    @patch("apps.owasp.api.internal.dataloaders.chapter.EntityChannel")
+    @pytest.mark.asyncio
+    async def test_uses_chapter_content_type(
+        self, mock_entity_channel, mock_content_type, mock_get_results_by_keys
+    ):
+        """ContentType.objects.get_for_model is called with Chapter."""
+        mock_content_type.objects.get_for_model.return_value = MagicMock()
+        mock_entity_channel.objects.filter.return_value = MagicMock()
+        mock_get_results_by_keys.return_value = [[]]
+
+        await load_entity_channels_by_chapter_id([1])
+
+        mock_content_type.objects.get_for_model.assert_called_once_with(Chapter)
+
+
+class TestLoadEntityLeadersByChapterId:
+    """Tests for load_entity_leaders_by_chapter_id."""
+
+    @patch(
+        "apps.owasp.api.internal.dataloaders.chapter.get_results_by_keys",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "apps.owasp.api.internal.dataloaders.chapter.sync_to_async",
+        new=_fake_sync_to_async,
+    )
+    @patch("apps.owasp.api.internal.dataloaders.chapter.ContentType")
+    @patch("apps.owasp.api.internal.dataloaders.chapter.EntityMember")
+    @pytest.mark.asyncio
+    async def test_builds_queryset_with_correct_chain(
+        self, mock_entity_member, mock_content_type, mock_get_results_by_keys
+    ):
+        """Queryset is built with select_related, filter, and order_by in the right order."""
+        chapter_ids = [1, 2, 3]
+        mock_content_type_obj = MagicMock()
+        mock_content_type.objects.get_for_model.return_value = mock_content_type_obj
+        mock_queryset = MagicMock()
+        mock_filter = mock_entity_member.objects.select_related.return_value.filter
+        mock_filter.return_value.order_by.return_value = mock_queryset
+        mock_get_results_by_keys.return_value = [[], [], []]
+
+        await load_entity_leaders_by_chapter_id(chapter_ids)
+
+        mock_entity_member.objects.select_related.assert_called_once_with("member")
+        mock_filter.assert_called_once_with(
+            entity_type=mock_content_type_obj,
+            entity_id__in=chapter_ids,
+            role=mock_entity_member.Role.LEADER,
+            is_active=True,
+            is_reviewed=True,
+        )
+        mock_filter.return_value.order_by.assert_called_once_with("order")
+
+    @patch(
+        "apps.owasp.api.internal.dataloaders.chapter.get_results_by_keys",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "apps.owasp.api.internal.dataloaders.chapter.sync_to_async",
+        new=_fake_sync_to_async,
+    )
+    @patch("apps.owasp.api.internal.dataloaders.chapter.ContentType")
+    @patch("apps.owasp.api.internal.dataloaders.chapter.EntityMember")
+    @pytest.mark.asyncio
+    async def test_delegates_to_get_results_by_keys_correct_args(
+        self, mock_entity_member, mock_content_type, mock_get_results_by_keys
+    ):
+        """get_results_by_keys receives the queryset, chapter_ids, and correct key_field."""
+        chapter_ids = [10, 20]
+        mock_content_type.objects.get_for_model.return_value = MagicMock()
+        mock_queryset = MagicMock()
+        mock_filter = mock_entity_member.objects.select_related.return_value.filter
+        mock_filter.return_value.order_by.return_value = mock_queryset
+        mock_get_results_by_keys.return_value = [[], []]
+
+        await load_entity_leaders_by_chapter_id(chapter_ids)
+
+        mock_get_results_by_keys.assert_called_once_with(
+            mock_queryset, chapter_ids, key_field="entity_id"
+        )
+
+    @patch(
+        "apps.owasp.api.internal.dataloaders.chapter.get_results_by_keys",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "apps.owasp.api.internal.dataloaders.chapter.sync_to_async",
+        new=_fake_sync_to_async,
+    )
+    @patch("apps.owasp.api.internal.dataloaders.chapter.ContentType")
+    @patch("apps.owasp.api.internal.dataloaders.chapter.EntityMember")
+    @pytest.mark.asyncio
+    async def test_returns_result_from_get_results_by_keys(
+        self, mock_entity_member, mock_content_type, mock_get_results_by_keys
+    ):
+        """The return value is exactly what get_results_by_keys resolves to."""
+        mock_leader_a = MagicMock()
+        mock_leader_b = MagicMock()
+        expected = [[mock_leader_a, mock_leader_b], [], [mock_leader_a]]
+        mock_content_type.objects.get_for_model.return_value = MagicMock()
+        mock_filter = mock_entity_member.objects.select_related.return_value.filter
+        mock_filter.return_value.order_by.return_value = MagicMock()
+        mock_get_results_by_keys.return_value = expected
+
+        result = await load_entity_leaders_by_chapter_id([1, 2, 3])
+
+        assert result is expected
+
+    @patch(
+        "apps.owasp.api.internal.dataloaders.chapter.get_results_by_keys",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "apps.owasp.api.internal.dataloaders.chapter.sync_to_async",
+        new=_fake_sync_to_async,
+    )
+    @patch("apps.owasp.api.internal.dataloaders.chapter.ContentType")
+    @patch("apps.owasp.api.internal.dataloaders.chapter.EntityMember")
+    @pytest.mark.asyncio
+    async def test_empty_chapter_ids(
+        self, mock_entity_member, mock_content_type, mock_get_results_by_keys
+    ):
+        """An empty chapter_ids list results in an empty filter and empty return."""
+        mock_content_type.objects.get_for_model.return_value = MagicMock()
+        mock_filter = mock_entity_member.objects.select_related.return_value.filter
+        mock_filter.return_value.order_by.return_value = MagicMock()
+        mock_get_results_by_keys.return_value = []
+
+        result = await load_entity_leaders_by_chapter_id([])
+
+        mock_filter.assert_called_once_with(
+            entity_type=mock_content_type.objects.get_for_model.return_value,
+            entity_id__in=[],
+            role=mock_entity_member.Role.LEADER,
+            is_active=True,
+            is_reviewed=True,
+        )
+        assert result == []
+
+    @patch(
+        "apps.owasp.api.internal.dataloaders.chapter.get_results_by_keys",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "apps.owasp.api.internal.dataloaders.chapter.sync_to_async",
+        new=_fake_sync_to_async,
+    )
+    @patch("apps.owasp.api.internal.dataloaders.chapter.ContentType")
+    @patch("apps.owasp.api.internal.dataloaders.chapter.EntityMember")
+    @pytest.mark.asyncio
+    async def test_single_chapter_id(
+        self, mock_entity_member, mock_content_type, mock_get_results_by_keys
+    ):
+        """A single-element list is handled correctly end-to-end."""
+        mock_leader = MagicMock()
+        mock_content_type.objects.get_for_model.return_value = MagicMock()
+        mock_filter = mock_entity_member.objects.select_related.return_value.filter
+        mock_filter.return_value.order_by.return_value = MagicMock()
+        mock_get_results_by_keys.return_value = [[mock_leader]]
+
+        result = await load_entity_leaders_by_chapter_id([42])
+
+        mock_filter.assert_called_once_with(
+            entity_type=mock_content_type.objects.get_for_model.return_value,
+            entity_id__in=[42],
+            role=mock_entity_member.Role.LEADER,
+            is_active=True,
+            is_reviewed=True,
+        )
+        assert result == [[mock_leader]]
+
+    @patch(
+        "apps.owasp.api.internal.dataloaders.chapter.get_results_by_keys",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "apps.owasp.api.internal.dataloaders.chapter.sync_to_async",
+        new=_fake_sync_to_async,
+    )
+    @patch("apps.owasp.api.internal.dataloaders.chapter.ContentType")
+    @patch("apps.owasp.api.internal.dataloaders.chapter.EntityMember")
+    @pytest.mark.asyncio
+    async def test_uses_chapter_content_type(
+        self, mock_entity_member, mock_content_type, mock_get_results_by_keys
+    ):
+        """ContentType.objects.get_for_model is called with Chapter."""
+        mock_content_type.objects.get_for_model.return_value = MagicMock()
+        mock_filter = mock_entity_member.objects.select_related.return_value.filter
+        mock_filter.return_value.order_by.return_value = MagicMock()
+        mock_get_results_by_keys.return_value = [[]]
+
+        await load_entity_leaders_by_chapter_id([1])
+
+        mock_content_type.objects.get_for_model.assert_called_once_with(Chapter)
+
+
+class TestGetChapterLoaders:
+    """Tests for get_chapter_loaders."""
+
+    def test_returns_mapping(self):
+        """Factory always returns a Mapping with both loaders."""
+        loaders = get_chapter_loaders()
+        assert ENTITY_CHANNELS_BY_CHAPTER_ID_LOADER in loaders
+        assert ENTITY_LEADERS_BY_CHAPTER_ID_LOADER in loaders
+        assert isinstance(loaders[ENTITY_CHANNELS_BY_CHAPTER_ID_LOADER], DataLoader)
+        assert isinstance(loaders[ENTITY_LEADERS_BY_CHAPTER_ID_LOADER], DataLoader)
+
+    def test_returns_new_instances_on_each_call(self):
+        """Each call produces distinct DataLoader instances for per-request isolation."""
+        loaders1 = get_chapter_loaders()
+        loaders2 = get_chapter_loaders()
+        assert loaders1 is not loaders2
+        assert (
+            loaders1[ENTITY_CHANNELS_BY_CHAPTER_ID_LOADER]
+            is not loaders2[ENTITY_CHANNELS_BY_CHAPTER_ID_LOADER]
+        )
+        assert (
+            loaders1[ENTITY_LEADERS_BY_CHAPTER_ID_LOADER]
+            is not loaders2[ENTITY_LEADERS_BY_CHAPTER_ID_LOADER]
+        )
+
+    def test_entity_channels_load_fn_is_load_entity_channels_by_chapter_id(self):
+        """The channels DataLoader is wired to load_entity_channels_by_chapter_id."""
+        loaders = get_chapter_loaders()
+        assert (
+            loaders[ENTITY_CHANNELS_BY_CHAPTER_ID_LOADER].load_fn
+            is load_entity_channels_by_chapter_id
+        )
+
+    def test_entity_leaders_load_fn_is_load_entity_leaders_by_chapter_id(self):
+        """The leaders DataLoader is wired to load_entity_leaders_by_chapter_id."""
+        loaders = get_chapter_loaders()
+        assert (
+            loaders[ENTITY_LEADERS_BY_CHAPTER_ID_LOADER].load_fn
+            is load_entity_leaders_by_chapter_id
+        )

--- a/backend/tests/unit/apps/owasp/api/internal/nodes/chapter_test.py
+++ b/backend/tests/unit/apps/owasp/api/internal/nodes/chapter_test.py
@@ -1,9 +1,17 @@
 """Test cases for ChapterNode."""
 
 import math
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, MagicMock, Mock
 
+import pytest
+import strawberry
+
+from apps.owasp.api.internal.dataloaders.chapter import (
+    ENTITY_CHANNELS_BY_CHAPTER_ID_LOADER,
+    ENTITY_LEADERS_BY_CHAPTER_ID_LOADER,
+)
 from apps.owasp.api.internal.nodes.chapter import ChapterNode, GeoLocationType
+from apps.owasp.models.chapter import Chapter
 from tests.unit.apps.common.graphql_node_base_test import GraphQLNodeBaseTest
 
 
@@ -149,3 +157,45 @@ class TestChapterNode(GraphQLNodeBaseTest):
         result = field.base_resolver.wrapped_func(None, mock_chapter)
 
         assert result is None
+
+    def test_meta_configuration_includes_entity_fields(self):
+        """ChapterNode exposes the entity_channels and entity_leaders fields."""
+        field_names = {field.name for field in ChapterNode.__strawberry_definition__.fields}
+        assert "entity_channels" in field_names
+        assert "entity_leaders" in field_names
+
+    @pytest.mark.asyncio
+    async def test_entity_channels_resolver_uses_dataloader(self):
+        """Test entity_channels resolver delegates to the entity_channels dataloader."""
+        mock_chapter = MagicMock(spec=Chapter)
+        mock_channel1 = MagicMock()
+        mock_channel2 = MagicMock()
+
+        field = self._get_field_by_name("entity_channels", ChapterNode)
+        info = MagicMock(spec=strawberry.Info)
+        mock_dataloader = AsyncMock()
+        mock_dataloader.load = AsyncMock(return_value=[mock_channel1, mock_channel2])
+        info.context.owasp_dataloaders = {ENTITY_CHANNELS_BY_CHAPTER_ID_LOADER: mock_dataloader}
+
+        result = await field.base_resolver.wrapped_func(mock_chapter, mock_chapter, info)
+
+        mock_dataloader.load.assert_called_once_with(mock_chapter.pk)
+        assert result == [mock_channel1, mock_channel2]
+
+    @pytest.mark.asyncio
+    async def test_entity_leaders_resolver_uses_dataloader(self):
+        """Test entity_leaders resolver delegates to the entity_leaders dataloader."""
+        mock_chapter = MagicMock(spec=Chapter)
+        mock_leader1 = MagicMock()
+        mock_leader2 = MagicMock()
+
+        field = self._get_field_by_name("entity_leaders", ChapterNode)
+        info = MagicMock(spec=strawberry.Info)
+        mock_dataloader = AsyncMock()
+        mock_dataloader.load = AsyncMock(return_value=[mock_leader1, mock_leader2])
+        info.context.owasp_dataloaders = {ENTITY_LEADERS_BY_CHAPTER_ID_LOADER: mock_dataloader}
+
+        result = await field.base_resolver.wrapped_func(mock_chapter, mock_chapter, info)
+
+        mock_dataloader.load.assert_called_once_with(mock_chapter.pk)
+        assert result == [mock_leader1, mock_leader2]


### PR DESCRIPTION
## Proposed change

<!-- Don't forget to link your PR to an existing issue.-->
Resolves #5243

<!-- Describe the big picture of your changes.-->
- Optimized entity_leaders and entity_channels in ChapterNode
- Reduced Response time from 1.7s to 0.3s
- Reduced DB operations from 600+ to 10

### PoC

https://github.com/user-attachments/assets/99fd000d-c3d5-4f05-b57b-9defd5a7a70a

### Tested Query
```graphql
{
  recentChapters(limit: 1000) {
    id
    entityLeaders {
      id
    }
    entityChannels {
      id
    }
  }
}
```
## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran all required checks and tests locally; all warnings addressed and failures resolved
- [x] I used AI for code, documentation, tests, or communication related to this PR
