### PR TITLE
fix(sitemap): resolve /repositories lastmod to Repository model

### DIFF
--- a/backend/src/apps/sitemap/views/static.py
+++ b/backend/src/apps/sitemap/views/static.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime
 from django.db.models import Max
 
 from apps.github.models.organization import Organization
+from apps.github.models.repository import Repository
 from apps.github.models.user import User
 from apps.owasp.models.chapter import Chapter
 from apps.owasp.models.committee import Committee
@@ -67,6 +68,7 @@ class StaticSitemap(BaseSitemap):
             "/members": User,
             "/organizations": Organization,
             "/projects": Project,
+            "/repositories": Repository,
             "/snapshots": Snapshot,
         }
 

--- a/backend/tests/unit/apps/sitemap/views/static_test.py
+++ b/backend/tests/unit/apps/sitemap/views/static_test.py
@@ -26,6 +26,7 @@ class TestStaticSitemap:
     def test_items(self, sitemap):
         assert sitemap.items() == sitemap.STATIC_ROUTES
 
+    @patch("apps.sitemap.views.static.Repository.objects.aggregate")
     @patch("apps.sitemap.views.static.Chapter.objects.aggregate")
     @patch("apps.sitemap.views.static.Committee.objects.aggregate")
     @patch("apps.sitemap.views.static.Organization.objects.aggregate")
@@ -39,6 +40,7 @@ class TestStaticSitemap:
         mock_organization,
         mock_committee,
         mock_chapter,
+        mock_repository,
         sitemap,
     ):
         dt = timezone.now()
@@ -47,6 +49,7 @@ class TestStaticSitemap:
         mock_organization.return_value = {"latest": dt}
         mock_project.return_value = {"latest": dt}
         mock_user.return_value = {"latest": dt}
+        mock_repository.return_value = {"latest": dt}
 
         for item in sitemap.STATIC_ROUTES:
             result = sitemap.lastmod(item)
@@ -73,6 +76,17 @@ class TestStaticSitemap:
 
         item = {"path": "/projects"}
         result = sitemap.lastmod(item)
+
+        mock_aggregate.assert_called_once_with(latest=ANY)
+        assert result == dt
+
+    @patch("apps.sitemap.views.static.Repository.objects.aggregate")
+    def test_lastmod_repositories_uses_repository_model(self, mock_aggregate, sitemap):
+        """Test lastmod resolves /repositories via the Repository model."""
+        dt = timezone.now()
+        mock_aggregate.return_value = {"latest": dt}
+
+        result = sitemap.lastmod({"path": "/repositories"})
 
         mock_aggregate.assert_called_once_with(latest=ANY)
         assert result == dt


### PR DESCRIPTION
## Summary

Fixes #5259

The static sitemap's `lastmod()` method falls back to `datetime.now(UTC)` for any path not present in `path_to_model`. The `/repositories` route is missing from this mapping, so `/sitemap/repositories.xml` always returns the current time as `<lastmod>`, regardless of the actual latest repository activity.

## Changes

- Added `Repository` import and `"/repositories": Repository` mapping to `path_to_model` in `backend/src/apps/sitemap/views/static.py`
- Added `@patch` for `Repository.objects.aggregate` on the existing `test_lastmod` test, plus a dedicated `test_lastmod_repositories_uses_repository_model` test confirming the route resolves to the correct model

## Test results

All 10 tests in `tests/unit/apps/sitemap/views/static_test.py` pass (Django 6.1.1, pytest-django 4.12.0).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md) guide
- [x] All existing tests pass
- [x] No new warnings or deprecations introduced
