### PR TITLE
refactor: consolidate Apollo Client setup into shared builder (#4006)

### DIFF
--- a/frontend/src/lib/apolloClient.ts
+++ b/frontend/src/lib/apolloClient.ts
@@ -1,0 +1,43 @@
+import { ApolloClient, HttpLink, InMemoryCache, NormalizedCacheObject } from '@apollo/client'
+import { setContext } from '@apollo/client/link/context'
+
+interface CreateApolloClientOptions {
+  uri: string | undefined
+  credentials: RequestCredentials
+  getCsrfToken: () => Promise<string | null>
+  ssrMode?: boolean
+  includeCsrfCookie?: boolean
+  cache?: NormalizedCacheObject
+}
+
+export function createApolloClient({
+  uri,
+  credentials,
+  getCsrfToken,
+  ssrMode = false,
+  includeCsrfCookie = false,
+  cache = {},
+}: CreateApolloClientOptions) {
+  const httpLink = new HttpLink({
+    credentials,
+    uri,
+  })
+
+  const authLink = setContext(async (_, { headers }) => {
+    const csrfToken = await getCsrfToken()
+
+    return {
+      headers: {
+        ...headers,
+        'X-CSRFToken': csrfToken ?? '',
+        ...(includeCsrfCookie ? { Cookie: csrfToken ? `csrftoken=${csrfToken}` : '' } : {}),
+      },
+    }
+  })
+
+  return new ApolloClient({
+    cache: new InMemoryCache().restore(cache),
+    link: authLink.concat(httpLink),
+    ssrMode,
+  })
+}

--- a/frontend/src/server/apolloClient.ts
+++ b/frontend/src/server/apolloClient.ts
@@ -1,32 +1,13 @@
-import { ApolloClient, InMemoryCache, HttpLink, NormalizedCacheObject } from '@apollo/client'
-import { setContext } from '@apollo/client/link/context'
+import { NormalizedCacheObject } from '@apollo/client'
 import { cookies } from 'next/headers'
+import { createApolloClient } from 'lib/apolloClient'
 import { fetchCsrfTokenServer } from 'server/fetchCsrfTokenServer'
 
-async function createApolloClient() {
-  const authLink = setContext(async (_, { headers }) => {
-    const cookieValue = await getCsrfTokenOnServer()
-    const csrfToken = cookieValue
-    return {
-      headers: {
-        ...headers,
-        'X-CSRFToken': csrfToken ?? '',
-        Cookie: csrfToken ? `csrftoken=${csrfToken}` : '',
-      },
-    }
-  })
-  const httpLink = new HttpLink({
-    credentials: 'same-origin',
-    uri: process.env.NEXT_SERVER_GRAPHQL_URL,
-  })
+export const getCsrfTokenOnServer = async () => {
+  const cookieStore = await cookies()
+  const csrfCookie = cookieStore.get('csrftoken')
 
-  return new ApolloClient({
-    cache: new InMemoryCache().restore(
-      (globalThis as unknown as { __APOLLO_STATE__?: NormalizedCacheObject }).__APOLLO_STATE__ ?? {}
-    ),
-    link: authLink.concat(httpLink),
-    ssrMode: true,
-  })
+  return csrfCookie ? csrfCookie.value : await fetchCsrfTokenServer()
 }
 
 // This is a no-op Apollo client for end-to-end tests.
@@ -35,11 +16,13 @@ const noopApolloClient = {
   query: async () => ({ data: null }),
 }
 export const apolloClient =
-  process.env.NEXT_SERVER_DISABLE_SSR === 'true' ? noopApolloClient : await createApolloClient()
-
-export const getCsrfTokenOnServer = async () => {
-  const cookieStore = await cookies()
-  const csrfCookie = cookieStore.get('csrftoken')
-
-  return csrfCookie ? csrfCookie.value : await fetchCsrfTokenServer()
-}
+  process.env.NEXT_SERVER_DISABLE_SSR === 'true'
+    ? noopApolloClient
+    : createApolloClient({
+        uri: process.env.NEXT_SERVER_GRAPHQL_URL,
+        credentials: 'same-origin',
+        getCsrfToken: getCsrfTokenOnServer,
+        ssrMode: true,
+        includeCsrfCookie: true,
+        cache: (globalThis as unknown as { __APOLLO_STATE__?: NormalizedCacheObject }).__APOLLO_STATE__ ?? {},
+      })

--- a/frontend/src/utils/helpers/apolloClient.ts
+++ b/frontend/src/utils/helpers/apolloClient.ts
@@ -1,36 +1,21 @@
-import { ApolloClient, InMemoryCache, HttpLink } from '@apollo/client'
-import { setContext } from '@apollo/client/link/context'
 import { AppError, handleAppError } from 'app/global-error'
+import { createApolloClient } from 'lib/apolloClient'
 import { GRAPHQL_URL } from 'utils/env.client'
 import { getCsrfToken } from 'utils/utility'
-const createApolloClient = () => {
+
+const createClientApolloClient = () => {
   if (!GRAPHQL_URL) {
     const error = new AppError(500, 'Missing GraphQL URL')
     handleAppError(error)
     return null
   }
 
-  const httpLink = new HttpLink({
-    credentials: 'include',
+  return createApolloClient({
     uri: GRAPHQL_URL,
-  })
-
-  const authLink = setContext(async (_, { headers }) => {
-    const csrfToken = await getCsrfToken()
-
-    return {
-      headers: {
-        ...headers,
-        'X-CSRFToken': csrfToken || '',
-      },
-    }
-  })
-
-  return new ApolloClient({
-    cache: new InMemoryCache(),
-    link: authLink.concat(httpLink),
+    credentials: 'include',
+    getCsrfToken,
   })
 }
-const apolloClient = createApolloClient()
+const apolloClient = createClientApolloClient()
 
 export default apolloClient


### PR DESCRIPTION
﻿## Consolidate duplicate `apolloClient.ts` into a shared builder

Closes #4006

### What changed

The two `apolloClient.ts` files (`server/apolloClient.ts` and `utils/helpers/apolloClient.ts`) duplicated the same Apollo Client wiring: `HttpLink` + CSRF `authLink` + `InMemoryCache` + `ApolloClient`. Configuration drift risk was the point of #4006.

Rather than merging the two files into one module, I extracted the shared construction into a single parameterized builder:

- **`src/lib/apolloClient.ts`** (new): `createApolloClient({ uri, credentials, getCsrfToken, ssrMode, includeCsrfCookie, cache })` â€” the single source of truth for client construction.
- **`src/server/apolloClient.ts`**: thin wrapper â€” supplies the server URL, cookie-based CSRF, `ssrMode: true`, `__APOLLO_STATE__` restore, and the E2E no-op client. Public exports (`apolloClient`, `getCsrfTokenOnServer`) unchanged.
- **`src/utils/helpers/apolloClient.ts`**: thin wrapper â€” supplies `GRAPHQL_URL`, client-side CSRF, and the `AppError` guard. Default export unchanged.

### Why not one file for both?

The two files cannot physically merge into one module: `server/apolloClient.ts` imports `next/headers`, which is server-only, while `utils/helpers/apolloClient.ts` is imported from `wrappers/provider.tsx` (a `'use client'` component). A single module shared by both would pull `next/headers` into the client bundle and break the build. The builder keeps the real shared logic in one place without crossing the client/server boundary.

### Verification

- All import sites are untouched â€” the named export `apolloClient` and the default export keep their existing shapes, so the 8 server components and the client provider resolve exactly as before.
- The server builder is synchronous now (was `await createApolloClient()`); the module-level result is the same resolved client, and callers already `await` it.

No test files reference these modules (checked via repo search). `npm run test:unit` runs `tsc --noEmit` first; I could not run it locally as this machine has no Node toolchain, so CI is the gate.
