### PR TITLE
fix: add server-side program status transition validation

### DIFF
--- a/backend/src/apps/mentorship/api/internal/mutations/program.py
+++ b/backend/src/apps/mentorship/api/internal/mutations/program.py
@@ -199,7 +199,9 @@ class ProgramMutation:
     def update_program_status(
         self, info: strawberry.Info, input_data: UpdateProgramStatusInput
     ) -> ProgramNode:
-        """Update only the status of a program."""
+        """Update only the status of a program. Validates transitions:
+        DRAFT -> PUBLISHED, PUBLISHED -> DRAFT, PUBLISHED -> COMPLETED.
+        """
         user = info.context.request.user
 
         try:
@@ -211,9 +213,35 @@ class ProgramMutation:
         if not program.has_admin(user):
             raise PermissionDenied
 
-        program.status = input_data.status.value
+        current_status = program.status
+        new_status = input_data.status.value
+
+        valid_transitions = {
+            Program.ProgramStatus.DRAFT: [Program.ProgramStatus.PUBLISHED],
+            Program.ProgramStatus.PUBLISHED: [
+                Program.ProgramStatus.DRAFT,
+                Program.ProgramStatus.COMPLETED,
+            ],
+            Program.ProgramStatus.COMPLETED: [],
+        }
+
+        allowed = valid_transitions.get(current_status, [])
+        if new_status not in allowed:
+            msg = (
+                f"Invalid status transition from '{current_status}' to '{new_status}'. "
+                f"Allowed transitions from '{current_status}': {allowed}."
+            )
+            logger.warning("Status transition denied for program '%s': %s", program.key, msg)
+            raise ValidationError(msg)
+
+        program.status = new_status
         program.save()
 
-        logger.info("Updated status of program '%s' to '%s'", program.key, program.status)
+        logger.info(
+            "Updated status of program '%s' from '%s' to '%s'",
+            program.key,
+            current_status,
+            new_status,
+        )
 
         return program

--- a/backend/tests/unit/apps/mentorship/api/internal/mutations/program_mutation_test.py
+++ b/backend/tests/unit/apps/mentorship/api/internal/mutations/program_mutation_test.py
@@ -13,6 +13,7 @@ from apps.mentorship.api.internal.mutations.program import (
     resolve_admins_from_logins,
 )
 from apps.mentorship.api.internal.nodes.enum import ProgramStatusEnum
+from apps.mentorship.models.program import Program
 
 
 @pytest.fixture(autouse=True)
@@ -460,8 +461,8 @@ class TestUpdateProgramStatus:
     """Tests for ProgramMutation.update_program_status."""
 
     @patch("apps.mentorship.api.internal.mutations.program.Program")
-    def test_update_status_success(self, mock_program, mutation):
-        """Test successful status update."""
+    def test_update_status_draft_to_published(self, mock_program, mutation):
+        """Test successful status update from DRAFT to PUBLISHED."""
         user = MagicMock()
         info = _make_info(user)
 
@@ -471,6 +472,7 @@ class TestUpdateProgramStatus:
 
         mock_prog = MagicMock()
         mock_prog.has_admin.return_value = True
+        mock_prog.status = Program.ProgramStatus.DRAFT
         mock_program.objects.select_for_update.return_value.get.return_value = mock_prog
 
         result = mutation.update_program_status(info, input_data)
@@ -478,6 +480,24 @@ class TestUpdateProgramStatus:
         assert result == mock_prog
         assert mock_prog.status == ProgramStatusEnum.PUBLISHED.value
         mock_prog.save.assert_called_once()
+
+    @patch("apps.mentorship.api.internal.mutations.program.Program")
+    def test_update_status_invalid_transition(self, mock_program, mutation):
+        """Test ValidationError for invalid transition (DRAFT to COMPLETED)."""
+        user = MagicMock()
+        info = _make_info(user)
+
+        input_data = MagicMock()
+        input_data.key = "prog-1"
+        input_data.status = ProgramStatusEnum.COMPLETED
+
+        mock_prog = MagicMock()
+        mock_prog.has_admin.return_value = True
+        mock_prog.status = Program.ProgramStatus.DRAFT
+        mock_program.objects.select_for_update.return_value.get.return_value = mock_prog
+
+        with pytest.raises(ValidationError, match="Invalid status transition"):
+            mutation.update_program_status(info, input_data)
 
     @patch("apps.mentorship.api.internal.mutations.program.Program")
     def test_update_status_program_not_found(self, mock_program, mutation):


### PR DESCRIPTION
## Summary

Adds strict server-side validation for program status transitions in the `update_program_status` mutation. Previously, any status could be set to any other status without validation, allowing invalid transitions like DRAFT → COMPLETED or COMPLETED → PUBLISHED.

## Changes

- Added `valid_transitions` dictionary defining allowed state machine transitions:
  - `DRAFT → PUBLISHED`
  - `PUBLISHED → DRAFT, COMPLETED`
  - `COMPLETED → (none — terminal state)`
- Returns `ValidationError` with descriptive message when a transition is disallowed
- Added test coverage for valid (DRAFT→PUBLISHED) and invalid (DRAFT→COMPLETED) transitions

## Related

Fixes issue #5302 — server-side program status validation missing