### PR TITLE
Fix /repositories sitemap lastmod to use latest repository update

### DIFF
--- a/backend/src/apps/sitemap/views/static.py
+++ b/backend/src/apps/sitemap/views/static.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime
 from django.db.models import Max
 
 from apps.github.models.organization import Organization
+from apps.github.models.repository import Repository
 from apps.github.models.user import User
 from apps.owasp.models.chapter import Chapter
 from apps.owasp.models.committee import Committee
@@ -67,6 +68,7 @@ class StaticSitemap(BaseSitemap):
             "/members": User,
             "/organizations": Organization,
             "/projects": Project,
+            "/repositories": Repository,
             "/snapshots": Snapshot,
         }
 


### PR DESCRIPTION
Fixes: #5259

## Changes

Map /repositories to the Repository model in StaticSitemap.lastmod so the sitemap entry's <lastmod> reflects the most recently updated Repository instead of the datetime.now(UTC) fallback reserved for paths without a model.

## Verification

- lastmod now derives from Repository.objects.aggregate(Max(updated_at)), consistent with the other seven content routes.