### PR TITLE
fix: inconsistent bottom spacing below search component across pa

### DIFF
--- a/frontend/src/components/SearchPageLayout.tsx
+++ b/frontend/src/components/SearchPageLayout.tsx
@@ -53,12 +53,14 @@ const SearchPageLayout = ({
     searchBarClassName = 'md:rounded-r-none'
   }
 
+  const hasMobileToolbar = Boolean(filterChildren || (inlineSort && sortChildren))
+
   return (
     <div className="text-text flex min-h-screen w-full flex-col items-center justify-normal p-5">
       <div
         className={`flex w-full flex-col md:flex-row md:items-center md:justify-center ${
           inlineSort ? 'md:gap-0' : 'md:gap-2'
-        }`}
+        } ${hasMobileToolbar ? '' : 'mb-4 md:mb-0'}`}
       >
         {filterChildren &&
           (isFirstLoad ? (


### PR DESCRIPTION
Fixes #5148

Added `mb-4 md:mb-0` to the search toolbar row in `SearchPageLayout` when a page has no mobile filter/sort controls, matching the `mb-4` spacing that chapters-style pages already get from their mobile toolbar section. This gives Projects, Members, and similar pages consistent bottom spacing below the search bar on mobile. (Issue checkboxes and other non-bug instructions in the issue text were ignored.)The mobile spacing fix is in place. Pages without mobile filter/sort controls (Projects, Members, Committees, etc.) now get `mb-4` below the search toolbar on mobile, matching the spacing chapters-style pages already had.

No local test suite detected.

---
This change was prepared with AI assistance under human direction and review.