### PR TITLE
feat(header): expand UserMenu trigger to show avatar, name and handle…

### DIFF
--- a/frontend/src/components/UserMenu.tsx
+++ b/frontend/src/components/UserMenu.tsx
@@ -74,7 +74,7 @@ export default function UserMenu({
         aria-expanded={isOpen}
         aria-haspopup="true"
         aria-controls={dropdownId}
-        className="w-auto cursor-pointer focus:outline-hidden"
+        className="flex cursor-pointer items-center gap-2 focus:outline-hidden"
         disabled={isLoggingOut}
       >
         <div className="h-10 w-10 overflow-hidden rounded-full">
@@ -86,6 +86,22 @@ export default function UserMenu({
             className="h-full w-full object-cover"
           />
         </div>
+        <div className="flex flex-col items-start leading-tight">
+          <span className="text-sm font-semibold text-slate-800 dark:text-slate-200">
+            {session?.user?.name}
+          </span>
+          <span className="text-xs text-slate-500 dark:text-slate-400">
+            @{session?.user?.login ?? session?.user?.email?.split('@')[0]}
+          </span>
+        </div>
+        <svg
+          className={`h-4 w-4 text-slate-500 transition-transform dark:text-slate-400 ${isOpen ? 'rotate-180' : ''}`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
       </button>
 
       {isOpen && (


### PR DESCRIPTION
## Proposed change

Resolves #3746

The authenticated user button in the navbar previously rendered only a bare avatar circle, giving no visible identity context. This change expands the UserMenu trigger to display the user's avatar, display name, GitHub handle, and an animated chevron 

Changes in UserMenu.tsx:

- session.user.name rendered 
- @login handle rendered 
- Inline chevron SVG added and animation of rotate when it pushed

## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [ ] **Required:** I ran all required checks and tests locally; all warnings addressed and failures resolved
- [x] I used AI for code, documentation, tests, or communication related to this PR
 
