### PR TITLE
bump immutable from 5.1.6 to 5.1.8

### DIFF
--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   dompurify: 3.4.11
   fast-uri: 3.1.2
   glob: 11.1.0
+  immutable@5: 5.1.8
   js-yaml: 4.2.0
   postcss: 8.5.10
   protobufjs: 7.6.4
@@ -4915,8 +4916,8 @@ packages:
   immediate@3.0.6:
     resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
 
-  immutable@5.1.6:
-    resolution: {integrity: sha512-q1swsS8K7L8usSHuOqF2TAoCCkonYz0SG38wLAggaa4Wml70zixIvt2ql4coQ2C2B3hTjltJry4r6bULwgAXLQ==}
+  immutable@5.1.8:
+    resolution: {integrity: sha512-TM5YqrGeTsVIPPpILzeqZ8D2Zc2TvNgSDi88zPF2a4cyqQdWV/wVWBDRDbNzzrLeRWScrFcOX9lW2iX6GOtUDw==}
 
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
@@ -7105,7 +7106,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.29.7
       graphql: 17.0.1
-      immutable: 5.1.6
+      immutable: 5.1.8
       invariant: 2.2.4
 
   '@asamuzakjp/css-color@3.2.0':
@@ -12800,7 +12801,7 @@ snapshots:
 
   immediate@3.0.6: {}
 
-  immutable@5.1.6: {}
+  immutable@5.1.8: {}
 
   import-fresh@3.3.1:
     dependencies:

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -29,6 +29,7 @@ minimumReleaseAgeExclude:
   - brace-expansion@5.0.7
   - dompurify@3.4.11
   - fast-uri@3.1.2
+  - immutable@5.1.8
   - js-yaml@4.2.0
   - next@16.2.6
   - postcss@8.5.10
@@ -48,6 +49,7 @@ overrides:
   dompurify: 3.4.11
   fast-uri: 3.1.2
   glob: 11.1.0
+  immutable@5: 5.1.8
   js-yaml: 4.2.0
   postcss: 8.5.10
   protobufjs: 7.6.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   brace-expansion@1: 1.1.16
   brace-expansion@5: 5.0.7
+  immutable@5: 5.1.8
 
 importers:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,10 +6,12 @@ minimumReleaseAge: 30240
 minimumReleaseAgeExclude:
   - brace-expansion@1.1.16
   - brace-expansion@5.0.7
+  - immutable@5.1.8
 
 overrides:
   brace-expansion@1: 1.1.16
   brace-expansion@5: 5.0.7
+  immutable@5: 5.1.8
 
 saveExact: true
 


### PR DESCRIPTION
resolves #5288 

## Proposed change
Mitigate Dependabot alert #178
update `immutable` dependency to version `5.1.8`.

## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran all required checks and tests locally; all warnings addressed and failures resolved
- [x] I used AI for code, documentation, tests, or communication related to this PR
