### PR TITLE
Fix /repositories sitemap lastmod to use latest repository update

### DIFF
--- a/backend/src/apps/sitemap/views/static.py
+++ b/backend/src/apps/sitemap/views/static.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime
 from django.db.models import Max
 
 from apps.github.models.organization import Organization
+from apps.github.models.repository import Repository
 from apps.github.models.user import User
 from apps.owasp.models.chapter import Chapter
 from apps.owasp.models.committee import Committee
@@ -67,6 +68,7 @@ class StaticSitemap(BaseSitemap):
             "/members": User,
             "/organizations": Organization,
             "/projects": Project,
+            "/repositories": Repository,
             "/snapshots": Snapshot,
         }
 


### PR DESCRIPTION
## Summary
Fixes the sitemap \lastmod\ for the \/repositories\ page so it reflects the latest repository update instead of a stale date.

## Changes
- \ackend/src/apps/sitemap/views/static.py\: use the latest repository update time when generating the \lastmod\ entry.