### PR TITLE
fix(frontend): skip GetMyPrograms query for non-project leaders

### DIFF
--- a/frontend/src/app/my/mentorship/page.tsx
+++ b/frontend/src/app/my/mentorship/page.tsx
@@ -63,7 +63,7 @@ const MyMentorshipPage: React.FC = () => {
     variables: { search: debouncedQuery, page, limit: 24 },
     fetchPolicy: 'cache-and-network',
     errorPolicy: 'all',
-    skip: isSyncing,
+    skip: isSyncing || !isProjectLeader,
   })
 
   useEffect(() => {


### PR DESCRIPTION

## Proposed change

Resolves  #4277

This PR optimizes the `MyMentorshipPage` component by conditionally skipping the `GetMyPrograms` GraphQL query when the logged-in user is not a project leader.

- Updated Apollo Client's `useQuery` options for `GetMyPrograms` to set `skip: isSyncing || !isProjectLeader`.

## Checklist

- [x] **Required:** I followed the [contributing workflow](https://github.com/OWASP/Nest/blob/main/CONTRIBUTING.md#contributing-workflow)
- [X] **Required:** I verified that my code works as intended and resolves the issue as described
- [X] **Required:** I ran all required checks and tests locally; all warnings addressed and failures resolved
- [ ] I used AI for code, documentation, tests, or communication related to this PR
