### PR TITLE
fix(frontend): consistent Search bottom spacing on mobile across pages

### DIFF
--- a/frontend/src/components/SearchPageLayout.tsx
+++ b/frontend/src/components/SearchPageLayout.tsx
@@ -73,7 +73,7 @@ const SearchPageLayout = ({
               {filterChildren}
             </div>
           ))}
-        <div className="flex w-full justify-center md:w-[28rem] md:shrink-0">
+        <div className="mb-4 flex w-full justify-center md:mb-0 md:w-[28rem] md:shrink-0">
           <SearchBar
             isLoaded={!isFirstLoad}
             onSearch={onSearch}
@@ -98,7 +98,7 @@ const SearchPageLayout = ({
       {/* Mobile layout — max-w-md matches SearchBar so stacked controls align with search */}
       {(filterChildren || (inlineSort && sortChildren)) && (
         <div
-          className={`mx-auto mt-2 mb-4 flex w-full max-w-md items-stretch md:hidden ${
+          className={`mx-auto -mt-1 mb-4 flex w-full max-w-md items-stretch md:hidden ${
             inlineSort ? 'gap-0' : 'justify-between gap-4'
           }`}
         >


### PR DESCRIPTION
## Proposed change

Fixes inconsistent vertical spacing below the Search component in mobile viewport.

Pages rendered via `SearchPageLayout` **without** `filterChildren`/`sortChildren` (Members, Committees) had no gap between the search bar and content, while pages **with** filters (Chapters, Projects) got spacing from the mobile filter row.

- Added base `mb-4` to the search-bar wrapper (reset at `md:`)
- Compensated the mobile filter row's top margin (`mt-2` → `-mt-1`) so filtered pages don't double-space

Resolves #5148

## Checklist

- [x] I am assigned to issue #5148
- [x] Commits are signed and DCO signed-off
- [x] `tsc --noEmit` passes locally
- [x] Quality gates passed on prior run (SonarCloud, CodeRabbit, Snyk)