### PR TITLE
replace empty exception handler in Slack event command parsing

### DIFF
--- a/backend/src/apps/slack/models/event.py
+++ b/backend/src/apps/slack/models/event.py
@@ -46,12 +46,9 @@ class Event(TimestampedModel):
 
         command = payload.get("command", "")
         text = payload.get("text", "")
-        if command and command == OWASP_COMMAND:
-            try:
-                command, *args = text.strip().split()
-                text = " ".join(args)
-            except ValueError:
-                pass
+        if command and command == OWASP_COMMAND and (args := text.strip().split()):
+            command, *rest = args
+            text = " ".join(rest)
         self.command = command.lstrip("/")
         self.text = text
 

--- a/backend/tests/unit/apps/slack/models/event_test.py
+++ b/backend/tests/unit/apps/slack/models/event_test.py
@@ -86,8 +86,8 @@ class TestEventModel:
         assert event.user_id == "U555"
         assert event.user_name == "Eve"
 
-    def test_from_slack_value_error_in_command_parsing(self):
-        """Test from_slack handles ValueError when parsing command text."""
+    def test_from_slack_with_empty_command_text(self):
+        """Test from_slack keeps the default command when the text is empty."""
         context = {"channel_id": "C666", "user_id": "U666"}
         payload = {
             "channel_name": "test",
@@ -100,3 +100,18 @@ class TestEventModel:
 
         assert event.command == "owasp"
         assert event.text == ""
+
+    def test_from_slack_with_whitespace_only_command_text(self):
+        """Test from_slack keeps the default command when the text is whitespace only."""
+        context = {"channel_id": "C777", "user_id": "U777"}
+        payload = {
+            "channel_name": "test",
+            "command": Owasp().command_name,
+            "text": "   ",
+            "user_name": "Grace",
+        }
+        event = Event()
+        event.from_slack(context, payload)
+
+        assert event.command == "owasp"
+        assert event.text == "   "


### PR DESCRIPTION
## Proposed change

Resolves #3229

> **Note on assignment:** I'm not assigned to #3229 yet, and I know `check-contribution` may close this automatically. I asked for assignment in [this comment](https://github.com/OWASP/Nest/issues/3229#issuecomment-5298766444) and opened the PR so the work is visible alongside it. Happy for it to be closed and reopened once assignment is sorted, and I'm not trying to jump the queue.

### What this changes

`Event.from_slack` used a `try`/`except ValueError`/`pass` block to parse the command out of the Slack payload text. This replaces it with a guard on the split result:

```python
if command and command == OWASP_COMMAND and (args := text.strip().split()):
    command, *rest = args
    text = " ".join(rest)
```

### Why not add logging, as the issue suggested

Three things had drifted since the issue was filed in January, so I want to lay out the reasoning rather than just diffing.

The file moved to `backend/src/apps/slack/models/event.py` (lines 53-54) in the `src/` layout change.

The patch proposed in the issue would raise `NameError`. There is no logger in `event.py`, no `import logging` and no `logger = logging.getLogger(__name__)`, so `logger.debug(...)` would fail on the first bare `/owasp`.

Ruff doesn't flag the current code. Running the repo's own config:

```
$ ruff check --config ruff.toml --select S110 backend/src/apps/slack/models/event.py
All checks passed!
```

`S110` only fires on bare `except:` or `except Exception:`, not on a specific `ValueError`, so SonarQube is the only signal and its objection is to the empty handler.

Most importantly, `command, *args = text.strip().split()` raises `ValueError` only when the split returns an empty list, which is someone typing `/owasp` with no arguments. That is ordinary usage, not an error. Logging it with `exc_info=True` would emit a stack trace on a normal code path, trading a silent handler for log noise. Removing the exception-as-control-flow addresses the empty handler directly instead.

### Behaviour is unchanged

| `command` | `text` | before | after |
|---|---|---|---|
| `/owasp` | `"contribute foo bar"` | `('contribute', 'foo bar')` | same |
| `/owasp` | `"contribute"` | `('contribute', '')` | same |
| `/owasp` | `""` | `('owasp', '')` | same |
| `/owasp` | `"   "` | `('owasp', '   ')` | same |
| `/owasp` | `"\t\n "` | `('owasp', '\t\n ')` | same |
| `/contribute` | `"anything here"` | `('contribute', 'anything here')` | same |
| `""` | `"orphan text"` | `('', 'orphan text')` | same |
| *(key missing)* | *(key missing)* | `('', '')` | same |

### Tests

Renamed `test_from_slack_value_error_in_command_parsing`, which no longer describes what it covers now that no `ValueError` is raised, and added a whitespace-only case. That one is worth pinning because `text` stays `"   "` untouched, which is easy to break by accident.

```
tests/unit/apps/slack/models/event_test.py     7 passed  (6 before, +1 new)
tests/unit/apps/slack/                       488 passed  (487 before)
tests/unit/                                 3596 passed  (3595 on main, +1 new)
ruff check / ruff format                     clean
```

The full-suite run shows 3 pre-existing failures in `apps/owasp/models/project_health_metrics_test.py`. I verified these are identical on unmodified `origin/main` and unrelated to this change. They pass in isolation (52/52), so it looks like test-ordering state leaking under serial execution; CI's `--dist=loadscope` distribution likely avoids it.

## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow) *(except the assignment step, flagged above)*
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran all required checks and tests locally; all warnings addressed and failures resolved
- [x] I used AI for code, documentation, tests, or communication related to this PR
