### PR TITLE
fix: bump postgresql16-client pin to 16.15-r0

### DIFF
--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -67,7 +67,7 @@ ARG OWASP_UID
 
 RUN apk --no-cache update && \
     apk --no-cache upgrade && \
-    apk --no-cache add make postgresql16-client=16.14-r0 && \
+    apk --no-cache add make postgresql16-client=16.15-r0 && \
     rm -rf /var/cache/apk/* /var/tmp/* /tmp/* && \
     addgroup -S -g ${OWASP_GID} owasp && \
     adduser -S -h /home/owasp -u ${OWASP_UID} -G owasp owasp
@@ -118,7 +118,7 @@ ARG OWASP_UID
 
 RUN apk --no-cache update && \
     apk --no-cache upgrade && \
-    apk --no-cache add ffmpeg make postgresql16-client=16.14-r0 \
+    apk --no-cache add ffmpeg make postgresql16-client=16.15-r0 \
     # WeasyPrint dependencies: https://doc.courtbouillon.org/weasyprint/stable/first_steps.html
     so:libfontconfig.so.1 so:libgobject-2.0.so.0 so:libharfbuzz-subset.so.0 \
     so:libharfbuzz.so.0 so:libpango-1.0.so.0 so:libpangoft2-1.0.so.0 ttf-freefont && \

--- a/docker/backend/Dockerfile.local
+++ b/docker/backend/Dockerfile.local
@@ -57,7 +57,7 @@ RUN mkdir -p ${APK_CACHE_DIR} && \
 
 RUN --mount=type=cache,target=${APK_CACHE_DIR} \
     apk --no-cache update && \
-    apk --no-cache add postgresql16-client=16.14-r0 redis && \
+    apk --no-cache add postgresql16-client=16.15-r0 redis && \
     addgroup -S -g ${OWASP_GID} owasp && \
     adduser -S -h /home/owasp -u ${OWASP_UID} -G owasp owasp
 


### PR DESCRIPTION
## Proposed change

<!-- Don't forget to link your PR to an existing issue.-->
Resolves #5504 

<!-- Describe the big picture of your changes.-->
Bump `postgresql16-client` package from `16.14-r0` to `16.15-r0` in all backend Dockerfiles.

Alpine v3.23 repos dropped `16.14-r0` on August 15, 2026 ([source](https://pkgs.alpinelinux.org/package/v3.23/community/x86_64/postgresql16-client)), breaking `make run` and `make load-data`.

## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran all required checks and tests locally; all warnings addressed and failures resolved
- [ ] I used AI for code, documentation, tests, or communication related to this PR
