### PR TITLE
Optimize top_contributors resolver in RepositoryNode

### DIFF
--- a/backend/src/apps/common/api/internal/dataloaders/utils.py
+++ b/backend/src/apps/common/api/internal/dataloaders/utils.py
@@ -91,3 +91,40 @@ async def get_m2m_results_by_keys[K, V](
             )
 
     return [mapping.get(key, []) for key in keys]
+
+
+async def get_top_contributors_by_keys[K](
+    queryset: QuerySet[Model],
+    keys: list[K],
+    key_field: str,
+) -> list[list[dict[str, str | int]]]:
+    """Map top-contributor rows back to an ordered list of dicts matching ``keys``.
+
+    Each queryset item is expected to expose ``user`` (with ``avatar_url``,
+    ``login`` and ``name``) and ``contributions_count``. The produced dict
+    structure is fixed across all top-contributor resolvers (repositories,
+    projects, chapters, committees, organizations).
+
+    Args:
+        queryset: The queryset of repository contributors to iterate over.
+        keys: A list of keys to map the results to, in the desired order.
+        key_field: The name of the attribute on each item that contains the key.
+
+    Returns:
+        A list of contributor-dict lists, one per key, in the same order as ``keys``.
+
+    """
+    mapping: dict[K, list[dict[str, str | int]]] = defaultdict(list)
+    async for item in queryset:
+        key: K = cast("K", getattr(item, key_field))
+        mapping[key].append(
+            {
+                "avatar_url": item.user.avatar_url,
+                "contributions_count": item.contributions_count,
+                "id": item.user.login,
+                "login": item.user.login,
+                "name": item.user.name,
+            }
+        )
+
+    return [mapping.get(key, []) for key in keys]

--- a/backend/src/apps/github/api/internal/dataloaders/__init__.py
+++ b/backend/src/apps/github/api/internal/dataloaders/__init__.py
@@ -5,6 +5,9 @@ from apps.github.api.internal.dataloaders.milestone import get_milestone_loaders
 from apps.github.api.internal.dataloaders.pull_request import get_pull_request_loaders
 from apps.github.api.internal.dataloaders.release import get_release_loaders
 from apps.github.api.internal.dataloaders.repository import get_repository_loaders
+from apps.github.api.internal.dataloaders.repository_contributor import (
+    get_repository_contributor_loaders,
+)
 from apps.github.api.internal.dataloaders.user import get_user_loaders
 
 
@@ -16,5 +19,6 @@ def get_github_dataloaders() -> dict[str, object]:
     loaders.update(get_pull_request_loaders())
     loaders.update(get_release_loaders())
     loaders.update(get_repository_loaders())
+    loaders.update(get_repository_contributor_loaders())
     loaders.update(get_user_loaders())
     return loaders

--- a/backend/src/apps/github/api/internal/dataloaders/__init__.py
+++ b/backend/src/apps/github/api/internal/dataloaders/__init__.py
@@ -18,7 +18,7 @@ def get_github_dataloaders() -> dict[str, object]:
     loaders.update(get_milestone_loaders())
     loaders.update(get_pull_request_loaders())
     loaders.update(get_release_loaders())
-    loaders.update(get_repository_loaders())
     loaders.update(get_repository_contributor_loaders())
+    loaders.update(get_repository_loaders())
     loaders.update(get_user_loaders())
     return loaders

--- a/backend/src/apps/github/api/internal/dataloaders/repository_contributor.py
+++ b/backend/src/apps/github/api/internal/dataloaders/repository_contributor.py
@@ -1,0 +1,68 @@
+"""DataLoaders for repository contributors."""
+
+from typing import TYPE_CHECKING
+
+from asgiref.sync import sync_to_async
+from django.db.models import F, Window
+from django.db.models.functions import RowNumber
+from strawberry.dataloader import DataLoader
+
+from apps.common.api.internal.dataloaders.utils import get_top_contributors_by_keys
+from apps.github.models.repository_contributor import RepositoryContributor
+
+TOP_CONTRIBUTORS_LIMIT = 15
+TOP_CONTRIBUTORS_BY_REPOSITORY_ID_LOADER = "top_contributors_by_repository_id"
+
+if TYPE_CHECKING:
+    from apps.github.models.managers.repository_contributor import (
+        RepositoryContributorQuerySet,
+    )
+
+
+async def load_top_contributors_by_repository_id(
+    repository_ids: list[int],
+) -> list[list[dict[str, str | int]]]:
+    """Batch-load top contributors for the given repository IDs in a single query.
+
+    Mirrors the per-repository slice of RepositoryContributor.get_top_contributors
+    (humans only, community repositories), ranked by contributions and capped at
+    TOP_CONTRIBUTORS_LIMIT per repository.
+
+    ``RepositoryContributor`` has ``unique_together = ("repository", "user")``, so each
+    user has exactly one row per repository and ``contributions_count`` is already the
+    user's total for that repository. Ranking by ``contributions_count`` therefore
+    matches the original aggregate (``Sum``+``GROUP BY``) without a window-on-aggregate
+    query, which Postgres forbids.
+    """
+    if not repository_ids:
+        return []
+
+    queryset: RepositoryContributorQuerySet = await sync_to_async(
+        lambda: RepositoryContributor.objects.by_humans().to_community_repositories()
+    )()
+
+    top_contributors: RepositoryContributorQuerySet = (
+        queryset.filter(repository_id__in=repository_ids)
+        .annotate(
+            row_number=Window(
+                expression=RowNumber(),
+                partition_by=[F("repository_id")],
+                order_by=F("contributions_count").desc(),
+            ),
+        )
+        .filter(row_number__lte=TOP_CONTRIBUTORS_LIMIT)
+        .order_by("repository_id", "-contributions_count")
+    )
+
+    return await get_top_contributors_by_keys(
+        queryset=top_contributors, keys=repository_ids, key_field="repository_id"
+    )
+
+
+def get_repository_contributor_loaders() -> dict[str, object]:
+    """Return a mapping of per-request DataLoader instances."""
+    return {
+        TOP_CONTRIBUTORS_BY_REPOSITORY_ID_LOADER: DataLoader[int, list[dict[str, str | int]]](
+            load_fn=load_top_contributors_by_repository_id
+        ),
+    }

--- a/backend/src/apps/github/api/internal/dataloaders/repository_contributor.py
+++ b/backend/src/apps/github/api/internal/dataloaders/repository_contributor.py
@@ -22,17 +22,9 @@ if TYPE_CHECKING:
 async def load_top_contributors_by_repository_id(
     repository_ids: list[int],
 ) -> list[list[dict[str, str | int]]]:
-    """Batch-load top contributors for the given repository IDs in a single query.
+    """Batch-load top contributors per repository (humans only, community repos).
 
-    Mirrors the per-repository slice of RepositoryContributor.get_top_contributors
-    (humans only, community repositories), ranked by contributions and capped at
-    TOP_CONTRIBUTORS_LIMIT per repository.
-
-    ``RepositoryContributor`` has ``unique_together = ("repository", "user")``, so each
-    user has exactly one row per repository and ``contributions_count`` is already the
-    user's total for that repository. Ranking by ``contributions_count`` therefore
-    matches the original aggregate (``Sum``+``GROUP BY``) without a window-on-aggregate
-    query, which Postgres forbids.
+    Capped at ``TOP_CONTRIBUTORS_LIMIT`` per repository.
     """
     if not repository_ids:
         return []

--- a/backend/src/apps/github/api/internal/nodes/repository.py
+++ b/backend/src/apps/github/api/internal/nodes/repository.py
@@ -15,6 +15,9 @@ from apps.github.api.internal.dataloaders.release import (
     LATEST_RELEASE_BY_REPOSITORY_ID_LOADER,
     RECENT_RELEASES_BY_REPOSITORY_ID_LOADER,
 )
+from apps.github.api.internal.dataloaders.repository_contributor import (
+    TOP_CONTRIBUTORS_BY_REPOSITORY_ID_LOADER,
+)
 from apps.github.api.internal.nodes.issue import IssueNode
 from apps.github.api.internal.nodes.milestone import MilestoneNode
 from apps.github.api.internal.nodes.organization import OrganizationNode
@@ -102,9 +105,14 @@ class RepositoryNode(strawberry.relay.Node):
         )
 
     @strawberry_django.field
-    def top_contributors(self, root: Repository) -> list[RepositoryContributorNode]:
+    async def top_contributors(
+        self, root: Repository, info: Info
+    ) -> list[RepositoryContributorNode]:
         """Resolve top contributors."""
-        return [RepositoryContributorNode(**tc) for tc in root.idx_top_contributors]
+        top_contributors = await info.context.github_dataloaders[
+            TOP_CONTRIBUTORS_BY_REPOSITORY_ID_LOADER
+        ].load(root.pk)
+        return [RepositoryContributorNode(**tc) for tc in top_contributors]
 
     @strawberry_django.field(only=["topics"])
     def topics(self, root: Repository) -> list[str]:

--- a/backend/tests/unit/apps/common/api/internal/dataloaders/utils_test.py
+++ b/backend/tests/unit/apps/common/api/internal/dataloaders/utils_test.py
@@ -10,6 +10,7 @@ from apps.common.api.internal.dataloaders.utils import (
     get_m2m_results_by_keys,
     get_result_by_keys,
     get_results_by_keys,
+    get_top_contributors_by_keys,
 )
 
 
@@ -415,3 +416,204 @@ class TestM2mResultsByKeys:
             make_qs(items), keys, m2m_field, key_field, value_field
         )
         assert result == expected
+
+
+class TestTopContributorsByKeys:
+    """Tests for get_top_contributors_by_keys."""
+
+    @staticmethod
+    def _make_contrib_item(key_field_value, **user_kw):
+        """Create a mock item with user and contributions_count."""
+        return make_item(
+            **{key_field_value[0]: key_field_value[1]},
+            user=SimpleNamespace(
+                avatar_url=user_kw.get("avatar_url", ""),
+                login=user_kw.get("login", ""),
+                name=user_kw.get("name", ""),
+            ),
+            contributions_count=user_kw.get("contributions_count", 0),
+        )
+
+    @pytest.mark.asyncio
+    async def test_basic_mapping(self):
+        """Each key maps to a list of contributor dicts."""
+        items = [
+            self._make_contrib_item(
+                ("repo_id", 1),
+                login="user1",
+                name="User 1",
+                contributions_count=100,
+                avatar_url="url1",
+            ),
+            self._make_contrib_item(
+                ("repo_id", 2),
+                login="user2",
+                name="User 2",
+                contributions_count=50,
+                avatar_url="url2",
+            ),
+        ]
+        result = await get_top_contributors_by_keys(make_qs(items), [1, 2], "repo_id")
+        assert result == [
+            [
+                {
+                    "avatar_url": "url1",
+                    "contributions_count": 100,
+                    "id": "user1",
+                    "login": "user1",
+                    "name": "User 1",
+                }
+            ],
+            [
+                {
+                    "avatar_url": "url2",
+                    "contributions_count": 50,
+                    "id": "user2",
+                    "login": "user2",
+                    "name": "User 2",
+                }
+            ],
+        ]
+
+    @pytest.mark.asyncio
+    async def test_empty_queryset(self):
+        """Empty queryset returns empty list for every key."""
+        result = await get_top_contributors_by_keys(make_qs([]), [1, 2], "repo_id")
+        assert result == [[], []]
+
+    @pytest.mark.asyncio
+    async def test_empty_keys(self):
+        """Empty keys list returns an empty list."""
+        items = [self._make_contrib_item(("repo_id", 1), login="user1")]
+        result = await get_top_contributors_by_keys(make_qs(items), [], "repo_id")
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_key_absent_from_results(self):
+        """A key with no matching items gets an empty list."""
+        items = [self._make_contrib_item(("repo_id", 1), login="user1")]
+        result = await get_top_contributors_by_keys(make_qs(items), [1, 2], "repo_id")
+        assert result == [
+            [
+                {
+                    "avatar_url": "",
+                    "contributions_count": 0,
+                    "id": "user1",
+                    "login": "user1",
+                    "name": "",
+                }
+            ],
+            [],
+        ]
+
+    @pytest.mark.asyncio
+    async def test_multiple_contributors_per_key(self):
+        """Multiple contributors for the same key are collected into one list."""
+        items = [
+            self._make_contrib_item(("repo_id", 1), login="user1", contributions_count=100),
+            self._make_contrib_item(("repo_id", 1), login="user2", contributions_count=50),
+            self._make_contrib_item(("repo_id", 2), login="user3", contributions_count=25),
+        ]
+        result = await get_top_contributors_by_keys(make_qs(items), [1, 2], "repo_id")
+        assert result == [
+            [
+                {
+                    "avatar_url": "",
+                    "contributions_count": 100,
+                    "id": "user1",
+                    "login": "user1",
+                    "name": "",
+                },
+                {
+                    "avatar_url": "",
+                    "contributions_count": 50,
+                    "id": "user2",
+                    "login": "user2",
+                    "name": "",
+                },
+            ],
+            [
+                {
+                    "avatar_url": "",
+                    "contributions_count": 25,
+                    "id": "user3",
+                    "login": "user3",
+                    "name": "",
+                },
+            ],
+        ]
+
+    @pytest.mark.asyncio
+    async def test_order_matches_keys_not_queryset(self):
+        """Output order follows keys, not queryset iteration order."""
+        items = [
+            self._make_contrib_item(("repo_id", 2), login="user2"),
+            self._make_contrib_item(("repo_id", 1), login="user1"),
+        ]
+        result = await get_top_contributors_by_keys(make_qs(items), [1, 2], "repo_id")
+        assert result == [
+            [
+                {
+                    "avatar_url": "",
+                    "contributions_count": 0,
+                    "id": "user1",
+                    "login": "user1",
+                    "name": "",
+                }
+            ],
+            [
+                {
+                    "avatar_url": "",
+                    "contributions_count": 0,
+                    "id": "user2",
+                    "login": "user2",
+                    "name": "",
+                }
+            ],
+        ]
+
+    @pytest.mark.asyncio
+    async def test_items_not_in_keys_are_ignored(self):
+        """Items whose key is not in keys are silently discarded."""
+        items = [
+            self._make_contrib_item(("repo_id", 1), login="user1"),
+            self._make_contrib_item(("repo_id", 99), login="orphan"),
+        ]
+        result = await get_top_contributors_by_keys(make_qs(items), [1], "repo_id")
+        assert result == [
+            [
+                {
+                    "avatar_url": "",
+                    "contributions_count": 0,
+                    "id": "user1",
+                    "login": "user1",
+                    "name": "",
+                }
+            ],
+        ]
+
+    @pytest.mark.asyncio
+    async def test_duplicate_keys_in_keys_list(self):
+        """A key appearing multiple times in keys produces one entry per occurrence."""
+        items = [self._make_contrib_item(("repo_id", 1), login="user1")]
+        result = await get_top_contributors_by_keys(make_qs(items), [1, 1], "repo_id")
+        assert result == [
+            [
+                {
+                    "avatar_url": "",
+                    "contributions_count": 0,
+                    "id": "user1",
+                    "login": "user1",
+                    "name": "",
+                }
+            ],
+            [
+                {
+                    "avatar_url": "",
+                    "contributions_count": 0,
+                    "id": "user1",
+                    "login": "user1",
+                    "name": "",
+                }
+            ],
+        ]

--- a/backend/tests/unit/apps/github/api/internal/dataloaders/repository_contributor_test.py
+++ b/backend/tests/unit/apps/github/api/internal/dataloaders/repository_contributor_test.py
@@ -1,0 +1,168 @@
+"""Tests for repository contributor dataloaders."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from strawberry.dataloader import DataLoader
+
+from apps.github.api.internal.dataloaders.repository_contributor import (
+    TOP_CONTRIBUTORS_BY_REPOSITORY_ID_LOADER,
+    TOP_CONTRIBUTORS_LIMIT,
+    get_repository_contributor_loaders,
+    load_top_contributors_by_repository_id,
+)
+
+
+class TestLoadTopContributorsByRepositoryId:
+    """Tests for load_top_contributors_by_repository_id."""
+
+    @staticmethod
+    def _setup_sync_to_async(mock_sync_to_async, mock_qs):
+        """Configure sync_to_async mock: returns a callable that returns an awaitable."""
+        mock_sync_to_async.return_value = AsyncMock(return_value=mock_qs)
+
+    @patch(
+        "apps.github.api.internal.dataloaders.repository_contributor.get_top_contributors_by_keys",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "apps.github.api.internal.dataloaders.repository_contributor.sync_to_async",
+    )
+    @pytest.mark.asyncio
+    async def test_builds_queryset_with_correct_chain(
+        self, mock_sync_to_async, mock_get_top_contributors
+    ):
+        """Queryset is built with filter, annotate (window), filter (row_number), order_by."""
+        repository_ids = [1, 2, 3]
+        mock_qs = MagicMock()
+        mock_filter_result = mock_qs.filter.return_value
+        mock_annotate_result = mock_filter_result.annotate.return_value
+        mock_annotate_result.filter.return_value.order_by.return_value = mock_qs
+        self._setup_sync_to_async(mock_sync_to_async, mock_qs)
+        mock_get_top_contributors.return_value = [[], [], []]
+
+        await load_top_contributors_by_repository_id(repository_ids)
+
+        mock_qs.filter.assert_called_once_with(repository_id__in=repository_ids)
+        mock_filter_result.annotate.assert_called_once()
+        mock_annotate_result.filter.assert_called_once()
+
+    @patch(
+        "apps.github.api.internal.dataloaders.repository_contributor.get_top_contributors_by_keys",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "apps.github.api.internal.dataloaders.repository_contributor.sync_to_async",
+    )
+    @pytest.mark.asyncio
+    async def test_delegates_to_get_top_contributors_by_keys(
+        self, mock_sync_to_async, mock_get_top_contributors
+    ):
+        """Delegates to get_top_contributors_by_keys with correct args."""
+        repository_ids = [10, 20]
+        mock_qs = MagicMock()
+        mock_chain = mock_qs.filter.return_value.annotate.return_value.filter.return_value
+        mock_order_by = mock_chain.order_by.return_value
+        self._setup_sync_to_async(mock_sync_to_async, mock_qs)
+        mock_get_top_contributors.return_value = [[], []]
+
+        await load_top_contributors_by_repository_id(repository_ids)
+
+        mock_get_top_contributors.assert_called_once_with(
+            queryset=mock_order_by, keys=repository_ids, key_field="repository_id"
+        )
+
+    @patch(
+        "apps.github.api.internal.dataloaders.repository_contributor.get_top_contributors_by_keys",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "apps.github.api.internal.dataloaders.repository_contributor.sync_to_async",
+    )
+    @pytest.mark.asyncio
+    async def test_returns_result_from_get_top_contributors(
+        self, mock_sync_to_async, mock_get_top_contributors
+    ):
+        """Return value is exactly what get_top_contributors_by_keys resolves to."""
+        repository_ids = [1, 2]
+        mock_qs = MagicMock()
+        self._setup_sync_to_async(mock_sync_to_async, mock_qs)
+        expected = [
+            [
+                {
+                    "avatar_url": "url1",
+                    "contributions_count": 100,
+                    "id": "user1",
+                    "login": "user1",
+                    "name": "User 1",
+                }
+            ],
+            [
+                {
+                    "avatar_url": "url2",
+                    "contributions_count": 50,
+                    "id": "user2",
+                    "login": "user2",
+                    "name": "User 2",
+                }
+            ],
+        ]
+        mock_get_top_contributors.return_value = expected
+
+        result = await load_top_contributors_by_repository_id(repository_ids)
+
+        assert result == expected
+
+    @pytest.mark.asyncio
+    async def test_empty_repository_ids(self):
+        """An empty repository_ids list returns an empty list."""
+        result = await load_top_contributors_by_repository_id([])
+        assert result == []
+
+    @patch(
+        "apps.github.api.internal.dataloaders.repository_contributor.get_top_contributors_by_keys",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "apps.github.api.internal.dataloaders.repository_contributor.sync_to_async",
+    )
+    @pytest.mark.asyncio
+    async def test_window_filter_enforces_limit(
+        self, mock_sync_to_async, mock_get_top_contributors
+    ):
+        """The window function filter enforces TOP_CONTRIBUTORS_LIMIT."""
+        repository_ids = [1]
+        mock_qs = MagicMock()
+        mock_annotate_result = mock_qs.filter.return_value.annotate.return_value
+        self._setup_sync_to_async(mock_sync_to_async, mock_qs)
+        mock_get_top_contributors.return_value = [[]]
+
+        await load_top_contributors_by_repository_id(repository_ids)
+
+        mock_annotate_result.filter.assert_called_once_with(row_number__lte=TOP_CONTRIBUTORS_LIMIT)
+
+
+class TestGetRepositoryContributorLoaders:
+    """Tests for get_repository_contributor_loaders."""
+
+    def test_returns_mapping_with_top_contributors_loader(self):
+        """Factory returns a mapping with the top contributors loader."""
+        loaders = get_repository_contributor_loaders()
+        assert TOP_CONTRIBUTORS_BY_REPOSITORY_ID_LOADER in loaders
+        assert isinstance(loaders[TOP_CONTRIBUTORS_BY_REPOSITORY_ID_LOADER], DataLoader)
+
+    def test_returns_new_instances_on_each_call(self):
+        """Each call produces distinct DataLoader instances for per-request isolation."""
+        loaders1 = get_repository_contributor_loaders()
+        loaders2 = get_repository_contributor_loaders()
+        assert loaders1 is not loaders2
+        assert (
+            loaders1[TOP_CONTRIBUTORS_BY_REPOSITORY_ID_LOADER]
+            is not loaders2[TOP_CONTRIBUTORS_BY_REPOSITORY_ID_LOADER]
+        )
+
+    def test_load_fn_is_load_top_contributors_by_repository_id(self):
+        """The top contributors loader is wired to load_top_contributors_by_repository_id."""
+        loaders = get_repository_contributor_loaders()
+        loader = loaders[TOP_CONTRIBUTORS_BY_REPOSITORY_ID_LOADER]
+        assert loader.load_fn is load_top_contributors_by_repository_id

--- a/backend/tests/unit/apps/github/api/internal/nodes/repository_test.py
+++ b/backend/tests/unit/apps/github/api/internal/nodes/repository_test.py
@@ -12,6 +12,9 @@ from apps.github.api.internal.dataloaders.release import (
     LATEST_RELEASE_BY_REPOSITORY_ID_LOADER,
     RECENT_RELEASES_BY_REPOSITORY_ID_LOADER,
 )
+from apps.github.api.internal.dataloaders.repository_contributor import (
+    TOP_CONTRIBUTORS_BY_REPOSITORY_ID_LOADER,
+)
 from apps.github.api.internal.nodes.issue import IssueNode
 from apps.github.api.internal.nodes.milestone import MilestoneNode
 from apps.github.api.internal.nodes.organization import OrganizationNode
@@ -243,10 +246,10 @@ class TestRepositoryNode(GraphQLNodeBaseTest):
 
         assert result == []
 
-    def test_top_contributors_method(self):
-        """Test top_contributors method resolution."""
-        mock_repository = Mock()
-        mock_repository.idx_top_contributors = [
+    @pytest.mark.asyncio
+    async def test_top_contributors_method(self):
+        """Test top_contributors async resolution via dataloader."""
+        mock_contributors = [
             {
                 "avatar_url": "url1",
                 "contributions_count": 100,
@@ -262,11 +265,24 @@ class TestRepositoryNode(GraphQLNodeBaseTest):
                 "name": "User 2",
             },
         ]
+        mock_loader = Mock()
+        mock_loader.load = AsyncMock(return_value=mock_contributors)
+        mock_info = Mock()
+        mock_info.context.github_dataloaders = {
+            TOP_CONTRIBUTORS_BY_REPOSITORY_ID_LOADER: mock_loader
+        }
+
+        mock_repository = Mock()
+        mock_repository.pk = 1
 
         field = self._get_field_by_name("top_contributors", RepositoryNode)
-        result = field.base_resolver.wrapped_func(None, mock_repository)
+        result = await field.base_resolver.wrapped_func(None, mock_repository, mock_info)
+
         assert len(result) == 2
         assert all(isinstance(c, RepositoryContributorNode) for c in result)
+        assert result[0].login == "user1"
+        assert result[1].login == "user2"
+        mock_loader.load.assert_awaited_once_with(1)
 
     def test_topics_method(self):
         """Test topics method resolution."""


### PR DESCRIPTION
**Note**: We don't need to sum contribution count for all RepositoryContributor instances for a user in this case, as it is guaranteed that a user has only one RepositroyContributor instance for the related repository.

## Proposed change

<!-- Don't forget to link your PR to an existing issue.-->
Resolves #5224


<!-- Describe the big picture of your changes.-->
- Optimized top_contributors query in RepositoryNode
- Reduced response time from 10 to 2 seconds
- Reduced DB operations from 2K to 7

---
### PoC

https://github.com/user-attachments/assets/8c46be43-283f-41ca-ae2d-8702b303136b

### Tested Query
```graphql
{
  repositories(organization: "OWASP", limit: 1000) {
    id
    topContributors {
      id
      projectName
      contributionsCount
      projectKey
    }
  }
}
```

## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran all required checks and tests locally; all warnings addressed and failures resolved
- [x] I used AI for code, documentation, tests, or communication related to this PR
