### PR TITLE
fix(sitemap): map /repositories to Repository model for static lastmod

### DIFF
--- a/backend/src/apps/sitemap/views/static.py
+++ b/backend/src/apps/sitemap/views/static.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime
 from django.db.models import Max
 
 from apps.github.models.organization import Organization
+from apps.github.models.repository import Repository
 from apps.github.models.user import User
 from apps.owasp.models.chapter import Chapter
 from apps.owasp.models.committee import Committee
@@ -67,6 +68,7 @@ class StaticSitemap(BaseSitemap):
             "/members": User,
             "/organizations": Organization,
             "/projects": Project,
+            "/repositories": Repository,
             "/snapshots": Snapshot,
         }
 

--- a/backend/tests/unit/apps/sitemap/views/static_test.py
+++ b/backend/tests/unit/apps/sitemap/views/static_test.py
@@ -31,10 +31,12 @@ class TestStaticSitemap:
     @patch("apps.sitemap.views.static.Organization.objects.aggregate")
     @patch("apps.sitemap.views.static.Snapshot.objects.aggregate")
     @patch("apps.sitemap.views.static.Project.objects.aggregate")
+    @patch("apps.sitemap.views.static.Repository.objects.aggregate")
     @patch("apps.sitemap.views.static.User.objects.aggregate")
     def test_lastmod(
         self,
         mock_user,
+        mock_repository,
         mock_project,
         mock_organization,
         mock_committee,
@@ -46,6 +48,7 @@ class TestStaticSitemap:
         mock_committee.return_value = {"latest": dt}
         mock_organization.return_value = {"latest": dt}
         mock_project.return_value = {"latest": dt}
+        mock_repository.return_value = {"latest": dt}
         mock_user.return_value = {"latest": dt}
 
         for item in sitemap.STATIC_ROUTES:
@@ -72,6 +75,18 @@ class TestStaticSitemap:
         mock_aggregate.return_value = {"latest": dt}
 
         item = {"path": "/projects"}
+        result = sitemap.lastmod(item)
+
+        mock_aggregate.assert_called_once_with(latest=ANY)
+        assert result == dt
+
+    @patch("apps.sitemap.views.static.Repository.objects.aggregate")
+    def test_lastmod_with_repositories_mapped_path(self, mock_aggregate, sitemap):
+        """Test lastmod uses Repository model latest updated_at for /repositories."""
+        dt = timezone.now()
+        mock_aggregate.return_value = {"latest": dt}
+
+        item = {"path": "/repositories"}
         result = sitemap.lastmod(item)
 
         mock_aggregate.assert_called_once_with(latest=ANY)


### PR DESCRIPTION
## Problem
In `apps/sitemap/views/static.py`, `StaticSitemap.lastmod()` defines a `path_to_model` mapping for static routes to compute the latest `updated_at` timestamp. However, `/repositories` was omitted from this mapping despite being declared in `BaseSitemap.STATIC_ROUTES`. As a result, the sitemap defaulted to `datetime.now(UTC)` for `/repositories` rather than using the `Repository` model's latest `updated_at` timestamp (#5259).

## Solution
- In `backend/src/apps/sitemap/views/static.py`, import `Repository` from `apps.github.models.repository` and map `"/repositories": Repository` in `path_to_model`.
- In `backend/tests/unit/apps/sitemap/views/static_test.py`, add `mock_repository` to `test_lastmod` and add `test_lastmod_with_repositories_mapped_path` to verify that `Repository` model's `latest` updated_at is queried for `/repositories`.

Fixes #5259
