### PR TITLE
Update ReadTheDocs theme to match Nest light and dark themes

### DIFF
--- a/.mkdocs.yaml
+++ b/.mkdocs.yaml
@@ -16,6 +16,9 @@ theme:
   name: material
   logo: assets/images/owasp_icon_white_sm.png
   favicon: assets/images/favicon.png
+  font:
+    text: Geist
+    code: Geist Mono
   features:
     - navigation.tabs
     - navigation.instant
@@ -82,3 +85,6 @@ plugins:
   - mkdocstrings:
       default_handler: python
   - tags
+
+extra_css:
+  - assets/stylesheets/nest-theme.css

--- a/docs/src/assets/stylesheets/nest-theme.css
+++ b/docs/src/assets/stylesheets/nest-theme.css
@@ -1,0 +1,131 @@
+[data-md-color-scheme='default'] {
+  --md-primary-fg-color: #1d7bd7;
+  --md-accent-fg-color: #1d7bd7;
+  --md-default-bg-color: #f4f6fc;
+  --md-default-fg-color: #000000;
+  --md-typeset-color: #000000;
+  --md-typeset-a-color: #1565c0;
+}
+
+[data-md-color-scheme='slate'] {
+  --md-primary-fg-color: #1d7bd7;
+  --md-accent-fg-color: #1d7bd7;
+  --md-default-bg-color: #212529;
+  --md-default-fg-color: #ffffff;
+  --md-typeset-color: #ffffff;
+  --md-typeset-a-color: #64b5f6;
+}
+
+/* Header */
+[data-md-color-scheme='default'] .md-header,
+[data-md-color-scheme='default'] .md-tabs {
+  background-color: #98afc7;
+  color: #000000;
+}
+
+[data-md-color-scheme='slate'] .md-header,
+[data-md-color-scheme='slate'] .md-tabs {
+  background-color: #1e293b;
+  color: #ffffff;
+}
+
+/* Content links */
+[data-md-color-scheme='default'] .md-content .md-typeset a {
+  color: #1565c0;
+}
+
+[data-md-color-scheme='slate'] .md-typeset a {
+  color: #64b5f6 !important;
+}
+
+/* sidebar links */
+
+[data-md-color-scheme='default'] .md-nav__link--active,
+[data-md-color-scheme='default'] .md-nav__link:hover,
+[data-md-color-scheme='default'] .md-nav__link:focus {
+  color: #1565c0 !important;
+}
+
+[data-md-color-scheme='slate'] .md-nav__link--active,
+[data-md-color-scheme='slate'] .md-nav__link:hover,
+[data-md-color-scheme='slate'] .md-nav__link:focus {
+  color: #64b5f6 !important;
+}
+
+/* Header links */
+
+[data-md-color-scheme='slate'] .md-header a,
+[data-md-color-scheme='slate'] .md-tabs a,
+[data-md-color-scheme='slate'] .md-header__title,
+[data-md-color-scheme='slate'] .md-tabs__link {
+  color: #ffffff;
+}
+
+[data-md-color-scheme='slate'] .md-header a:hover,
+[data-md-color-scheme='slate'] .md-tabs a:hover,
+[data-md-color-scheme='slate'] .md-tabs__link:hover {
+  color: #64b5f6 !important;
+}
+
+[data-md-color-scheme='default'] .md-header a,
+[data-md-color-scheme='default'] .md-tabs a,
+[data-md-color-scheme='default'] .md-header__title,
+[data-md-color-scheme='default'] .md-tabs__link {
+  color: #000000;
+}
+
+[data-md-color-scheme='default'] .md-header a:hover,
+[data-md-color-scheme='default'] .md-tabs a:hover,
+[data-md-color-scheme='default'] .md-tabs__link:hover {
+  color: #ffffff !important;
+}
+
+/* Tabs typography */
+
+.md-tabs .md-tabs__link,
+.md-tabs__list .md-tabs__item .md-tabs__link {
+  font-weight: 500 !important;
+}
+
+.md-tabs__link {
+  opacity: 1 !important;
+}
+
+/* Search */
+
+[data-md-color-scheme='default'] .md-search__form {
+  background-color: rgba(0, 0, 0, 0.15);
+}
+
+[data-md-color-scheme='slate'] .md-search__form {
+  background-color: rgba(0, 0, 0, 0.25);
+}
+
+/* Footer */
+
+[data-md-color-scheme='default'] .md-footer-meta {
+  background-color: #98afc7;
+  color: #000000;
+}
+
+[data-md-color-scheme='slate'] .md-footer-meta {
+  background-color: #1e293b;
+  color: #ffffff;
+}
+
+/* Logo */
+
+[data-md-color-scheme='default'] .md-header__button.md-logo img,
+[data-md-color-scheme='default'] .md-header__button.md-logo svg {
+  filter: invert(1) brightness(0);
+}
+
+/* Code blocks */
+
+[data-md-color-scheme='default'] .md-content .md-typeset a code {
+  color: #1565c0;
+}
+
+[data-md-color-scheme='slate'] .md-content .md-typeset a code {
+  color: #64b5f6;
+}

--- a/frontend/__tests__/unit/components/GlobalSearch.test.tsx
+++ b/frontend/__tests__/unit/components/GlobalSearch.test.tsx
@@ -59,6 +59,7 @@ const mockWindowOpen = jest.fn()
 
 describe('GlobalSearch', () => {
   beforeEach(() => {
+    localStorage.clear()
     ;(useRouter as jest.Mock).mockReturnValue(mockRouter)
     ;(fetchAlgoliaData as jest.Mock).mockResolvedValue({ hits: [], totalPages: 0 })
     jest.clearAllMocks()
@@ -521,6 +522,94 @@ describe('GlobalSearch', () => {
     fireEvent.keyDown(input, { key: 'Enter' })
     await waitFor(() => {
       expect(mockRouter.push).toHaveBeenCalledWith('/projects/project-1')
+    })
+  })
+
+  // test for recent searches functionality
+
+  test('persists selected suggestion to localStorage across a remount', async () => {
+    ;(fetchAlgoliaData as jest.Mock).mockImplementation((index: string) => {
+      if (index === 'projects') {
+        return Promise.resolve({
+          hits: [{ key: 'test-project', name: 'Test Project' }],
+          totalPages: 1,
+        })
+      }
+      return Promise.resolve({ hits: [], totalPages: 0 })
+    })
+
+    const { unmount } = render(<GlobalSearch />)
+    fireEvent.click(screen.getByLabelText('Open search'))
+
+    const input = screen.getByPlaceholderText('Search the OWASP community...')
+    await userEvent.type(input, 'test')
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Project')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Test Project'))
+
+    unmount()
+
+    render(<GlobalSearch />)
+    fireEvent.click(screen.getByLabelText('Open search'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Recent Searches')).toBeInTheDocument()
+      expect(screen.getByText('Test Project')).toBeInTheDocument()
+    })
+  })
+
+  // test for saving typed query to recent searches when pressing Enter without selecting a suggestion
+  test('saves typed query to recent searches when pressing Enter without selecting a suggestion', async () => {
+    ;(fetchAlgoliaData as jest.Mock).mockResolvedValue({ hits: [], totalPages: 0 })
+
+    const { unmount } = render(<GlobalSearch />)
+    fireEvent.click(screen.getByLabelText('Open search'))
+
+    const input = screen.getByPlaceholderText('Search the OWASP community...')
+    await userEvent.type(input, 'japan')
+
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    unmount()
+
+    render(<GlobalSearch />)
+    fireEvent.click(screen.getByLabelText('Open search'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Recent Searches')).toBeInTheDocument()
+      expect(screen.getByText('japan')).toBeInTheDocument()
+    })
+  })
+
+  // test for removing a recent search from the list
+  test('removes a recent search from the list', async () => {
+    ;(fetchAlgoliaData as jest.Mock).mockResolvedValue({ hits: [], totalPages: 0 })
+
+    const { unmount } = render(<GlobalSearch />)
+    fireEvent.click(screen.getByLabelText('Open search'))
+
+    const input = screen.getByPlaceholderText('Search the OWASP community...')
+    await userEvent.type(input, 'japan')
+
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    unmount()
+
+    render(<GlobalSearch />)
+    fireEvent.click(screen.getByLabelText('Open search'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Recent Searches')).toBeInTheDocument()
+      expect(screen.getByText('japan')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByLabelText('Remove japan from recent searches'))
+
+    await waitFor(() => {
+      expect(screen.queryByText('japan')).not.toBeInTheDocument()
     })
   })
 })

--- a/frontend/src/components/GlobalSearch.tsx
+++ b/frontend/src/components/GlobalSearch.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { sendGAEvent } from '@next/third-parties/google'
+import useRecentSearches from 'hooks/useRecentSearches'
 import { useShouldAutoFocusSearch } from 'hooks/useShouldAutoFocusSearch'
 import { debounce } from 'lodash'
 import { useRouter } from 'next/navigation'
@@ -21,6 +22,7 @@ type SearchHit = Chapter | Event | Organization | Project | User
 const INDEXES = ['chapters', 'events', 'organizations', 'projects', 'users']
 const SUGGESTION_COUNT = 3
 const EMPTY_STATE_EXAMPLES = 'Try searches like "OWASP", "London", "AppSec", "Nest", or "John".'
+const MAX_RECENT_SEARCHES = 5
 
 export default function GlobalSearch() {
   const [isOpen, setIsOpen] = useState(false)
@@ -32,6 +34,7 @@ export default function GlobalSearch() {
     subIndex: number
   } | null>(null)
   const [searchError, setSearchError] = useState(false)
+  const [isSearching, setIsSearching] = useState(false)
 
   const router = useRouter()
   const inputRef = useRef<HTMLInputElement>(null)
@@ -39,6 +42,7 @@ export default function GlobalSearch() {
   const searchVersionRef = useRef(0)
   const previousFocusRef = useRef<HTMLElement | null>(null)
   const shouldAutoFocus = useShouldAutoFocusSearch()
+  const { recentSearchResults, setRecentSearch, removeRecentSearch } = useRecentSearches()
 
   useEffect(() => {
     const handleGlobalKeyDown = (e: KeyboardEvent) => {
@@ -72,6 +76,7 @@ export default function GlobalSearch() {
     if (!isOpen) {
       searchVersionRef.current++
       setSearchQuery('')
+      setIsSearching(false)
       setSuggestions([])
       setShowSuggestions(false)
       setHighlightedIndex(null)
@@ -109,6 +114,7 @@ export default function GlobalSearch() {
             })
           )
           if (version !== searchVersionRef.current) return
+          setIsSearching(false)
           if (failedCount === INDEXES.length) {
             setSuggestions([])
             setShowSuggestions(false)
@@ -119,11 +125,30 @@ export default function GlobalSearch() {
           }
         } else {
           searchVersionRef.current++
+          setIsSearching(false)
           setSuggestions([])
           setShowSuggestions(false)
         }
       }, 300),
     []
+  )
+
+  // Function to add a search query to recent searches
+
+  const handleAddRecentSearch = useCallback(
+    (query: string) => {
+      if (query && query.trim() !== '') {
+        const trimmedQuery = query.trim()
+        setRecentSearch((prev: string[]) => {
+          const current = Array.isArray(prev)
+            ? prev.filter((item): item is string => typeof item === 'string')
+            : []
+          const filtered = current.filter((item) => item !== trimmedQuery)
+          return [trimmedQuery, ...filtered].slice(0, MAX_RECENT_SEARCHES)
+        })
+      }
+    },
+    [setRecentSearch]
   )
 
   useEffect(() => {
@@ -135,6 +160,12 @@ export default function GlobalSearch() {
   const handleSuggestionClick = useCallback(
     (suggestion: SearchHit, indexName: string) => {
       setIsOpen(false)
+
+      const hitRecord = suggestion as unknown as Record<string, string | undefined>
+      const label = hitRecord.name || hitRecord.login
+      if (label) {
+        handleAddRecentSearch(label)
+      }
 
       switch (indexName) {
         case 'chapters':
@@ -163,7 +194,7 @@ export default function GlobalSearch() {
           break
       }
     },
-    [router]
+    [router, handleAddRecentSearch]
   )
 
   useEffect(() => {
@@ -243,6 +274,7 @@ export default function GlobalSearch() {
   const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newQuery = e.target.value
     setSearchQuery(newQuery)
+    setIsSearching(newQuery.trim() !== '')
     debouncedSearch(newQuery)
     setHighlightedIndex(null)
   }
@@ -250,9 +282,11 @@ export default function GlobalSearch() {
   const handleClearSearch = () => {
     searchVersionRef.current++
     setSearchQuery('')
+    setIsSearching(false)
     setSuggestions([])
     setShowSuggestions(false)
     setHighlightedIndex(null)
+    setSearchError(false)
     if (shouldAutoFocus) {
       inputRef.current?.focus()
     }
@@ -346,6 +380,13 @@ export default function GlobalSearch() {
   )
 
   const renderSearchContent = () => {
+    if (isSearching) {
+      return (
+        <div className="px-4 py-3 text-center text-sm text-gray-400 dark:text-gray-500">
+          Searching...
+        </div>
+      )
+    }
     if (showSuggestions && suggestions.length > 0) {
       return (
         <>
@@ -380,11 +421,50 @@ export default function GlobalSearch() {
       )
     }
 
-    return (
-      <div className="px-4 py-2 text-center text-sm text-gray-400 dark:text-gray-500">
-        {EMPTY_STATE_EXAMPLES}
-      </div>
-    )
+    if (!searchQuery && Array.isArray(recentSearchResults) && recentSearchResults.length > 0) {
+      return (
+        <div>
+          <div className="px-4 pt-3 pb-1 text-xs font-semibold tracking-wider text-gray-500 uppercase dark:text-gray-400">
+            Recent Searches
+          </div>
+          <ul>
+            {recentSearchResults.map((result: string) => (
+              <li
+                key={result}
+                className="mx-2 mb-2 flex items-center justify-between rounded-lg px-3 py-2.5 text-sm text-gray-700 hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700/50"
+              >
+                <button
+                  type="button"
+                  onClick={() => {
+                    setSearchQuery(result)
+                    debouncedSearch(result)
+                  }}
+                  className="flex-1 truncate overflow-hidden border-none bg-transparent text-left"
+                >
+                  {result}
+                </button>
+                <button
+                  type="button"
+                  aria-label={`Remove ${result} from recent searches`}
+                  className="ml-2 shrink-0 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+                  onClick={() => removeRecentSearch(result)}
+                >
+                  <FaTimes className="h-3 w-3" />
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )
+    }
+
+    if (!searchQuery && (!Array.isArray(recentSearchResults) || recentSearchResults.length === 0)) {
+      return (
+        <div className="px-4 py-2 text-center text-sm text-gray-400 dark:text-gray-500">
+          {EMPTY_STATE_EXAMPLES}
+        </div>
+      )
+    }
   }
 
   return (
@@ -422,15 +502,20 @@ export default function GlobalSearch() {
           />
           <div
             ref={panelRef}
-            className="relative mx-4 w-full max-w-xl overflow-hidden rounded-xl border border-gray-200 bg-white shadow-2xl dark:border-gray-700 dark:bg-gray-800"
+            className="relative mx-4 w-full max-w-xl rounded-xl border border-gray-200 bg-white shadow-2xl dark:border-gray-700 dark:bg-gray-800"
           >
-            <div className="relative flex items-center border-b border-gray-200 dark:border-gray-700">
+            <div className="relative flex items-center rounded-t-xl border-b border-gray-200 dark:border-gray-700">
               <FaSearch className="pointer-events-none absolute left-4 h-4 w-4 text-gray-400" />
               <input
                 ref={inputRef}
                 type="text"
                 value={searchQuery}
                 onChange={handleSearchChange}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && highlightedIndex === null && searchQuery.trim() !== '') {
+                    handleAddRecentSearch(searchQuery)
+                  }
+                }}
                 placeholder="Search the OWASP community..."
                 aria-label="Search the OWASP community"
                 className="h-14 w-full bg-transparent pr-10 pl-11 text-base text-gray-900 placeholder-gray-400 focus:outline-none dark:text-white dark:placeholder-gray-500"

--- a/frontend/src/hooks/useRecentSearches.ts
+++ b/frontend/src/hooks/useRecentSearches.ts
@@ -1,0 +1,56 @@
+'use client'
+
+/**
+ * Custom hook to manage and persist recent search results in localStorage.
+ * Handles retrieving, saving, and removing individual recent searches.
+ */
+
+import { useState, useEffect, useCallback } from 'react'
+
+const useRecentSearches = () => {
+  const [recentSearchResults, setRecentSearchResults] = useState<string[]>([])
+
+  useEffect(() => {
+    try {
+      const savedResults = localStorage.getItem('recentSearchResults')
+      if (savedResults) {
+        const parseResults = JSON.parse(savedResults)
+        if (Array.isArray(parseResults) && parseResults.every((item) => typeof item === 'string')) {
+          setRecentSearchResults(parseResults)
+        }
+      }
+    } catch {
+      // Ignore errors related to localStorage access or JSON parsing
+    }
+  }, [])
+
+  const setRecentSearch = useCallback((updater: string[] | ((prev: string[]) => string[])) => {
+    setRecentSearchResults((prev) => {
+      const next = typeof updater === 'function' ? updater(prev) : updater
+      try {
+        localStorage.setItem('recentSearchResults', JSON.stringify(next))
+      } catch {
+        // Ignore errors related to localStorage access
+      }
+      return next
+    })
+  }, [])
+
+  // Removes a specific search query from the recent searches list.
+
+  const removeRecentSearch = useCallback((query: string) => {
+    setRecentSearchResults((prev) => {
+      const next = prev.filter((item) => item !== query)
+      try {
+        localStorage.setItem('recentSearchResults', JSON.stringify(next))
+      } catch {
+        // Ignore errors related to localStorage access
+      }
+      return next
+    })
+  }, [])
+
+  return { recentSearchResults, setRecentSearch, removeRecentSearch }
+}
+
+export default useRecentSearches


### PR DESCRIPTION
## Proposed change

Resolves #5507

This PR customizes the ReadTheDocs/MkDocs documentation theme to match the Nest light and dark themes.

## Changes

Added custom light and dark theme colors based on the Nest frontend theme (globals.css).
Added the Geist font and Geist Mono for code to match the Nest frontend typography.
Updated the documentation header, tabs, and footer to match the Nest header/footer colors.
Updated sidebar navigation and inline content link colors for both themes.
Fixed the documentation logo so it renders correctly (inverted) in light mode.
Enabled custom primary, accent, and link colors through nest-theme.css.


## Design decisions

The Nest frontend theme values were used as the source of truth for the documentation colors:

Header / tabs / footer background — Light mode: 
#98AFC7, Dark mode: 
#1e293b
Page background — Light mode: 
#f4f6fc, Dark mode: 
#212529
Primary color — 
#1d7bd7 (from Nest's --primary CSS variable)

The primary color (
#1d7bd7) did not meet the WCAG 4.5:1 contrast requirement for normal text on either background (~4.0:1 light, ~3.6:1 dark). Separate, darker/lighter accessible link colors were defined per scheme instead:
Light mode links: 
#1565C0 (~5.3:1 contrast)
Dark mode links: 
#64B5F6 (~7.0:1 contrast)
Styling was implemented through nest-theme.css .

## Validation

Verified contrast ratios for all text/background color pairs against WCAG AA (4.5:1 normal text, 3:1 UI components)
Verified the documentation in both light and dark modes, including theme switching
Verified all documentation pages (Home, API, Backend, Frontend, NestBot, Schema, Maintenance) render correctly in both themes, including code blocks, tables, and navigation


## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [x] **Required:** I verified that my code works as intended and resolves the issue as described
- [x] **Required:** I ran all required checks and tests locally; all warnings addressed and failures resolved
- [x] I used AI for code, documentation, tests, or communication related to this PR
