### PR TITLE
Optimize entity channels and entity leaders in ProjectNode

### DIFF
--- a/backend/src/apps/github/api/internal/nodes/repository.py
+++ b/backend/src/apps/github/api/internal/nodes/repository.py
@@ -21,7 +21,7 @@ from apps.github.api.internal.nodes.organization import OrganizationNode
 from apps.github.api.internal.nodes.release import ReleaseNode
 from apps.github.api.internal.nodes.repository_contributor import RepositoryContributorNode
 from apps.github.models.repository import Repository
-from apps.owasp.api.internal.dataloaders.project import PROJECT_BY_REPOSITORY_ID_LOADER
+from apps.owasp.api.internal.dataloaders.project import PROJECT_BY_REPOSITORY_ID
 
 if TYPE_CHECKING:
     from apps.owasp.api.internal.nodes.project import ProjectNode
@@ -79,7 +79,7 @@ class RepositoryNode(strawberry.relay.Node):
         self, root: Repository, info: Info
     ) -> Annotated["ProjectNode", strawberry.lazy("apps.owasp.api.internal.nodes.project")] | None:
         """Resolve project."""
-        return await info.context.owasp_dataloaders[PROJECT_BY_REPOSITORY_ID_LOADER].load(root.pk)
+        return await info.context.owasp_dataloaders[PROJECT_BY_REPOSITORY_ID].load(root.pk)
 
     @strawberry_django.field
     async def recent_milestones(

--- a/backend/src/apps/owasp/api/internal/dataloaders/project.py
+++ b/backend/src/apps/owasp/api/internal/dataloaders/project.py
@@ -1,5 +1,7 @@
 """DataLoaders for projects."""
 
+from asgiref.sync import sync_to_async
+from django.contrib.contenttypes.models import ContentType
 from django.db.models import F, Window
 from django.db.models.functions import RowNumber
 from strawberry.dataloader import DataLoader
@@ -9,12 +11,16 @@ from apps.common.api.internal.dataloaders.utils import (
     get_result_by_keys,
     get_results_by_keys,
 )
+from apps.owasp.models.entity_channel import EntityChannel
+from apps.owasp.models.entity_member import EntityMember
 from apps.owasp.models.project import Project
 from apps.owasp.models.project_health_metrics import ProjectHealthMetrics
 
 PROJECT_BY_REPOSITORY_ID_LOADER = "project_by_repository_id"
 HEALTH_METRICS_LIST_BY_PROJECT_ID = "health_metrics_list_by_project_id"
 HEALTH_METRICS_LATEST_BY_PROJECT_ID = "health_metrics_latest_by_project_id"
+ENTITY_CHANNELS_BY_PROJECT_ID = "entity_channels_by_project_id"
+ENTITY_LEADERS_BY_PROJECT_ID = "entity_leaders_by_project_id"
 
 
 async def load_projects_by_repository_id(
@@ -78,6 +84,39 @@ async def load_health_metrics_latest_by_project_id(
     return await get_result_by_keys(metrics, project_ids, key_field="project_id")
 
 
+async def load_entity_channels_by_project_id(
+    project_ids: list[int],
+) -> list[list[EntityChannel]]:
+    """Batch-load entity channels for the given project IDs in a single query."""
+    project_content_type = await sync_to_async(ContentType.objects.get_for_model)(Project)
+    channels = EntityChannel.objects.filter(
+        entity_type=project_content_type,
+        entity_id__in=project_ids,
+        is_active=True,
+        is_reviewed=True,
+    )
+    return await get_results_by_keys(channels, project_ids, key_field="entity_id")
+
+
+async def load_entity_leaders_by_project_id(
+    project_ids: list[int],
+) -> list[list[EntityMember]]:
+    """Batch-load entity leaders for the given project IDs in a single query."""
+    project_content_type = await sync_to_async(ContentType.objects.get_for_model)(Project)
+    leaders = (
+        EntityMember.objects.select_related("member")
+        .filter(
+            entity_type=project_content_type,
+            entity_id__in=project_ids,
+            role=EntityMember.Role.LEADER,
+            is_active=True,
+            is_reviewed=True,
+        )
+        .order_by("order")
+    )
+    return await get_results_by_keys(leaders, project_ids, key_field="entity_id")
+
+
 def get_project_loaders() -> dict[str, object]:
     """Return a mapping of per-request DataLoader instances."""
     return {
@@ -89,5 +128,11 @@ def get_project_loaders() -> dict[str, object]:
         ),
         HEALTH_METRICS_LATEST_BY_PROJECT_ID: DataLoader[int, ProjectHealthMetrics | None](
             load_fn=load_health_metrics_latest_by_project_id,
+        ),
+        ENTITY_CHANNELS_BY_PROJECT_ID: DataLoader[int, list[EntityChannel]](
+            load_fn=load_entity_channels_by_project_id,
+        ),
+        ENTITY_LEADERS_BY_PROJECT_ID: DataLoader[int, list[EntityMember]](
+            load_fn=load_entity_leaders_by_project_id,
         ),
     }

--- a/backend/src/apps/owasp/api/internal/dataloaders/project.py
+++ b/backend/src/apps/owasp/api/internal/dataloaders/project.py
@@ -16,11 +16,11 @@ from apps.owasp.models.entity_member import EntityMember
 from apps.owasp.models.project import Project
 from apps.owasp.models.project_health_metrics import ProjectHealthMetrics
 
-PROJECT_BY_REPOSITORY_ID_LOADER = "project_by_repository_id"
-HEALTH_METRICS_LIST_BY_PROJECT_ID = "health_metrics_list_by_project_id"
-HEALTH_METRICS_LATEST_BY_PROJECT_ID = "health_metrics_latest_by_project_id"
 ENTITY_CHANNELS_BY_PROJECT_ID = "entity_channels_by_project_id"
 ENTITY_LEADERS_BY_PROJECT_ID = "entity_leaders_by_project_id"
+HEALTH_METRICS_LATEST_BY_PROJECT_ID = "health_metrics_latest_by_project_id"
+HEALTH_METRICS_LIST_BY_PROJECT_ID = "health_metrics_list_by_project_id"
+PROJECT_BY_REPOSITORY_ID = "project_by_repository_id"
 
 
 async def load_projects_by_repository_id(
@@ -120,19 +120,19 @@ async def load_entity_leaders_by_project_id(
 def get_project_loaders() -> dict[str, object]:
     """Return a mapping of per-request DataLoader instances."""
     return {
-        PROJECT_BY_REPOSITORY_ID_LOADER: DataLoader[int, Project | None](
-            load_fn=load_projects_by_repository_id,
-        ),
-        HEALTH_METRICS_LIST_BY_PROJECT_ID: DataLoader[tuple[int, int], list[ProjectHealthMetrics]](
-            load_fn=load_health_metrics_list_by_project_id
-        ),
-        HEALTH_METRICS_LATEST_BY_PROJECT_ID: DataLoader[int, ProjectHealthMetrics | None](
-            load_fn=load_health_metrics_latest_by_project_id,
-        ),
         ENTITY_CHANNELS_BY_PROJECT_ID: DataLoader[int, list[EntityChannel]](
             load_fn=load_entity_channels_by_project_id,
         ),
         ENTITY_LEADERS_BY_PROJECT_ID: DataLoader[int, list[EntityMember]](
             load_fn=load_entity_leaders_by_project_id,
+        ),
+        HEALTH_METRICS_LATEST_BY_PROJECT_ID: DataLoader[int, ProjectHealthMetrics | None](
+            load_fn=load_health_metrics_latest_by_project_id,
+        ),
+        HEALTH_METRICS_LIST_BY_PROJECT_ID: DataLoader[tuple[int, int], list[ProjectHealthMetrics]](
+            load_fn=load_health_metrics_list_by_project_id
+        ),
+        PROJECT_BY_REPOSITORY_ID: DataLoader[int, Project | None](
+            load_fn=load_projects_by_repository_id,
         ),
     }

--- a/backend/src/apps/owasp/api/internal/nodes/project.py
+++ b/backend/src/apps/owasp/api/internal/nodes/project.py
@@ -25,10 +25,14 @@ from apps.github.api.internal.nodes.pull_request import PullRequestNode
 from apps.github.api.internal.nodes.release import ReleaseNode
 from apps.github.api.internal.nodes.repository import RepositoryNode
 from apps.owasp.api.internal.dataloaders.project import (
+    ENTITY_CHANNELS_BY_PROJECT_ID,
+    ENTITY_LEADERS_BY_PROJECT_ID,
     HEALTH_METRICS_LATEST_BY_PROJECT_ID,
     HEALTH_METRICS_LIST_BY_PROJECT_ID,
 )
 from apps.owasp.api.internal.nodes.common import GenericEntityNode
+from apps.owasp.api.internal.nodes.entity_channel import EntityChannelNode
+from apps.owasp.api.internal.nodes.entity_member import EntityMemberNode
 from apps.owasp.api.internal.nodes.project_health_metrics import (
     ProjectHealthMetricsNode,
 )
@@ -64,6 +68,18 @@ class ProjectNode(GenericEntityNode):
     def contribution_stats(self, root: Project) -> strawberry.scalars.JSON | None:
         """Resolve contribution stats with camelCase keys."""
         return deep_camelize(root.contribution_stats)
+
+    @strawberry_django.field
+    async def entity_channels(
+        self, root: Project, info: strawberry.Info
+    ) -> list[EntityChannelNode]:
+        """Resolve entity channels."""
+        return await info.context.owasp_dataloaders[ENTITY_CHANNELS_BY_PROJECT_ID].load(root.pk)
+
+    @strawberry_django.field
+    async def entity_leaders(self, root: Project, info: strawberry.Info) -> list[EntityMemberNode]:
+        """Resolve entity leaders."""
+        return await info.context.owasp_dataloaders[ENTITY_LEADERS_BY_PROJECT_ID].load(root.pk)
 
     @strawberry_django.field
     async def health_metrics_list(

--- a/backend/tests/unit/apps/github/api/internal/nodes/repository_test.py
+++ b/backend/tests/unit/apps/github/api/internal/nodes/repository_test.py
@@ -18,7 +18,7 @@ from apps.github.api.internal.nodes.organization import OrganizationNode
 from apps.github.api.internal.nodes.release import ReleaseNode
 from apps.github.api.internal.nodes.repository import RepositoryNode
 from apps.github.api.internal.nodes.repository_contributor import RepositoryContributorNode
-from apps.owasp.api.internal.dataloaders.project import PROJECT_BY_REPOSITORY_ID_LOADER
+from apps.owasp.api.internal.dataloaders.project import PROJECT_BY_REPOSITORY_ID
 from tests.unit.apps.common.graphql_node_base_test import GraphQLNodeBaseTest
 
 
@@ -168,7 +168,7 @@ class TestRepositoryNode(GraphQLNodeBaseTest):
         mock_loader = Mock()
         mock_loader.load = AsyncMock(return_value=mock_project)
         mock_info = Mock()
-        mock_info.context.owasp_dataloaders = {PROJECT_BY_REPOSITORY_ID_LOADER: mock_loader}
+        mock_info.context.owasp_dataloaders = {PROJECT_BY_REPOSITORY_ID: mock_loader}
 
         mock_repository = Mock()
         mock_repository.pk = 1

--- a/backend/tests/unit/apps/owasp/api/internal/dataloaders/project_test.py
+++ b/backend/tests/unit/apps/owasp/api/internal/dataloaders/project_test.py
@@ -10,7 +10,7 @@ from apps.owasp.api.internal.dataloaders.project import (
     ENTITY_LEADERS_BY_PROJECT_ID,
     HEALTH_METRICS_LATEST_BY_PROJECT_ID,
     HEALTH_METRICS_LIST_BY_PROJECT_ID,
-    PROJECT_BY_REPOSITORY_ID_LOADER,
+    PROJECT_BY_REPOSITORY_ID,
     Project,
     get_project_loaders,
     load_entity_channels_by_project_id,
@@ -680,7 +680,7 @@ class TestGetProjectLoaders:
     @pytest.mark.parametrize(
         "loader_key",
         [
-            PROJECT_BY_REPOSITORY_ID_LOADER,
+            PROJECT_BY_REPOSITORY_ID,
             HEALTH_METRICS_LIST_BY_PROJECT_ID,
             HEALTH_METRICS_LATEST_BY_PROJECT_ID,
             ENTITY_CHANNELS_BY_PROJECT_ID,
@@ -696,7 +696,7 @@ class TestGetProjectLoaders:
     def test_load_fn_is_load_projects_by_repository_id(self):
         """The project_by_repository_id loader is wired to load_projects_by_repository_id."""
         loaders = get_project_loaders()
-        assert loaders[PROJECT_BY_REPOSITORY_ID_LOADER].load_fn is load_projects_by_repository_id
+        assert loaders[PROJECT_BY_REPOSITORY_ID].load_fn is load_projects_by_repository_id
 
     def test_load_fn_is_load_health_metrics_list_by_project_id(self):
         """The list loader is wired to load_health_metrics_list_by_project_id."""
@@ -727,7 +727,7 @@ class TestGetProjectLoaders:
     @pytest.mark.parametrize(
         "loader_key",
         [
-            PROJECT_BY_REPOSITORY_ID_LOADER,
+            PROJECT_BY_REPOSITORY_ID,
             HEALTH_METRICS_LIST_BY_PROJECT_ID,
             HEALTH_METRICS_LATEST_BY_PROJECT_ID,
             ENTITY_CHANNELS_BY_PROJECT_ID,

--- a/backend/tests/unit/apps/owasp/api/internal/dataloaders/project_test.py
+++ b/backend/tests/unit/apps/owasp/api/internal/dataloaders/project_test.py
@@ -6,14 +6,27 @@ import pytest
 from strawberry.dataloader import DataLoader
 
 from apps.owasp.api.internal.dataloaders.project import (
+    ENTITY_CHANNELS_BY_PROJECT_ID,
+    ENTITY_LEADERS_BY_PROJECT_ID,
     HEALTH_METRICS_LATEST_BY_PROJECT_ID,
     HEALTH_METRICS_LIST_BY_PROJECT_ID,
     PROJECT_BY_REPOSITORY_ID_LOADER,
+    Project,
     get_project_loaders,
+    load_entity_channels_by_project_id,
+    load_entity_leaders_by_project_id,
     load_health_metrics_latest_by_project_id,
     load_health_metrics_list_by_project_id,
     load_projects_by_repository_id,
 )
+
+
+async def _async_return(value):
+    return value
+
+
+def _fake_sync_to_async(fn):
+    return lambda *args, **kwargs: _async_return(fn(*args, **kwargs))
 
 
 class TestLoadProjectsByRepositoryId:
@@ -310,6 +323,357 @@ class TestLoadHealthMetricsLatestByProjectId:
         assert result == []
 
 
+class TestLoadEntityChannelsByProjectId:
+    """Tests for load_entity_channels_by_project_id."""
+
+    @patch(
+        "apps.owasp.api.internal.dataloaders.project.get_results_by_keys",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "apps.owasp.api.internal.dataloaders.project.sync_to_async",
+        new=_fake_sync_to_async,
+    )
+    @patch("apps.owasp.api.internal.dataloaders.project.ContentType")
+    @patch("apps.owasp.api.internal.dataloaders.project.EntityChannel")
+    @pytest.mark.asyncio
+    async def test_builds_queryset_with_correct_filter(
+        self, mock_entity_channel, mock_content_type, mock_get_results_by_keys
+    ):
+        """Queryset is built with the correct filter arguments."""
+        project_ids = [1, 2, 3]
+        mock_content_type_obj = MagicMock()
+        mock_content_type.objects.get_for_model.return_value = mock_content_type_obj
+        mock_queryset = MagicMock()
+        mock_entity_channel.objects.filter.return_value = mock_queryset
+        mock_get_results_by_keys.return_value = [[], [], []]
+
+        await load_entity_channels_by_project_id(project_ids)
+
+        mock_entity_channel.objects.filter.assert_called_once_with(
+            entity_type=mock_content_type_obj,
+            entity_id__in=project_ids,
+            is_active=True,
+            is_reviewed=True,
+        )
+
+    @patch(
+        "apps.owasp.api.internal.dataloaders.project.get_results_by_keys",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "apps.owasp.api.internal.dataloaders.project.sync_to_async",
+        new=_fake_sync_to_async,
+    )
+    @patch("apps.owasp.api.internal.dataloaders.project.ContentType")
+    @patch("apps.owasp.api.internal.dataloaders.project.EntityChannel")
+    @pytest.mark.asyncio
+    async def test_delegates_to_get_results_by_keys_correct_args(
+        self, mock_entity_channel, mock_content_type, mock_get_results_by_keys
+    ):
+        """get_results_by_keys receives the queryset, project_ids, and correct key_field."""
+        project_ids = [10, 20]
+        mock_content_type.objects.get_for_model.return_value = MagicMock()
+        mock_queryset = MagicMock()
+        mock_entity_channel.objects.filter.return_value = mock_queryset
+        mock_get_results_by_keys.return_value = [[], []]
+
+        await load_entity_channels_by_project_id(project_ids)
+
+        mock_get_results_by_keys.assert_called_once_with(
+            mock_queryset, project_ids, key_field="entity_id"
+        )
+
+    @patch(
+        "apps.owasp.api.internal.dataloaders.project.get_results_by_keys",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "apps.owasp.api.internal.dataloaders.project.sync_to_async",
+        new=_fake_sync_to_async,
+    )
+    @patch("apps.owasp.api.internal.dataloaders.project.ContentType")
+    @patch("apps.owasp.api.internal.dataloaders.project.EntityChannel")
+    @pytest.mark.asyncio
+    async def test_returns_result_from_get_results_by_keys(
+        self, mock_entity_channel, mock_content_type, mock_get_results_by_keys
+    ):
+        """The return value is exactly what get_results_by_keys resolves to."""
+        mock_channel_a = MagicMock()
+        mock_channel_b = MagicMock()
+        expected = [[mock_channel_a, mock_channel_b], [], [mock_channel_a]]
+        mock_content_type.objects.get_for_model.return_value = MagicMock()
+        mock_entity_channel.objects.filter.return_value = MagicMock()
+        mock_get_results_by_keys.return_value = expected
+
+        result = await load_entity_channels_by_project_id([1, 2, 3])
+
+        assert result is expected
+
+    @patch(
+        "apps.owasp.api.internal.dataloaders.project.get_results_by_keys",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "apps.owasp.api.internal.dataloaders.project.sync_to_async",
+        new=_fake_sync_to_async,
+    )
+    @patch("apps.owasp.api.internal.dataloaders.project.ContentType")
+    @patch("apps.owasp.api.internal.dataloaders.project.EntityChannel")
+    @pytest.mark.asyncio
+    async def test_empty_project_ids(
+        self, mock_entity_channel, mock_content_type, mock_get_results_by_keys
+    ):
+        """An empty project_ids list results in an empty filter and empty return."""
+        mock_content_type.objects.get_for_model.return_value = MagicMock()
+        mock_entity_channel.objects.filter.return_value = MagicMock()
+        mock_get_results_by_keys.return_value = []
+
+        result = await load_entity_channels_by_project_id([])
+
+        mock_entity_channel.objects.filter.assert_called_once_with(
+            entity_type=mock_content_type.objects.get_for_model.return_value,
+            entity_id__in=[],
+            is_active=True,
+            is_reviewed=True,
+        )
+        assert result == []
+
+    @patch(
+        "apps.owasp.api.internal.dataloaders.project.get_results_by_keys",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "apps.owasp.api.internal.dataloaders.project.sync_to_async",
+        new=_fake_sync_to_async,
+    )
+    @patch("apps.owasp.api.internal.dataloaders.project.ContentType")
+    @patch("apps.owasp.api.internal.dataloaders.project.EntityChannel")
+    @pytest.mark.asyncio
+    async def test_single_project_id(
+        self, mock_entity_channel, mock_content_type, mock_get_results_by_keys
+    ):
+        """A single-element list is handled correctly end-to-end."""
+        mock_channel = MagicMock()
+        mock_content_type.objects.get_for_model.return_value = MagicMock()
+        mock_entity_channel.objects.filter.return_value = MagicMock()
+        mock_get_results_by_keys.return_value = [[mock_channel]]
+
+        result = await load_entity_channels_by_project_id([42])
+
+        mock_entity_channel.objects.filter.assert_called_once_with(
+            entity_type=mock_content_type.objects.get_for_model.return_value,
+            entity_id__in=[42],
+            is_active=True,
+            is_reviewed=True,
+        )
+        assert result == [[mock_channel]]
+
+    @patch(
+        "apps.owasp.api.internal.dataloaders.project.get_results_by_keys",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "apps.owasp.api.internal.dataloaders.project.sync_to_async",
+        new=_fake_sync_to_async,
+    )
+    @patch("apps.owasp.api.internal.dataloaders.project.ContentType")
+    @patch("apps.owasp.api.internal.dataloaders.project.EntityChannel")
+    @pytest.mark.asyncio
+    async def test_uses_project_content_type(
+        self, mock_entity_channel, mock_content_type, mock_get_results_by_keys
+    ):
+        """ContentType.objects.get_for_model is called with Project."""
+        mock_content_type.objects.get_for_model.return_value = MagicMock()
+        mock_entity_channel.objects.filter.return_value = MagicMock()
+        mock_get_results_by_keys.return_value = [[]]
+
+        await load_entity_channels_by_project_id([1])
+
+        mock_content_type.objects.get_for_model.assert_called_once_with(Project)
+
+
+class TestLoadEntityLeadersByProjectId:
+    """Tests for load_entity_leaders_by_project_id."""
+
+    @patch(
+        "apps.owasp.api.internal.dataloaders.project.get_results_by_keys",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "apps.owasp.api.internal.dataloaders.project.sync_to_async",
+        new=_fake_sync_to_async,
+    )
+    @patch("apps.owasp.api.internal.dataloaders.project.ContentType")
+    @patch("apps.owasp.api.internal.dataloaders.project.EntityMember")
+    @pytest.mark.asyncio
+    async def test_builds_queryset_with_correct_chain(
+        self, mock_entity_member, mock_content_type, mock_get_results_by_keys
+    ):
+        """Queryset is built with select_related, filter, and order_by in the right order."""
+        project_ids = [1, 2, 3]
+        mock_content_type_obj = MagicMock()
+        mock_content_type.objects.get_for_model.return_value = mock_content_type_obj
+        mock_queryset = MagicMock()
+        mock_filter = mock_entity_member.objects.select_related.return_value.filter
+        mock_filter.return_value.order_by.return_value = mock_queryset
+        mock_get_results_by_keys.return_value = [[], [], []]
+
+        await load_entity_leaders_by_project_id(project_ids)
+
+        mock_entity_member.objects.select_related.assert_called_once_with("member")
+        mock_filter.assert_called_once_with(
+            entity_type=mock_content_type_obj,
+            entity_id__in=project_ids,
+            role=mock_entity_member.Role.LEADER,
+            is_active=True,
+            is_reviewed=True,
+        )
+        mock_filter.return_value.order_by.assert_called_once_with("order")
+
+    @patch(
+        "apps.owasp.api.internal.dataloaders.project.get_results_by_keys",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "apps.owasp.api.internal.dataloaders.project.sync_to_async",
+        new=_fake_sync_to_async,
+    )
+    @patch("apps.owasp.api.internal.dataloaders.project.ContentType")
+    @patch("apps.owasp.api.internal.dataloaders.project.EntityMember")
+    @pytest.mark.asyncio
+    async def test_delegates_to_get_results_by_keys_correct_args(
+        self, mock_entity_member, mock_content_type, mock_get_results_by_keys
+    ):
+        """get_results_by_keys receives the queryset, project_ids, and correct key_field."""
+        project_ids = [10, 20]
+        mock_content_type.objects.get_for_model.return_value = MagicMock()
+        mock_queryset = MagicMock()
+        mock_filter = mock_entity_member.objects.select_related.return_value.filter
+        mock_filter.return_value.order_by.return_value = mock_queryset
+        mock_get_results_by_keys.return_value = [[], []]
+
+        await load_entity_leaders_by_project_id(project_ids)
+
+        mock_get_results_by_keys.assert_called_once_with(
+            mock_queryset, project_ids, key_field="entity_id"
+        )
+
+    @patch(
+        "apps.owasp.api.internal.dataloaders.project.get_results_by_keys",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "apps.owasp.api.internal.dataloaders.project.sync_to_async",
+        new=_fake_sync_to_async,
+    )
+    @patch("apps.owasp.api.internal.dataloaders.project.ContentType")
+    @patch("apps.owasp.api.internal.dataloaders.project.EntityMember")
+    @pytest.mark.asyncio
+    async def test_returns_result_from_get_results_by_keys(
+        self, mock_entity_member, mock_content_type, mock_get_results_by_keys
+    ):
+        """The return value is exactly what get_results_by_keys resolves to."""
+        mock_leader_a = MagicMock()
+        mock_leader_b = MagicMock()
+        expected = [[mock_leader_a, mock_leader_b], [], [mock_leader_a]]
+        mock_content_type.objects.get_for_model.return_value = MagicMock()
+        mock_filter = mock_entity_member.objects.select_related.return_value.filter
+        mock_filter.return_value.order_by.return_value = MagicMock()
+        mock_get_results_by_keys.return_value = expected
+
+        result = await load_entity_leaders_by_project_id([1, 2, 3])
+
+        assert result is expected
+
+    @patch(
+        "apps.owasp.api.internal.dataloaders.project.get_results_by_keys",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "apps.owasp.api.internal.dataloaders.project.sync_to_async",
+        new=_fake_sync_to_async,
+    )
+    @patch("apps.owasp.api.internal.dataloaders.project.ContentType")
+    @patch("apps.owasp.api.internal.dataloaders.project.EntityMember")
+    @pytest.mark.asyncio
+    async def test_empty_project_ids(
+        self, mock_entity_member, mock_content_type, mock_get_results_by_keys
+    ):
+        """An empty project_ids list results in an empty filter and empty return."""
+        mock_content_type.objects.get_for_model.return_value = MagicMock()
+        mock_filter = mock_entity_member.objects.select_related.return_value.filter
+        mock_filter.return_value.order_by.return_value = MagicMock()
+        mock_get_results_by_keys.return_value = []
+
+        result = await load_entity_leaders_by_project_id([])
+
+        mock_filter.assert_called_once_with(
+            entity_type=mock_content_type.objects.get_for_model.return_value,
+            entity_id__in=[],
+            role=mock_entity_member.Role.LEADER,
+            is_active=True,
+            is_reviewed=True,
+        )
+        assert result == []
+
+    @patch(
+        "apps.owasp.api.internal.dataloaders.project.get_results_by_keys",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "apps.owasp.api.internal.dataloaders.project.sync_to_async",
+        new=_fake_sync_to_async,
+    )
+    @patch("apps.owasp.api.internal.dataloaders.project.ContentType")
+    @patch("apps.owasp.api.internal.dataloaders.project.EntityMember")
+    @pytest.mark.asyncio
+    async def test_single_project_id(
+        self, mock_entity_member, mock_content_type, mock_get_results_by_keys
+    ):
+        """A single-element list is handled correctly end-to-end."""
+        mock_leader = MagicMock()
+        mock_content_type.objects.get_for_model.return_value = MagicMock()
+        mock_filter = mock_entity_member.objects.select_related.return_value.filter
+        mock_filter.return_value.order_by.return_value = MagicMock()
+        mock_get_results_by_keys.return_value = [[mock_leader]]
+
+        result = await load_entity_leaders_by_project_id([42])
+
+        mock_filter.assert_called_once_with(
+            entity_type=mock_content_type.objects.get_for_model.return_value,
+            entity_id__in=[42],
+            role=mock_entity_member.Role.LEADER,
+            is_active=True,
+            is_reviewed=True,
+        )
+        assert result == [[mock_leader]]
+
+    @patch(
+        "apps.owasp.api.internal.dataloaders.project.get_results_by_keys",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "apps.owasp.api.internal.dataloaders.project.sync_to_async",
+        new=_fake_sync_to_async,
+    )
+    @patch("apps.owasp.api.internal.dataloaders.project.ContentType")
+    @patch("apps.owasp.api.internal.dataloaders.project.EntityMember")
+    @pytest.mark.asyncio
+    async def test_uses_project_content_type(
+        self, mock_entity_member, mock_content_type, mock_get_results_by_keys
+    ):
+        """ContentType.objects.get_for_model is called with Project."""
+        mock_content_type.objects.get_for_model.return_value = MagicMock()
+        mock_filter = mock_entity_member.objects.select_related.return_value.filter
+        mock_filter.return_value.order_by.return_value = MagicMock()
+        mock_get_results_by_keys.return_value = [[]]
+
+        await load_entity_leaders_by_project_id([1])
+
+        mock_content_type.objects.get_for_model.assert_called_once_with(Project)
+
+
 class TestGetProjectLoaders:
     """Tests for get_project_loaders."""
 
@@ -319,6 +683,8 @@ class TestGetProjectLoaders:
             PROJECT_BY_REPOSITORY_ID_LOADER,
             HEALTH_METRICS_LIST_BY_PROJECT_ID,
             HEALTH_METRICS_LATEST_BY_PROJECT_ID,
+            ENTITY_CHANNELS_BY_PROJECT_ID,
+            ENTITY_LEADERS_BY_PROJECT_ID,
         ],
     )
     def test_returns_mapping(self, loader_key):
@@ -348,12 +714,24 @@ class TestGetProjectLoaders:
             is load_health_metrics_latest_by_project_id
         )
 
+    def test_load_fn_is_load_entity_channels_by_project_id(self):
+        """The channels loader is wired to load_entity_channels_by_project_id."""
+        loaders = get_project_loaders()
+        assert loaders[ENTITY_CHANNELS_BY_PROJECT_ID].load_fn is load_entity_channels_by_project_id
+
+    def test_load_fn_is_load_entity_leaders_by_project_id(self):
+        """The leaders loader is wired to load_entity_leaders_by_project_id."""
+        loaders = get_project_loaders()
+        assert loaders[ENTITY_LEADERS_BY_PROJECT_ID].load_fn is load_entity_leaders_by_project_id
+
     @pytest.mark.parametrize(
         "loader_key",
         [
             PROJECT_BY_REPOSITORY_ID_LOADER,
             HEALTH_METRICS_LIST_BY_PROJECT_ID,
             HEALTH_METRICS_LATEST_BY_PROJECT_ID,
+            ENTITY_CHANNELS_BY_PROJECT_ID,
+            ENTITY_LEADERS_BY_PROJECT_ID,
         ],
     )
     def test_returns_new_instances_on_each_call(self, loader_key):

--- a/backend/tests/unit/apps/owasp/api/internal/nodes/project_test.py
+++ b/backend/tests/unit/apps/owasp/api/internal/nodes/project_test.py
@@ -24,6 +24,8 @@ from apps.github.api.internal.nodes.pull_request import PullRequestNode
 from apps.github.api.internal.nodes.release import ReleaseNode
 from apps.github.api.internal.nodes.repository import RepositoryNode
 from apps.owasp.api.internal.dataloaders.project import (
+    ENTITY_CHANNELS_BY_PROJECT_ID,
+    ENTITY_LEADERS_BY_PROJECT_ID,
     HEALTH_METRICS_LATEST_BY_PROJECT_ID,
     HEALTH_METRICS_LIST_BY_PROJECT_ID,
 )
@@ -48,6 +50,8 @@ class TestProjectNode(GraphQLNodeBaseTest):
             "contribution_stats",
             "contributors_count",
             "created_at",
+            "entity_channels",
+            "entity_leaders",
             "forks_count",
             "is_active",
             "issues_count",
@@ -420,4 +424,38 @@ class TestProjectNodeResolvers:
         result = await resolver(None, mock_project, mock_info)
 
         assert result == mock_repos
+        mock_loader.load.assert_awaited_once_with(1)
+
+    @pytest.mark.asyncio
+    async def test_entity_channels_loads_via_dataloader(self):
+        """entity_channels delegates to the dataloader with pk."""
+        mock_channels = [Mock(), Mock()]
+        mock_loader = Mock()
+        mock_loader.load = AsyncMock(return_value=mock_channels)
+        mock_info = self._build_info(owasp={ENTITY_CHANNELS_BY_PROJECT_ID: mock_loader})
+
+        mock_project = Mock()
+        mock_project.pk = 1
+
+        resolver = self._get_resolver("entity_channels")
+        result = await resolver(None, mock_project, mock_info)
+
+        assert result == mock_channels
+        mock_loader.load.assert_awaited_once_with(1)
+
+    @pytest.mark.asyncio
+    async def test_entity_leaders_loads_via_dataloader(self):
+        """entity_leaders delegates to the dataloader with pk."""
+        mock_leaders = [Mock(), Mock()]
+        mock_loader = Mock()
+        mock_loader.load = AsyncMock(return_value=mock_leaders)
+        mock_info = self._build_info(owasp={ENTITY_LEADERS_BY_PROJECT_ID: mock_loader})
+
+        mock_project = Mock()
+        mock_project.pk = 1
+
+        resolver = self._get_resolver("entity_leaders")
+        result = await resolver(None, mock_project, mock_info)
+
+        assert result == mock_leaders
         mock_loader.load.assert_awaited_once_with(1)


### PR DESCRIPTION
## Proposed change

<!-- Don't forget to link your PR to an existing issue.-->
Resolves #5242

<!-- Describe the big picture of your changes.-->
- Optimizee entity channels and entity leaders in ProjectNode
- Reduced DB operations from 600 to 8
- Reduced Response time fro 1.33s to 0.133s

### PoC

https://github.com/user-attachments/assets/c2aa0bbe-6c71-4c6d-9314-1d8dc2bffa68

### Tested Query

```graphql
{
  recentProjects(limit: 1000) {
    id
    entityLeaders {
      id
      member {
        id
      }
    }
    entityChannels {
      id
    }
  }
}
```

## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran all required checks and tests locally; all warnings addressed and failures resolved
- [x] I used AI for code, documentation, tests, or communication related to this PR
