### PR TITLE
feat: update ReadTheDocs theme styling

### DIFF
--- a/.mkdocs.yaml
+++ b/.mkdocs.yaml
@@ -16,6 +16,9 @@ theme:
   name: material
   logo: assets/images/owasp_icon_white_sm.png
   favicon: assets/images/favicon.png
+  font:
+    text: Geist
+    code: Geist Mono
   features:
     - navigation.tabs
     - navigation.instant
@@ -38,14 +41,14 @@ theme:
       toggle:
         icon: material/lightbulb-outline
         name: Switch to dark mode
-      primary: teal
-      accent: amber
+      primary: custom
+      accent: custom
     - scheme: slate
       toggle:
         icon: material/weather-night
         name: Switch to light mode
-      primary: teal
-      accent: cyan
+      primary: custom
+      accent: custom
 markdown_extensions:
   - abbr
   - admonition
@@ -82,3 +85,6 @@ plugins:
   - mkdocstrings:
       default_handler: python
   - tags
+
+extra_css:
+  - stylesheets/extra.css

--- a/docs/src/stylesheets/extra.css
+++ b/docs/src/stylesheets/extra.css
@@ -1,0 +1,74 @@
+/* Nest brand theme overrides for MkDocs Material */
+
+/* ---------- Light mode ---------- */
+[data-md-color-scheme='default'] {
+  --md-default-bg-color: #f4f6fc;
+  --md-default-fg-color: hsl(0 0% 3.9%);
+  --md-typeset-color: #000;
+
+  --md-primary-fg-color: hsl(210 76% 48%);
+  --md-primary-fg-color--light: hsl(210 76% 60%);
+  --md-primary-fg-color--dark: hsl(210 76% 38%);
+  --md-primary-bg-color: hsl(0 0% 100%);
+
+  --md-accent-fg-color: hsl(210 76% 38%);
+  --md-accent-fg-color--transparent: hsl(210 76% 38% / 0.1);
+
+  --md-typeset-a-color: #1d7bd7;
+
+  --md-code-bg-color: #e5e5e5;
+  --md-code-fg-color: oklch(58.8% 0.158 241.966);
+
+  --md-footer-bg-color: hsl(0 0% 14.9%);
+  --md-footer-fg-color: hsl(0 0% 98%);
+}
+
+/* ---------- Dark mode ---------- */
+[data-md-color-scheme='slate'] {
+  --md-default-bg-color: #212529;
+  --md-default-fg-color: hsl(0 0% 98%);
+  --md-typeset-color: #fff;
+
+  --md-primary-fg-color: hsl(210 76% 48%);
+  --md-primary-fg-color--light: hsl(210 76% 60%);
+  --md-primary-fg-color--dark: hsl(210 76% 38%);
+  --md-primary-bg-color: hsl(0 0% 3.9%);
+
+  --md-accent-fg-color: hsl(210 76% 60%);
+  --md-accent-fg-color--transparent: hsl(210 76% 60% / 0.15);
+
+  --md-typeset-a-color: #1d7bd7;
+
+  --md-code-bg-color: #333539;
+  --md-code-fg-color: oklch(74.6% 0.16 232.661);
+
+  --md-footer-bg-color: hsl(0 0% 9%);
+  --md-footer-fg-color: hsl(0 0% 98%);
+}
+
+/* ------------ Scrollbar ------------*/
+[data-md-color-scheme='default'] ::-webkit-scrollbar-track {
+  background: #7689ad;
+}
+[data-md-color-scheme='default'] ::-webkit-scrollbar-thumb {
+  background: #3d4554;
+}
+[data-md-color-scheme='slate'] ::-webkit-scrollbar-track {
+  background: #2d3748;
+}
+[data-md-color-scheme='slate'] ::-webkit-scrollbar-thumb {
+  background: #4a5568;
+}
+
+/* Header colors to match Nest */
+[data-md-color-scheme='default'] .md-header,
+[data-md-color-scheme='default'] .md-tabs {
+  background-color: #98afc7;
+  --md-primary-bg-color: #1e293b;
+}
+
+[data-md-color-scheme='slate'] .md-header,
+[data-md-color-scheme='slate'] .md-tabs {
+  background-color: #1e293b;
+  --md-primary-bg-color: #cbd5e1;
+}

--- a/docs/src/stylesheets/extra.css
+++ b/docs/src/stylesheets/extra.css
@@ -47,17 +47,31 @@
 }
 
 /* ------------ Scrollbar ------------ */
+html[data-md-color-scheme='default']::-webkit-scrollbar-track,
 [data-md-color-scheme='default'] ::-webkit-scrollbar-track {
   background: #94a3b8;
 }
+html[data-md-color-scheme='default']::-webkit-scrollbar-thumb,
 [data-md-color-scheme='default'] ::-webkit-scrollbar-thumb {
   background: #334155;
 }
+html[data-md-color-scheme='slate']::-webkit-scrollbar-track,
 [data-md-color-scheme='slate'] ::-webkit-scrollbar-track {
   background: #1f2937;
 }
+html[data-md-color-scheme='slate']::-webkit-scrollbar-thumb,
 [data-md-color-scheme='slate'] ::-webkit-scrollbar-thumb {
   background: #94a3b8;
+}
+
+/* Firefox fallback (standardized scrollbar properties) */
+html[data-md-color-scheme='default'] {
+  scrollbar-color: #334155 #94a3b8;
+  scrollbar-width: auto;
+}
+html[data-md-color-scheme='slate'] {
+  scrollbar-color: #94a3b8 #1f2937;
+  scrollbar-width: auto;
 }
 
 /* Header colors to match Nest */

--- a/docs/src/stylesheets/extra.css
+++ b/docs/src/stylesheets/extra.css
@@ -47,29 +47,29 @@
 }
 
 /* ------------ Scrollbar ------------ */
-html[data-md-color-scheme='default']::-webkit-scrollbar-track,
+html:has(body[data-md-color-scheme='default'])::-webkit-scrollbar-track,
 [data-md-color-scheme='default'] ::-webkit-scrollbar-track {
   background: #94a3b8;
 }
-html[data-md-color-scheme='default']::-webkit-scrollbar-thumb,
+html:has(body[data-md-color-scheme='default'])::-webkit-scrollbar-thumb,
 [data-md-color-scheme='default'] ::-webkit-scrollbar-thumb {
   background: #334155;
 }
-html[data-md-color-scheme='slate']::-webkit-scrollbar-track,
+html:has(body[data-md-color-scheme='slate'])::-webkit-scrollbar-track,
 [data-md-color-scheme='slate'] ::-webkit-scrollbar-track {
   background: #1f2937;
 }
-html[data-md-color-scheme='slate']::-webkit-scrollbar-thumb,
+html:has(body[data-md-color-scheme='slate'])::-webkit-scrollbar-thumb,
 [data-md-color-scheme='slate'] ::-webkit-scrollbar-thumb {
   background: #94a3b8;
 }
 
 /* Firefox fallback (standardized scrollbar properties) */
-html[data-md-color-scheme='default'] {
+html:has(body[data-md-color-scheme='default']) {
   scrollbar-color: #334155 #94a3b8;
   scrollbar-width: auto;
 }
-html[data-md-color-scheme='slate'] {
+html:has(body[data-md-color-scheme='slate']) {
   scrollbar-color: #94a3b8 #1f2937;
   scrollbar-width: auto;
 }

--- a/docs/src/stylesheets/extra.css
+++ b/docs/src/stylesheets/extra.css
@@ -14,7 +14,7 @@
   --md-accent-fg-color: hsl(210 76% 38%);
   --md-accent-fg-color--transparent: hsl(210 76% 38% / 0.1);
 
-  --md-typeset-a-color: #1d7bd7;
+  --md-typeset-a-color: #1d4ed8;
 
   --md-code-bg-color: #e5e5e5;
   --md-code-fg-color: oklch(58.8% 0.158 241.966);
@@ -37,7 +37,7 @@
   --md-accent-fg-color: hsl(210 76% 60%);
   --md-accent-fg-color--transparent: hsl(210 76% 60% / 0.15);
 
-  --md-typeset-a-color: #1d7bd7;
+  --md-typeset-a-color: #60a5fa;
 
   --md-code-bg-color: #333539;
   --md-code-fg-color: oklch(74.6% 0.16 232.661);
@@ -46,18 +46,18 @@
   --md-footer-fg-color: hsl(0 0% 98%);
 }
 
-/* ------------ Scrollbar ------------*/
+/* ------------ Scrollbar ------------ */
 [data-md-color-scheme='default'] ::-webkit-scrollbar-track {
-  background: #7689ad;
+  background: #94a3b8;
 }
 [data-md-color-scheme='default'] ::-webkit-scrollbar-thumb {
-  background: #3d4554;
+  background: #334155;
 }
 [data-md-color-scheme='slate'] ::-webkit-scrollbar-track {
-  background: #2d3748;
+  background: #1f2937;
 }
 [data-md-color-scheme='slate'] ::-webkit-scrollbar-thumb {
-  background: #4a5568;
+  background: #94a3b8;
 }
 
 /* Header colors to match Nest */


### PR DESCRIPTION
## Proposed change

Resolves #5507

This PR updates the ReadTheDocs/MkDocs documentation theme to match the Nest light and dark themes.

### Changes

- Added Geist and Geist Mono fonts to match the Nest frontend typography.
- Added custom light and dark theme colors based on the Nest frontend theme.
- Updated the documentation header and tabs to match the Nest header colors.
- Added custom code block and link colors for both themes.
- Added light and dark scrollbar styling.
- Enabled custom primary and accent colors through `extra.css`.

### Design decisions

- The Nest frontend theme values were used as the source of truth for the documentation colors.
- Header colors were taken from the Nest `Header.tsx` implementation:
  - Light mode: `#98AFC7`
  - Dark mode: `#1e293b`
- The existing primary color behavior was preserved through scoped `--md-primary-bg-color` overrides for the light and dark header backgrounds.
- Styling was implemented through `extra.css` instead of `custom_dir`, since no MkDocs HTML/template overrides are required.

### Validation

- `make test-docs` — passed (10 tests)
- Pre-commit checks — passed
- Prettier — passed
- `git diff --check` — passed
- Verified the documentation in both light and dark modes.
- Verified code blocks, tables, navigation, and other documentation elements in both themes.
- `make check-test` — ESLint reported a warning from the ignored generated `frontend/coverage/lcov-report/block-navigation.js`; no changes were made to generated or unrelated files.

## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran all required checks and tests locally; all warnings addressed and failures resolved
- [x] I used AI for code, documentation, tests, or communication related to this PR