### PR TITLE
expand usermenu to show name, handle

### DIFF
--- a/frontend/__tests__/unit/components/UserMenu.test.tsx
+++ b/frontend/__tests__/unit/components/UserMenu.test.tsx
@@ -478,6 +478,134 @@ describe('UserMenu Component', () => {
       expect(screen.getByTestId('github-icon')).toBeInTheDocument()
     })
 
+    it('renders user display name and handle when authenticated', () => {
+      mockUseSession.mockReturnValue({
+        session: {
+          ...mockSession,
+          user: {
+            ...mockSession.user,
+            name: 'John Doe',
+            login: 'johndoe',
+          },
+        },
+        isSyncing: false,
+        status: 'authenticated',
+      })
+
+      render(<UserMenu isGitHubAuthEnabled={true} />)
+
+      expect(screen.getByText('John Doe')).toBeInTheDocument()
+      expect(screen.getByText('@johndoe')).toBeInTheDocument()
+    })
+
+    it('falls back to login when name is absent and does not duplicate handle', () => {
+      mockUseSession.mockReturnValue({
+        session: {
+          ...mockSession,
+          user: {
+            ...mockSession.user,
+            name: undefined,
+            login: 'johndoe',
+          },
+        },
+        isSyncing: false,
+        status: 'authenticated',
+      })
+
+      render(<UserMenu isGitHubAuthEnabled={true} />)
+
+      expect(screen.getByText('johndoe')).toBeInTheDocument()
+      expect(screen.queryByText('@johndoe')).not.toBeInTheDocument()
+    })
+
+    it('does not render handle when display name matches handle case-insensitively', () => {
+      mockUseSession.mockReturnValue({
+        session: {
+          ...mockSession,
+          user: {
+            ...mockSession.user,
+            name: 'JohnDoe',
+            login: 'johndoe',
+          },
+        },
+        isSyncing: false,
+        status: 'authenticated',
+      })
+
+      render(<UserMenu isGitHubAuthEnabled={true} />)
+
+      expect(screen.getByText('JohnDoe')).toBeInTheDocument()
+      expect(screen.queryByText('@johndoe')).not.toBeInTheDocument()
+    })
+
+    it('renders handle derived from email when name and login are absent', () => {
+      mockUseSession.mockReturnValue({
+        session: {
+          ...mockSession,
+          user: {
+            ...mockSession.user,
+            name: undefined,
+            login: undefined,
+            email: 'john@example.com',
+          },
+        },
+        isSyncing: false,
+        status: 'authenticated',
+      })
+
+      render(<UserMenu isGitHubAuthEnabled={true} />)
+
+      expect(screen.getByText('User')).toBeInTheDocument()
+      expect(screen.getByText('@john')).toBeInTheDocument()
+    })
+
+    it('falls back to User when neither name nor login is present', () => {
+      mockUseSession.mockReturnValue({
+        session: {
+          ...mockSession,
+          user: {
+            ...mockSession.user,
+            name: undefined,
+            login: undefined,
+            email: undefined,
+          },
+        },
+        isSyncing: false,
+        status: 'authenticated',
+      })
+
+      render(<UserMenu isGitHubAuthEnabled={true} />)
+
+      expect(screen.getByText('User')).toBeInTheDocument()
+      expect(screen.queryByText(/^@/)).not.toBeInTheDocument()
+    })
+
+    it('toggles chevron rotation class when dropdown opens and closes', async () => {
+      mockUseSession.mockReturnValue({
+        session: mockSession,
+        isSyncing: false,
+        status: 'authenticated',
+      })
+
+      const { container } = render(<UserMenu isGitHubAuthEnabled={true} />)
+      const chevron = container.querySelector('svg.transition-transform')
+      expect(chevron).toBeInTheDocument()
+      expect(chevron).not.toHaveClass('rotate-180')
+
+      const button = screen.getByRole('button')
+      fireEvent.click(button)
+
+      await waitFor(() => {
+        expect(chevron).toHaveClass('rotate-180')
+      })
+
+      fireEvent.click(button)
+
+      await waitFor(() => {
+        expect(chevron).not.toHaveClass('rotate-180')
+      })
+    })
+
     it('renders correct sign out button text', async () => {
       mockUseSession.mockReturnValue({
         session: mockSession,

--- a/frontend/src/components/UserMenu.tsx
+++ b/frontend/src/components/UserMenu.tsx
@@ -66,6 +66,10 @@ export default function UserMenu({
   const userMenuItemClasses =
     'block w-full cursor-pointer px-4 py-2 text-left text-sm font-medium text-slate-600 hover:bg-slate-100 hover:text-slate-900 dark:text-slate-400 dark:hover:bg-slate-700 dark:hover:text-white'
 
+  const displayName = session?.user?.name || session?.user?.login || 'User'
+  const userHandle = session?.user?.login ?? session?.user?.email?.split('@')[0]
+  const showHandle = Boolean(userHandle && userHandle.toLowerCase() !== displayName.toLowerCase())
+
   return (
     <div ref={dropdownRef} className="relative flex items-center justify-center">
       <button
@@ -74,10 +78,10 @@ export default function UserMenu({
         aria-expanded={isOpen}
         aria-haspopup="true"
         aria-controls={dropdownId}
-        className="w-auto cursor-pointer focus:outline-hidden"
+        className="flex w-auto cursor-pointer items-center gap-2 focus:outline-hidden"
         disabled={isLoggingOut}
       >
-        <div className="h-10 w-10 overflow-hidden rounded-full">
+        <div className="h-10 w-10 shrink-0 overflow-hidden rounded-full">
           <Image
             src={session?.user?.image ?? '/default-avatar.png'}
             alt="User avatar"
@@ -86,8 +90,28 @@ export default function UserMenu({
             className="h-full w-full object-cover"
           />
         </div>
+        <div className="flex min-w-0 flex-col items-start leading-tight">
+          <span className="max-w-28 truncate text-sm font-semibold text-slate-800 sm:max-w-36 dark:text-slate-200">
+            {displayName}
+          </span>
+          {showHandle && (
+            <span className="max-w-28 truncate text-xs text-slate-500 sm:max-w-36 dark:text-slate-400">
+              @{userHandle}
+            </span>
+          )}
+        </div>
+        <svg
+          className={`h-4 w-4 shrink-0 text-slate-500 transition-transform duration-200 dark:text-slate-400 ${
+            isOpen ? 'rotate-180' : ''
+          }`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
       </button>
-
       {isOpen && (
         <div
           id={dropdownId}


### PR DESCRIPTION
## Proposed change
Resolves #3746 

The authenticated user button in the navbar previously rendered only a bare avatar circle, giving no visible identity context and feeling visually unbalanced in both the desktop navbar and the mobile drawer.                                                
    This change expands the UserMenu trigger to display:                                                                         
    - The user's circular avatar                                                                                                   
    - Display name                                                                             
    - GitHub handle                                                                
    - Smoothly animated rotating chevron indicator when the menu opens/closes                                                      
    - `min-w-0` and truncation styling to ensure long names/logins do not overflow in desktop view or the 16rem mobile navigation drawer                                                                                                                           
                                                                                                                                   
    Unit tests have been added to verify:                                                                                          
    - Name and handle rendering                                                                                                    
    - Fallback when display name is not provided                                                                                   
    - Safe omitting of handle when absent
    - Chevron icon rotation class toggling on menu state change

## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran all required checks and tests locally; all warnings addressed and failures resolved
- [x] I used AI for code, documentation, tests, or communication related to this PR
